### PR TITLE
Revamp cudf-java build skill with nightly libcudf option

### DIFF
--- a/.agents/skills/build-test-cudf-java/SKILL.md
+++ b/.agents/skills/build-test-cudf-java/SKILL.md
@@ -38,7 +38,7 @@ Use a local libcudf source build when the changes affect libcudf, require unrele
 
 ## Running Java tests
 
-**Always run `mvn install -DskipTests` first** before running tests. The `mvn test` goal re-triggers the cmake/native build step. If `target/cmake-build` already contains fully built artifacts from a prior `mvn install`, this is an incremental no-op. But if the cmake-build directory was cleaned or is missing, `mvn test` may hit a race condition where the linker tries to link `libcudfjni.so` before `libarrow.a` is fully built, causing a `cannot find libarrow.a` error. If this happens, re-run `mvn install -DskipTests` to rebuild the native code cleanly, then retry `mvn test`.
+**Always run `mvn install $MVN_COMMON_OPTS -DskipTests` first** before running tests. The `mvn test` goal re-triggers the cmake/native build step. If `target/cmake-build` already contains fully built artifacts from a prior `mvn install`, this is an incremental no-op. But if the cmake-build directory was cleaned or is missing, `mvn test` may hit a race condition where the linker tries to link `libcudfjni.so` before `libarrow.a` is fully built, causing a `cannot find libarrow.a` error. If this happens, re-run `mvn install $MVN_COMMON_OPTS -DskipTests` to rebuild the native code cleanly, then retry `mvn test`.
 
 ### All tests
 

--- a/.agents/skills/build-test-cudf-java/SKILL.md
+++ b/.agents/skills/build-test-cudf-java/SKILL.md
@@ -24,62 +24,21 @@ If either is missing, detect the OS and install using the appropriate package ma
 
 Detect the OS by checking which package manager is available (e.g. `command -v apt-get`, `command -v dnf`, etc.) and use the matching command.
 
-### libcudf C++ with Java-required CMake flags
+Run all Maven commands below from the `java/` directory.
 
-libcudf must be built with specific CMake flags for the Java bindings. Read `java/README.md` **(section: "Build From Source")** for the current required flags, then verify they are set:
+## Choose a libcudf provider
 
-```bash
-grep -E "<FLAG1>|<FLAG2>|.." cpp/build/latest/CMakeCache.txt
-```
+Prefer the installed nightly package when the changes are limited to Java or JNI and the user has not requested a libcudf source rebuild:
 
