### PR TITLE
Remove wrong example from the docs

### DIFF
--- a/cpp/doxygen/regex.md
+++ b/cpp/doxygen/regex.md
@@ -28,7 +28,6 @@ By default, only the `\n` character is recognized as a line break. The [cudf::st
 - Unescaped special characters (listed in the third row of the Characters table below) when they are intended to match as literals.
 - Unmatched paired special characters like `()`, `[]`, and `{}`.
 - Empty groups, classes, or quantifiers. That is, `()` and `[]` without an enclosing expression and `{}` without a valid integer.
-- Incomplete ranges in character classes like `[-z]`, `[a-]`, and `[-]`.
 - Unqualified quantifiers. That is, a quantifier with no preceding item to match like `*a`, `a⎮?`, `(+)`, `{2}a`, etc.
 
 ## Features Supported


### PR DESCRIPTION
## Description

Remove wrong example from the docs

The examples for invalid ranges were actually valid syntax. The document states this elsewhere that

> If '`-`' is the first or last character (e.g. `[a-]` or `[-z]`), it
> will match a literal '`-`' and not infer a range.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
