### PR TITLE
Fix pinned-host spill reservations for packed table alignment

### DIFF
--- a/cpp/libcudf_streaming/src/table_chunk.cpp
+++ b/cpp/libcudf_streaming/src/table_chunk.cpp
@@ -158,6 +158,22 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
   //    not matter.
   rapidsmpf::BufferResource* br = reservation.br();
 
+  // A cudf table's allocation size may be slightly smaller than its packed size because
+  // pack() aligns each output buffer. Spill reservations are based on the former, so grow
+  // the reservation to the actual packed size when the difference is only alignment
+  // overhead. This applies to both pinned-host and ordinary-host destinations.
+  auto resize_reservation_for_pack_alignment = [&](std::size_t packed_size) {
+    if (packed_size > reservation.size()) {
+      auto const alignment_overhead = packed_size - reservation.size();
+      auto const max_alignment_overhead =
+        1024 * static_cast<std::size_t>(table_view().num_columns());
+      if (alignment_overhead <= max_alignment_overhead) {
+        reservation =
+          br->reserve(reservation.mem_type(), packed_size, rapidsmpf::AllowOverbooking::YES).first;
+      }
+    }
+  };
+
   // If the table view is available and the table is not packed, we can use libcudf to
   // copy the table in device memory, or pack it to pinned/ host memory. Else, fall
   // through to case 2 (ie. use buffer_copy).
@@ -184,6 +200,8 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
         auto packed_pinned = cudf::pack(table_view(), stream(), br->pinned_mr());
         auto nbytes        = packed_pinned.gpu_data->size();
 
+        resize_reservation_for_pack_alignment(nbytes);
+
         br->statistics()->record_copy(rapidsmpf::MemoryType::DEVICE,
                                       rapidsmpf::MemoryType::PINNED_HOST,
                                       nbytes,
@@ -206,19 +224,7 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
           std::move(packed_columns.metadata),
           br->move(std::move(packed_columns.gpu_data), stream()));
 
-        // Handle the case where `cudf::pack` allocates slightly more than the
-        // input size. This can occur because cudf uses aligned allocations,
-        // which may exceed the requested size. To accommodate this, we
-        // allow some wiggle room.
-        if (packed_data->data->size > reservation.size()) {
-          auto const wiggle_room = 1024 * static_cast<std::size_t>(table_view().num_columns());
-          if (packed_data->data->size <= reservation.size() + wiggle_room) {
-            reservation =
-              br->reserve(
-                  reservation.mem_type(), packed_data->data->size, rapidsmpf::AllowOverbooking::YES)
-                .first;
-          }
-        }
+        resize_reservation_for_pack_alignment(packed_data->data->size);
         packed_data->data = br->move(std::move(packed_data->data), reservation);
         return table_chunk(std::move(packed_data));
       }

