### PR TITLE
Avoid resetting active once flags

### DIFF
--- a/cpp/librtcx/rtcx.cpp
+++ b/cpp/librtcx/rtcx.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <filesystem>
 #include <format>
+#include <mutex>
 #include <numeric>
 #include <source_location>
 
@@ -453,8 +454,8 @@ struct LibNVJitLink {
 static std::optional<LibCuda> cu;
 static std::optional<LibNVRTC> nvrtc;
 static std::optional<LibNVJitLink> nvjitlink;
-static std::optional<std::once_flag> init_libraries_flag{std::in_place};
-static std::optional<std::once_flag> teardown_libraries_flag{std::in_place};
+static std::mutex libraries_mutex;
+static bool libraries_initialized = false;
 
 }  // namespace
 
@@ -462,28 +463,35 @@ void initialize()
 {
   RTCX_FUNC_RANGE();
 
-  std::call_once(init_libraries_flag.value(), [] {
+  std::lock_guard guard{libraries_mutex};
+  if (libraries_initialized) { return; }
+
+  try {
     cu.emplace(LibCuda::_load());
     RTCX_EXPECTS(
       cu->Init(0) == CUDA_SUCCESS, "Failed to initialize CUDA driver API", std::runtime_error);
     nvrtc.emplace(LibNVRTC::_load());
     nvjitlink.emplace(LibNVJitLink::_load());
-  });
+    libraries_initialized = true;
+  } catch (...) {
+    nvjitlink.reset();
+    nvrtc.reset();
+    cu.reset();
+    throw;
+  }
 }
 
 void teardown()
 {
   RTCX_FUNC_RANGE();
 
-  std::call_once(teardown_libraries_flag.value(), [] {
-    nvjitlink.reset();
-    nvrtc.reset();
-    cu.reset();
-    init_libraries_flag.reset();
-    teardown_libraries_flag.reset();
-    init_libraries_flag.emplace();
-    teardown_libraries_flag.emplace();
-  });
+  std::lock_guard guard{libraries_mutex};
+  if (!libraries_initialized) { return; }
+
+  nvjitlink.reset();
+  nvrtc.reset();
+  cu.reset();
+  libraries_initialized = false;
 }
 
 blob_t blob_t::from_buffer(byte_buffer buffer)

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -14,6 +14,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <mutex>
 
 namespace cudf {
 
@@ -103,8 +104,7 @@ std::filesystem::path get_cudf_kernel_cache_dir()
 }
 
 static std::optional<context> _context{std::nullopt};
-static std::optional<std::once_flag> _context_init_flag{std::in_place};
-static std::optional<std::once_flag> _context_deinit_flag{std::in_place};
+static std::mutex _context_mutex;
 
 }  // namespace cudf
 
@@ -112,7 +112,9 @@ namespace CUDF_EXPORT cudf {
 
 void initialize(init_flags flags)
 {
-  std::call_once(*_context_init_flag, [&]() {
+  std::lock_guard guard{_context_mutex};
+
+  if (!_context.has_value()) {
     auto const dump_codegen      = detail::get_bool_env_or("LIBCUDF_JIT_DUMP_CODEGEN", false);
     auto const use_jit           = detail::get_bool_env_or("LIBCUDF_JIT_ENABLED", false);
     auto const preload_jit_cache = detail::get_bool_env_or("LIBCUDF_KERNEL_CACHE_PRELOAD", false);
@@ -152,20 +154,17 @@ void initialize(init_flags flags)
                        .kernel_cache_limit_process = kernel_cache_limit_process};
 
     _context.emplace(cfg, flags);
-  });
+  }
 
   _context->initialize_components(flags);
 }
 
 void teardown()
 {
-  std::call_once(*_context_deinit_flag, [&]() {
-    // reset the context to destroy all global objects and release resources, allowing for clean
-    // re-initialization in the future if desired.
-    _context.reset();
-    _context_init_flag.emplace();
-    _context_deinit_flag.emplace();
-  });
+  std::lock_guard guard{_context_mutex};
+  // reset the context to destroy all global objects and release resources, allowing for clean
+  // re-initialization in the future if desired.
+  _context.reset();
 }
 
 void enable_jit_cache(bool enabled)


### PR DESCRIPTION
## Summary
- Replace RTCX library init/teardown `once_flag` reset logic with an explicit mutex-protected initialized state.
- Do the same for cuDF global context initialization and teardown.

## Details
Both teardown paths rebuilt `std::once_flag` objects from inside the callable passed to `std::call_once` on those same flags. That makes reinitialize-after-teardown work, but it also mutates the synchronization object while `std::call_once` is still operating on it.

Using a mutex plus explicit state keeps the existing behavior: repeated initialization is idempotent, teardown is idempotent, and initialization can run again after teardown. RTCX initialization also cleans up partially initialized library handles before rethrowing if setup fails.

This does not change the documented expectation that teardown is not a general-purpose concurrent operation.

## Validation
- `pre-commit run --files cpp/librtcx/rtcx.cpp cpp/src/runtime/context.cpp`
- `git diff --check`

Local C++ gtests were not run because this checkout does not have a configured `cpp/build`/CMake build tree.