-If any flag is missing, reconfigure and rebuild libcudf following the `build-test-cudf` skill, passing the flags from the README. Ignore any flags that CMake reports as unused.
+- [Build JNI against an installed nightly libcudf](references/nightly-libcudf.md), then continue at [Running Java tests](#running-java-tests).
 
-## Environment setup
+Use a local libcudf source build when the changes affect libcudf, require unreleased libcudf headers or symbols, no compatible nightly exists, or the user explicitly requests a source build:
 
-Before any `mvn` command, export these variables from the `cudf/java` directory. All subsequent build and test commands assume these are set.
-
-```bash
-export CUDF_CPP_BUILD_DIR=$(readlink -f ../cpp/build/latest)
-```
-
-Export `MAVEN_OPTS` based on the JDK version. `--add-opens` flags are **required for every `mvn` invocation** on JDK 17+ (strong encapsulation). Without them, `gmaven-plugin:1.5` fails. On JDK 9-16 the flags are accepted but optional. On JDK 8 or below, **do not set them** — the JVM does not recognize `--add-opens` and will fail with `Unrecognized option`.
-
-```bash
-export MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED"
-```
-
-Export `MVN_COMMON_OPTS` to match the CI build configuration in `java/ci/build-in-docker.sh`. For example:
-
-```bash
-export MVN_COMMON_OPTS="-DCUDF_CPP_BUILD_DIR=$CUDF_CPP_BUILD_DIR -DBUILD_SHARED_LIBS=OFF -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=ON -DCUDA_STATIC_CUFILE=ON -DCUDF_JNI_LIBCUDF_STATIC=ON"
-```
-
-## Building cudf-java
-
-The Java JNI native code must be compiled for the same CUDA architectures as libcudf. Detect what libcudf was built with:
-
-```bash
-grep CMAKE_CUDA_ARCHITECTURES cpp/build/latest/CMakeCache.txt
-```
-
-Update `MVN_COMMON_OPTS` to use that value for `-DCMAKE_CUDA_ARCHITECTURES` (by default use `NATIVE`).
-
-```bash
-export MVN_COMMON_OPTS=$MVN_COMMON_OPTS -DCMAKE_CUDA_ARCHITECTURES=<VALUE>
-```
-
-```bash
-rm -rf target/cmake-build  # only needed if changing CMAKE_CUDA_ARCHITECTURES from a previous build
-mvn install $MVN_COMMON_OPTS -DskipTests
-```
-
-Notes:
-- Omit `rm -rf target/cmake-build` on incremental rebuilds when architectures haven't changed.
-- The native compilation is the slow step. Subsequent runs reuse cached artifacts if `target/cmake-build` is preserved.
+- [Build JNI against a local libcudf build](references/local-libcudf.md), then continue at [Running Java tests](#running-java-tests).
 
 ## Running Java tests
 
-**Always run `mvn install -DskipTests` first** (see Building section above) before running tests. The `mvn test` goal re-triggers the cmake/native build step. If `target/cmake-build` already contains fully built artifacts from a prior `mvn install`, this is an incremental no-op. But if the cmake-build directory was cleaned or is missing, `mvn test` may hit a race condition where the linker tries to link `libcudfjni.so` before `libarrow.a` is fully built, causing a `cannot find libarrow.a` error. If this happens, re-run `mvn install -DskipTests` to rebuild the native code cleanly, then retry `mvn test`.
+**Always run `mvn install -DskipTests` first** before running tests. The `mvn test` goal re-triggers the cmake/native build step. If `target/cmake-build` already contains fully built artifacts from a prior `mvn install`, this is an incremental no-op. But if the cmake-build directory was cleaned or is missing, `mvn test` may hit a race condition where the linker tries to link `libcudfjni.so` before `libarrow.a` is fully built, causing a `cannot find libarrow.a` error. If this happens, re-run `mvn install -DskipTests` to rebuild the native code cleanly, then retry `mvn test`.
 
 ### All tests
 
@@ -87,30 +46,38 @@ Notes:
 mvn test $MVN_COMMON_OPTS
 ```
 
+The POM routes tests that need special assertion or fork behavior to dedicated Surefire executions.
+
 ### Discovering tests
 
-Java test sources are at `java/src/test/java/ai/rapids/cudf/`. Use `find` or `glob` to discover test classes:
+Java test sources are at `src/test/java/ai/rapids/cudf/`. Use `find` or `glob` to discover test classes:
 
 ```bash
-find java/src/test/java -name "*Test.java" | head -20
+find src/test/java -name "*Test.java" | head -20
 ```
 
 ### Specific test class
 
 ```bash
-mvn test $MVN_COMMON_OPTS \
-  -Dtest="ai.rapids.cudf.ast.<ClassName>" \
-  -pl .
+mvn surefire:test@main-tests $MVN_COMMON_OPTS \
+  -Dtest="<ClassName>"
 ```
 
 ### Specific test method
 
 ```bash
-mvn test $MVN_COMMON_OPTS \
-  -Dtest="ai.rapids.cudf.ast.<ClassName>#<testName>" \
-  -pl .
+mvn surefire:test@main-tests $MVN_COMMON_OPTS \
+  -Dtest="<ClassName>#<testName>"
 ```
 
-### Known pre-existing failures
+Use the named `main-tests` execution for specific ordinary tests so `-Dtest` does not affect the separately configured executions.
 
-`ArrowColumnVectorTest` may show errors on JDK 21+ due to Netty/Arrow module access restrictions. These are unrelated to cudf code changes.
+### Tests with special configuration
+
+Invoke tests that require special configuration through their dedicated executions:
+
+```bash
+mvn surefire:test@non-empty-null-test $MVN_COMMON_OPTS
+mvn surefire:test@fatal-cuda-test $MVN_COMMON_OPTS
+mvn surefire:test@native-deps-loader-test $MVN_COMMON_OPTS
+```

--- a/.agents/skills/build-test-cudf-java/references/local-libcudf.md
+++ b/.agents/skills/build-test-cudf-java/references/local-libcudf.md
@@ -35,7 +35,7 @@ Match these JNI settings to the libcudf build:
 
 - Set `CUDF_USE_PER_THREAD_DEFAULT_STREAM=ON` only when libcudf was built with `CUDF_USE_PER_THREAD_DEFAULT_STREAM=ON`.
 - Set `CUDF_JNI_LIBCUDF_STATIC=ON` for a static libcudf build and `OFF` for a shared build.
-- Keep `USE_GDS=OFF` unless libcudf and the test environment were built for GDS.
+- Keep `USE_GDS=OFF` unless the test environment supports GDS and GDS tests are required.
 
 For example, a static PTDS build like the Java CI configuration uses:
 

--- a/.agents/skills/build-test-cudf-java/references/local-libcudf.md
+++ b/.agents/skills/build-test-cudf-java/references/local-libcudf.md
@@ -1,0 +1,68 @@
+# Build JNI against a local libcudf build
+
+Use this path when the Java/JNI changes require a libcudf source build.
+
+## Verify Java-required libcudf build flags
+
+Read `java/README.md` (section "Build From Source") for the current required libcudf flags and verify every one in `CMakeCache.txt`.
+
+Set the build directory to the libcudf build you intend to use. The repository default is shown here:
+
+```bash
+export CUDF_ROOT="$(git rev-parse --show-toplevel)"
+export CUDF_CPP_BUILD_DIR="${CUDF_CPP_BUILD_DIR:-$CUDF_ROOT/cpp/build}"
+```
+
+Also inspect the CUDA architecture, per-thread default stream setting, and shared/static library setting; these determine the matching JNI configuration:
+
+```bash
+grep -E \
+  'CMAKE_CUDA_ARCHITECTURES|CUDF_USE_PER_THREAD_DEFAULT_STREAM|BUILD_SHARED_LIBS' \
+  "$CUDF_CPP_BUILD_DIR/CMakeCache.txt"
+```
+
+If any required flag is missing, rebuild libcudf with the [`build-test-cudf` skill](../../build-test-cudf/SKILL.md), passing the current flags from `java/README.md`. Ignore flags that CMake reports as unused.
+
+## Configure and build JNI
+
+Point the Java build at the libcudf source and build directories, not an installed package. JNI CMake prefers `CUDF_INSTALL_DIR` when it is set, so unset it to prevent an installed libcudf from overriding `CUDF_CPP_BUILD_DIR`:
+
+```bash
+unset CUDF_INSTALL_DIR
+```
+
+Match these JNI settings to the libcudf build:
+
+- Set `CUDF_USE_PER_THREAD_DEFAULT_STREAM=ON` only when libcudf was built with `CUDF_USE_PER_THREAD_DEFAULT_STREAM=ON`.
+- Set `CUDF_JNI_LIBCUDF_STATIC=ON` for a static libcudf build and `OFF` for a shared build.
+- Keep `USE_GDS=OFF` unless libcudf and the test environment were built for GDS.
+
+For example, a static PTDS build like the Java CI configuration uses:
+
+```bash
+export MVN_COMMON_OPTS="${MVN_COMMON_OPTS:-} \
+  -DCUDF_CPP_BUILD_DIR=$CUDF_CPP_BUILD_DIR \
+  -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=ON \
+  -DCUDF_JNI_LIBCUDF_STATIC=ON \
+  -DUSE_GDS=OFF"
+```
+
+Add `-DCMAKE_CUDA_ARCHITECTURES=<architecture>` matching the value recorded from libcudf's CMakeCache.txt; if omitted, the pom defaults to RAPIDS (all architectures), which is slower.
+
+When switching libcudf providers or changing JNI CMake configuration, remove the cached JNI artifacts before building:
+
+```bash
+cd "$CUDF_ROOT/java"
+rm -rf target/cmake-build target/classes
+mvn install $MVN_COMMON_OPTS -DskipTests
+```
+
+For incremental source/JNI rebuilds with the same provider and configuration, preserve the native build cache and run only:
+
+```bash
+mvn install $MVN_COMMON_OPTS -DskipTests
+```
+
+Do not remove the entire `target/` directory unless a full clean build is necessary. Preserving `target/cmake-build` avoids repeating the slow native dependency build.
+
+Continue with [Running Java tests](../SKILL.md#running-java-tests).

--- a/.agents/skills/build-test-cudf-java/references/nightly-libcudf.md
+++ b/.agents/skills/build-test-cudf-java/references/nightly-libcudf.md
@@ -1,0 +1,84 @@
+# Build JNI against an installed nightly libcudf
+
+Use this path for Java/JNI-only changes when rebuilding libcudf from source is unnecessary. It validates against a compatible nightly package; it does not reproduce a release build.
+
+## Select and install the nightly
+
+Identify the libcudf commit required by the branch. For a pull request, use its base commit or merge base unless the changes explicitly require a newer libcudf commit:
+
+```bash
+git merge-base HEAD upstream/main
+```
+
+Inspect available nightly versions and build strings:
+
+```bash
+conda search --override-channels \
+  -c rapidsai-nightly -c conda-forge -c nvidia \
+  'libcudf=<VERSION>'
+```
+
+Choose an exact package whose commit is the required commit or a compatible ancestor. Match the CUDA major version used by the devcontainer. Use an existing conda environment, or create one before installing the package.
+
+Let conda solve libcudf's declared dependencies instead of pinning its transitive libraries manually. Preview the solution, then install the same exact libcudf build:
+
+```bash
+conda install --dry-run -y --override-channels \
+  -c rapidsai-nightly -c conda-forge -c nvidia \
+  'libcudf=<EXACT_VERSION>=<EXACT_BUILD>' \
+  'cuda-version=<CUDA_MAJOR>.*'
+
+conda install -y --override-channels \
+  -c rapidsai-nightly -c conda-forge -c nvidia \
+  'libcudf=<EXACT_VERSION>=<EXACT_BUILD>' \
+  'cuda-version=<CUDA_MAJOR>.*'
+```
+
+## Configure and build JNI
+
+Activate the environment and point CMake and the runtime linker at its installed libcudf:
+
+```bash
+conda activate <ENVIRONMENT>
+
+unset CUDF_ROOT CUDF_CPP_BUILD_DIR
+export CUDF_INSTALL_DIR="$CONDA_PREFIX"
+export LD_LIBRARY_PATH="$CUDF_INSTALL_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export CUDACXX="$CUDA_HOME/bin/nvcc"
+export CUDAToolkit_ROOT="$CUDA_HOME"
+export PATH="$CUDA_HOME/bin:$PATH"
+
+nvcc --version
+```
+
+Installed nightly packages are shared-library builds, so configure JNI accordingly:
+
+```bash
+export MVN_COMMON_OPTS="${MVN_COMMON_OPTS:-} \
+  -DCUDF_JNI_LIBCUDF_STATIC=OFF \
+  -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=OFF \
+  -DUSE_GDS=OFF"
+```
+
+Remove cached JNI artifacts when switching libcudf providers, then rebuild only Java and JNI:
+
+```bash
+cd "$(git rev-parse --show-toplevel)/java"
+rm -rf target/cmake-build target/classes
+mvn install $MVN_COMMON_OPTS -DskipTests
+```
+
+## Verify symbol resolution
+
+Confirm that CMake selected the installed package and that every JNI dependency resolves:
+
+```bash
+grep -E 'CUDF_INSTALL_DIR|cudf_DIR|CUDF_USE_PER_THREAD_DEFAULT_STREAM|CUDF_JNI_LIBCUDF_STATIC|USE_GDS' target/cmake-build/CMakeCache.txt
+ldd -r target/cmake-build/libcudfjni.so
+```
+
+The POM packages the libcudf resolved by `ldd`, so verify that it comes from `CUDF_INSTALL_DIR`. Its transitive shared-library dependencies are not bundled; keep `$CUDF_INSTALL_DIR/lib` on `LD_LIBRARY_PATH` while running tests. If resolution points at another environment, clean `target/cmake-build` and rebuild with the intended conda environment active.
+
+Continue with [Running Java tests](../SKILL.md#running-java-tests).

--- a/.agents/skills/build-test-cudf-java/references/nightly-libcudf.md
+++ b/.agents/skills/build-test-cudf-java/references/nightly-libcudf.md
@@ -4,21 +4,22 @@ Use this path for Java/JNI-only changes when rebuilding libcudf from source is u
 
 ## Select and install the nightly
 
-Identify the libcudf commit required by the branch. For a pull request, use its base commit or merge base unless the changes explicitly require a newer libcudf commit:
+Identify the libcudf commit required by the branch and the package series from `VERSION`. For a pull request, use its base commit or merge base unless the changes explicitly require a newer libcudf commit:
 
 ```bash
-git merge-base HEAD upstream/main
+REQUIRED_COMMIT="$(git merge-base HEAD upstream/main)"
+LIBCUDF_SERIES="$(cut -d. -f1,2 "$(git rev-parse --show-toplevel)/VERSION")"
 ```
 
-Inspect available nightly versions and build strings:
+Inspect available nightly versions and build strings for that series:
 
 ```bash
 conda search --override-channels \
   -c rapidsai-nightly -c conda-forge -c nvidia \
-  'libcudf=<VERSION>'
+  "libcudf=${LIBCUDF_SERIES}.*"
 ```
 
-Choose an exact package whose commit is the required commit or a compatible ancestor. Match the CUDA major version used by the devcontainer. Use an existing conda environment, or create one before installing the package.
+The build string ends in the first eight characters of the source commit, as defined by `conda/recipes/libcudf/recipe.yaml`. Prefer a build ending in the first eight characters of `REQUIRED_COMMIT`; if it is unavailable, use `git merge-base --is-ancestor <PACKAGE_COMMIT> "$REQUIRED_COMMIT"` to select the nearest available ancestor. Match the CUDA major version used by the devcontainer. Use an existing conda environment, or create one before installing the package.
 
 Let conda solve libcudf's declared dependencies instead of pinning its transitive libraries manually. Preview the solution, then install the same exact libcudf build:
 


### PR DESCRIPTION
## Description

Updates and expands the cudf-java build and test skill to match the current configurations. Separates the skill into two workflows: building from source, and building against nightly. The latter allows building directly from a pre-published nightly libcudf package as a fast path to avoid the full build-from-source when only Java/JNI changes were made. Removes some obsolete guidance and documents test execution.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