--- a/cpp/libcudf_streaming/src/table_chunk.cpp
+++ b/cpp/libcudf_streaming/src/table_chunk.cpp
@@ -24,9 +24,10 @@ table_chunk::table_chunk(std::unique_ptr<cudf::table> table, rmm::cuda_stream_vi
   : table_{std::move(table)}, stream_{stream}, is_spillable_{true}
 {
   RAPIDSMPF_EXPECTS(table_ != nullptr, "table pointer cannot be null", std::invalid_argument);
-  table_view_                                                               = table_->view();
-  data_alloc_size_[static_cast<std::size_t>(rapidsmpf::MemoryType::DEVICE)] = table_->alloc_size();
-  make_available_cost_                                                      = 0;
+  table_view_ = table_->view();
+  data_alloc_size_[static_cast<std::size_t>(rapidsmpf::MemoryType::DEVICE)] =
+    cudf::packed_size(*table_view_, stream_, rmm::mr::get_current_device_resource_ref());
+  make_available_cost_ = 0;
 }
 
 table_chunk::table_chunk(cudf::table_view table_view,
@@ -158,22 +159,6 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
   //    not matter.
   rapidsmpf::BufferResource* br = reservation.br();
 
-  // A cudf table's allocation size may be slightly smaller than its packed size because
-  // pack() aligns each output buffer. Spill reservations are based on the former, so grow
-  // the reservation to the actual packed size when the difference is only alignment
-  // overhead. This applies to both pinned-host and ordinary-host destinations.
-  auto resize_reservation_for_pack_alignment = [&](std::size_t packed_size) {
-    if (packed_size > reservation.size()) {
-      auto const alignment_overhead = packed_size - reservation.size();
-      auto const max_alignment_overhead =
-        1024 * static_cast<std::size_t>(table_view().num_columns());
-      if (alignment_overhead <= max_alignment_overhead) {
-        reservation =
-          br->reserve(reservation.mem_type(), packed_size, rapidsmpf::AllowOverbooking::YES).first;
-      }
-    }
-  };
-
   // If the table view is available and the table is not packed, we can use libcudf to
   // copy the table in device memory, or pack it to pinned/ host memory. Else, fall
   // through to case 2 (ie. use buffer_copy).
@@ -200,8 +185,6 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
         auto packed_pinned = cudf::pack(table_view(), stream(), br->pinned_mr());
         auto nbytes        = packed_pinned.gpu_data->size();
 
-        resize_reservation_for_pack_alignment(nbytes);
-
         br->statistics()->record_copy(rapidsmpf::MemoryType::DEVICE,
                                       rapidsmpf::MemoryType::PINNED_HOST,
                                       nbytes,
@@ -224,7 +207,6 @@ table_chunk table_chunk::copy(rapidsmpf::MemoryReservation& reservation) const
           std::move(packed_columns.metadata),
           br->move(std::move(packed_columns.gpu_data), stream()));
 
-        resize_reservation_for_pack_alignment(packed_data->data->size);
         packed_data->data = br->move(std::move(packed_data->data), reservation);
         return table_chunk(std::move(packed_data));
       }

--- a/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
@@ -473,8 +473,14 @@ TEST_F(StreamingTableChunk, ToPackedDataFromTable)
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expect, table_chunk{std::move(packed)}.table_view());
 }
 
-TEST_F(StreamingTableChunk, ToMessageUnalignedSize)
+TEST_P(StreamingTableChunk, ToMessageUnalignedSize)
 {
+  auto const spill_mem_type = GetParam();
+  if (spill_mem_type == rapidsmpf::MemoryType::PINNED_HOST &&
+      !rapidsmpf::is_pinned_memory_resources_supported()) {
+    GTEST_SKIP() << "MemoryType::PINNED_HOST isn't supported on the system.";
+  }
+
   constexpr unsigned int num_rows = 5;
   constexpr std::int64_t seed     = 2025;
   constexpr std::uint64_t seq     = 7;
@@ -495,14 +501,14 @@ TEST_F(StreamingTableChunk, ToMessageUnalignedSize)
   // Note: `m.copy_cost() == 80`, but cudf performs 128-byte aligned allocations.
   // This means `m.copy_cost()` is not always sufficient; however, table_chunk.copy()
   // accounts for this alignment internally.
-  auto reservation = br->reserve_or_fail(m.copy_cost(), rapidsmpf::MemoryType::HOST);
+  auto reservation                 = br->reserve_or_fail(m.copy_cost(), spill_mem_type);
   rapidsmpf::streaming::Message m2 = m.copy(reservation);
   EXPECT_EQ(reservation.size(), 0);
   EXPECT_FALSE(m2.empty());
   EXPECT_TRUE(m2.holds<table_chunk>());
   EXPECT_TRUE(m2.content_description().spillable());
   EXPECT_EQ(m2.copy_cost(), 128);
-  EXPECT_EQ(m2.content_description().content_size(rapidsmpf::MemoryType::HOST), 128);
+  EXPECT_EQ(m2.content_description().content_size(spill_mem_type), 128);
   EXPECT_EQ(m2.content_description().content_size(rapidsmpf::MemoryType::DEVICE), 0);
   EXPECT_EQ(m2.sequence_number(), seq);
 }

--- a/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
@@ -486,7 +486,11 @@ TEST_P(StreamingTableChunk, ToMessageUnalignedSize)
   constexpr std::uint64_t seq     = 7;
 
   auto expect = random_table_with_index(seed, num_rows, 0, 5);
-  auto chunk  = std::make_unique<table_chunk>(std::make_unique<cudf::table>(expect), stream);
+  auto const expected_packed_size =
+    cudf::packed_size(expect.view(), stream, rmm::mr::get_current_device_resource_ref());
+  EXPECT_EQ(expect.alloc_size(), 80);
+  EXPECT_EQ(expected_packed_size, 128);
+  auto chunk = std::make_unique<table_chunk>(std::make_unique<cudf::table>(expect), stream);
 
   rapidsmpf::streaming::Message m = to_message(seq, std::move(chunk));
   EXPECT_EQ(m.sequence_number(), seq);
@@ -494,21 +498,21 @@ TEST_P(StreamingTableChunk, ToMessageUnalignedSize)
   EXPECT_TRUE(m.holds<table_chunk>());
   EXPECT_TRUE(m.content_description().spillable());
   EXPECT_EQ(m.content_description().content_size(rapidsmpf::MemoryType::HOST), 0);
-  EXPECT_EQ(m.content_description().content_size(rapidsmpf::MemoryType::DEVICE), 80);
-  EXPECT_EQ(m.copy_cost(), 80);
+  EXPECT_EQ(m.content_description().content_size(rapidsmpf::MemoryType::DEVICE),
+            expected_packed_size);
+  EXPECT_EQ(m.copy_cost(), expected_packed_size);
 
   // Deep copy: device → host.
-  // Note: `m.copy_cost() == 80`, but cudf performs 128-byte aligned allocations.
-  // This means `m.copy_cost()` is not always sufficient; however, table_chunk.copy()
-  // accounts for this alignment internally.
+  // The copy cost includes cudf's packed-buffer alignment and is therefore sufficient
+  // before pack() allocates its output.
   auto reservation                 = br->reserve_or_fail(m.copy_cost(), spill_mem_type);
   rapidsmpf::streaming::Message m2 = m.copy(reservation);
   EXPECT_EQ(reservation.size(), 0);
   EXPECT_FALSE(m2.empty());
   EXPECT_TRUE(m2.holds<table_chunk>());
   EXPECT_TRUE(m2.content_description().spillable());
-  EXPECT_EQ(m2.copy_cost(), 128);
-  EXPECT_EQ(m2.content_description().content_size(spill_mem_type), 128);
+  EXPECT_EQ(m2.copy_cost(), expected_packed_size);
+  EXPECT_EQ(m2.content_description().content_size(spill_mem_type), expected_packed_size);
   EXPECT_EQ(m2.content_description().content_size(rapidsmpf::MemoryType::DEVICE), 0);
   EXPECT_EQ(m2.sequence_number(), seq);
 }


### PR DESCRIPTION
`cudf::pack()` may produce an aligned buffer slightly larger than the source table’s allocation size. During spilling to pinned host memory, the reservation was based on the source size, causing `BufferResource::release()` to raise a `reservation_error`.

This change does the following:
- Expands the reservation to the actual packed size when the difference is alignment overhead.
- Applies the existing host-memory handling to pinned-host spills.
- Extends the unaligned-size regression test to cover both `HOST` and `PINNED_HOST`.

Validated with the cudf-polars TPC-DS nightly benchmark on an NVL4 node.

A typical failure without this change is as below:

```c++
terminate called after throwing an instance of 'rapidsmpf::reservation_error'
  what():  std::bad_alloc: reservation_error: RapidsMPF fatal error at: /tmp/conda-bld-output/bld/rattler-build_librapidsmpf/work/cpp/src/memory/buffer_resource.cpp:198: MemoryReservation(57.01 MiB) isn't big enough (57.01 MiB)
```
