### PR TITLE
Enable parquet metadata prefetching by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -74,7 +74,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -92,7 +92,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -108,7 +108,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     secrets:
       CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}
@@ -146,7 +146,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
@@ -166,7 +166,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
@@ -208,7 +208,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -229,7 +229,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -249,7 +249,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -270,7 +270,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -291,7 +291,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -309,7 +309,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -330,7 +330,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -349,7 +349,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
@@ -371,7 +371,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -389,7 +389,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
@@ -411,7 +411,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -465,7 +465,7 @@ jobs:
   devcontainers:
     name: Build devcontainers
     secrets: inherit  # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/build-devcontainers.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/build-devcontainers.yaml@main
     permissions:
       packages: write
     with:

--- a/.github/workflows/pandas-tests.yaml
+++ b/.github/workflows/pandas-tests.yaml
@@ -30,7 +30,7 @@ jobs:
         packages: read
         pull-requests: read
       secrets: inherit # zizmor: ignore[secrets-inherit]
-      uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+      uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
       with:
         build_type: nightly
         branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
       - narwhals-tests
       - telemetry-setup
       - third-party-integration-tests-cudf-pandas
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     permissions:
       contents: read
     if: always()
@@ -85,7 +85,7 @@ jobs:
       packages: read
       pull-requests: read
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
     with:
       files_yaml: |
         build_docs:
@@ -342,7 +342,7 @@ jobs:
     permissions:
       contents: read
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize spark-rapids-jni cuml-compat-tests"
@@ -355,7 +355,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
     with:
       build_type: pull-request
       node_type: cpu16
@@ -369,7 +369,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: pull-request
       node_type: cpu16
@@ -385,7 +385,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     needs: checks
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: pull-request
       script: "ci/cpp_linters.sh"
@@ -397,7 +397,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
     with:
       build_type: pull-request
       package_name: libcudf
@@ -410,7 +410,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
@@ -424,7 +424,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -439,7 +439,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: ci/build_python_noarch.sh
@@ -453,7 +453,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
@@ -468,7 +468,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
@@ -484,7 +484,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
     with:
       build_type: pull-request
@@ -501,7 +501,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
     with:
       build_type: pull-request
@@ -518,7 +518,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
       build_type: pull-request
@@ -535,7 +535,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
@@ -553,7 +553,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
@@ -571,7 +571,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -589,7 +589,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -603,7 +603,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
       node_type: cpu8
@@ -621,7 +621,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
       node_type: cpu8
@@ -639,7 +639,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
@@ -653,7 +653,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
@@ -672,7 +672,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
@@ -689,7 +689,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
@@ -705,7 +705,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
@@ -724,7 +724,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).not_cudf_polars
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
@@ -741,7 +741,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
     with:
       arch: '["amd64", "arm64"]'
       cuda: '["13.3"]'
@@ -764,7 +764,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: (fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels || fromJSON(needs.changed-files.outputs.changed_file_groups).test_cudf_pandas) && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       # This selects the latest supported Python + CUDA minor versions for each ARCH/CUDA major version combo
@@ -780,7 +780,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
@@ -801,7 +801,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
@@ -810,7 +810,7 @@ jobs:
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       continue-on-error: true
-      container_image: "rapidsai/ci-conda:26.08-latest"
+      container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/test_cuml_compat.sh"
   pandas-tests:
     # run the Pandas unit tests using PR branch
@@ -822,7 +822,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
@@ -841,7 +841,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request

--- a/.github/workflows/pr_issue_status_automation.yml
+++ b/.github/workflows/pr_issue_status_automation.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
     get-project-id:
-      uses: rapidsai/shared-workflows/.github/workflows/project-get-item-id.yaml@release/26.08
+      uses: rapidsai/shared-workflows/.github/workflows/project-get-item-id.yaml@main
       secrets:
         ADD_TO_PROJECT_GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
       if: github.event.pull_request.state == 'open'
@@ -25,7 +25,7 @@ jobs:
 
     update-status:
       # This job sets the PR and its linked issues to "In Progress" status
-      uses: rapidsai/shared-workflows/.github/workflows/project-get-set-single-select-field.yaml@release/26.08
+      uses: rapidsai/shared-workflows/.github/workflows/project-get-set-single-select-field.yaml@main
       secrets:
         ADD_TO_PROJECT_GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
       if: ${{ github.event.pull_request.state == 'open' && needs.get-project-id.outputs.ITEM_PROJECT_ID != '' }}
@@ -65,7 +65,7 @@ jobs:
 
     update-release:
       # This job sets the PR and its linked issues to the release they are targeting
-      uses: rapidsai/shared-workflows/.github/workflows/project-get-set-single-select-field.yaml@release/26.08
+      uses: rapidsai/shared-workflows/.github/workflows/project-get-set-single-select-field.yaml@main
       secrets:
         ADD_TO_PROJECT_GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
       if: ${{ github.event.pull_request.state == 'open' && needs.get-project-id.outputs.ITEM_PROJECT_ID != '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -62,7 +62,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -80,7 +80,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -98,7 +98,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -114,7 +114,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -130,7 +130,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -145,7 +145,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -163,7 +163,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -181,7 +181,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -196,7 +196,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -211,7 +211,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -226,7 +226,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -245,7 +245,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -253,7 +253,7 @@ jobs:
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       continue-on-error: true
-      container_image: "rapidsai/ci-conda:26.08-latest"
+      container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/test_cuml_compat.sh"
   wheel-tests-cudf-polars:
     permissions:
@@ -263,7 +263,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -279,7 +279,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -294,7 +294,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -18,7 +18,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@release/26.08
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     secrets:
       slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:

--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-release/26.08
+main

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -841,6 +841,7 @@ add_library(
   src/jit/util.cpp
   src/join/conditional_join.cu
   src/join/cross_join.cu
+  src/join/direct_join.cu
   src/join/distinct_hash_join.cu
   src/join/filter_join_indices/filter_join_indices.cu
   src/join/filter_join_indices/filter_join_indices_jit.cu

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -150,6 +150,7 @@ ConfigureNVBench(
 ConfigureNVBench(
   JOIN_NVBENCH
   join/conditional_join.cpp
+  join/direct_join.cu
   join/distinct_join.cpp
   join/filter_join_indices.cpp
   join/filter_join_indices_jit.cu

--- a/cpp/benchmarks/join/direct_join.cu
+++ b/cpp/benchmarks/join/direct_join.cu
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "join_common.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/join/direct_join.hpp>
+#include <cudf/join/distinct_hash_join.hpp>
+#include <cudf/join/join.hpp>
+
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+#include <thrust/tabulate.h>
+
+// Apples-to-apples comparison of inner join implementations on input that satisfies
+// `direct_inner_join`'s preconditions: a single UINT32 key column per side, distinct right keys,
+// and all key values in [0, capacity) with capacity = right_size. The right keys are the shuffled
+// dense values [0, right_size), the key_remapping/dense-primary-key case, so every left key
+// matches and the input is identical for all algorithms.
+void nvbench_direct_inner_join(nvbench::state& state)
+{
+  if (should_skip_large_sizes(state)) { return; }
+
+  auto const right_size = static_cast<cudf::size_type>(state.get_int64("right_size"));
+  auto const left_size  = static_cast<cudf::size_type>(state.get_int64("left_size"));
+  auto const algorithm  = state.get_string("algorithm");
+  auto const capacity   = static_cast<std::size_t>(right_size);
+
+  // Dense distinct right keys: a shuffled sequence of [0, capacity)
+  auto right = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::UINT32}, right_size, cudf::mask_state::UNALLOCATED);
+  thrust::sequence(thrust::device,
+                   right->mutable_view().begin<std::uint32_t>(),
+                   right->mutable_view().end<std::uint32_t>());
+  thrust::shuffle(thrust::device,
+                  right->mutable_view().begin<std::uint32_t>(),
+                  right->mutable_view().end<std::uint32_t>(),
+                  thrust::default_random_engine{12345});
+
+  // Left keys cycle through [0, capacity), then shuffled
+  auto left = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::UINT32}, left_size, cudf::mask_state::UNALLOCATED);
+  thrust::tabulate(thrust::device,
+                   left->mutable_view().begin<std::uint32_t>(),
+                   left->mutable_view().end<std::uint32_t>(),
+                   thrust::placeholders::_1 % static_cast<std::uint32_t>(right_size));
+  thrust::shuffle(thrust::device,
+                  left->mutable_view().begin<std::uint32_t>(),
+                  left->mutable_view().end<std::uint32_t>(),
+                  thrust::default_random_engine{67890});
+
+  auto const left_view  = left->view();
+  auto const right_view = right->view();
+  auto const left_keys  = cudf::table_view{{left_view}};
+  auto const right_keys = cudf::table_view{{right_view}};
+
+  auto const input_bytes = estimate_size(left_keys) + estimate_size(right_keys);
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.add_element_count(input_bytes, "input_bytes");
+  state.add_global_memory_reads<nvbench::int8_t>(input_bytes);
+
+  if (algorithm == "hash") {
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+      auto result = cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL);
+    });
+  } else if (algorithm == "distinct_hash") {
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+      auto hj_obj = cudf::distinct_hash_join{right_keys, cudf::null_equality::UNEQUAL, 0.5};
+      auto result = hj_obj.inner_join(left_keys);
+    });
+  } else if (algorithm == "direct") {
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+      auto result = cudf::direct_inner_join(left_view, right_view, capacity);
+    });
+  } else {
+    state.skip("unknown algorithm");
+  }
+}
+
+NVBENCH_BENCH(nvbench_direct_inner_join)
+  .set_name("direct_inner_join")
+  .add_string_axis("algorithm", {"hash", "distinct_hash", "direct"})
+  .add_int64_axis("left_size", JOIN_SIZE_RANGE)
+  .add_int64_axis("right_size", JOIN_SIZE_RANGE)
+  .add_int64_axis("skip_large_sizes", {1});

--- a/cpp/include/cudf/io/avro.hpp
+++ b/cpp/include/cudf/io/avro.hpp
@@ -154,7 +154,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& columns(std::vector<std::string> col_names)
   {
-    options._columns = std::move(col_names);
+    options.set_columns(std::move(col_names));
     return *this;
   }
 
@@ -166,7 +166,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& skip_rows(size_type val)
   {
-    options._skip_rows = val;
+    options.set_skip_rows(val);
     return *this;
   }
 
@@ -178,7 +178,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& num_rows(size_type val)
   {
-    options._num_rows = val;
+    options.set_num_rows(val);
     return *this;
   }
 

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -535,7 +535,7 @@ class csv_reader_options {
    *
    * @param pfx String used as prefix in for each column name
    */
-  void set_prefix(std::string pfx) { _prefix = pfx; }
+  void set_prefix(std::string pfx) { _prefix = std::move(pfx); }
 
   /**
    * @brief Sets whether to rename duplicate column names.
@@ -685,17 +685,16 @@ class csv_reader_options {
   /**
    * @brief Sets the expected quoting style used in the input CSV data.
    *
-   * Note: Only the following quoting styles are supported:
-   *   1. MINIMAL: String columns containing special characters like row-delimiters/
-   *               field-delimiter/quotes will be quoted.
-   *   2. NONE: No quoting is done for any columns.
+   * The reader accepts all defined quoting styles. `NONE` disables quotation parsing; all other
+   * styles enable it.
    *
    * @param quoting Quoting style used
    */
   void set_quoting(quote_style quoting)
   {
-    CUDF_EXPECTS(quoting == quote_style::MINIMAL || quoting == quote_style::NONE,
-                 "Only MINIMAL and NONE are supported for quoting.");
+    CUDF_EXPECTS(quoting == quote_style::MINIMAL || quoting == quote_style::ALL ||
+                   quoting == quote_style::NONNUMERIC || quoting == quote_style::NONE,
+                 "Unsupported quoting style.");
     _quoting = quoting;
   }
 
@@ -867,7 +866,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& compression(compression_type comp)
   {
-    options._compression = comp;
+    options.set_compression(comp);
     return *this;
   }
 
@@ -903,7 +902,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& names(std::vector<std::string> col_names)
   {
-    options._names = std::move(col_names);
+    options.set_names(std::move(col_names));
     return *this;
   }
 
@@ -915,7 +914,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& prefix(std::string pfx)
   {
-    options._prefix = std::move(pfx);
+    options.set_prefix(std::move(pfx));
     return *this;
   }
 
@@ -927,7 +926,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& mangle_dupe_cols(bool val)
   {
-    options._mangle_dupe_cols = val;
+    options.enable_mangle_dupe_cols(val);
     return *this;
   }
 
@@ -939,7 +938,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& use_cols_names(std::vector<std::string> col_names)
   {
-    options._use_cols_names = std::move(col_names);
+    options.set_use_cols_names(std::move(col_names));
     return *this;
   }
 
@@ -951,7 +950,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& use_cols_indexes(std::vector<int> col_indices)
   {
-    options._use_cols_indexes = std::move(col_indices);
+    options.set_use_cols_indexes(std::move(col_indices));
     return *this;
   }
 
@@ -999,7 +998,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& header(size_type hdr)
   {
-    options._header = hdr;
+    options.set_header(hdr);
     return *this;
   }
 
@@ -1011,7 +1010,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& lineterminator(char term)
   {
-    options._lineterminator = term;
+    options.set_lineterminator(term);
     return *this;
   }
 
@@ -1023,7 +1022,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& delimiter(char delim)
   {
-    options._delimiter = delim;
+    options.set_delimiter(delim);
     return *this;
   }
 
@@ -1035,7 +1034,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& thousands(char val)
   {
-    options._thousands = val;
+    options.set_thousands(val);
     return *this;
   }
 
@@ -1047,7 +1046,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& decimal(char val)
   {
-    options._decimal = val;
+    options.set_decimal(val);
     return *this;
   }
 
@@ -1059,7 +1058,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& comment(char val)
   {
-    options._comment = val;
+    options.set_comment(val);
     return *this;
   }
 
@@ -1071,7 +1070,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& windowslinetermination(bool val)
   {
-    options._windowslinetermination = val;
+    options.enable_windowslinetermination(val);
     return *this;
   }
 
@@ -1083,7 +1082,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& delim_whitespace(bool val)
   {
-    options._delim_whitespace = val;
+    options.enable_delim_whitespace(val);
     return *this;
   }
 
@@ -1095,7 +1094,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& skipinitialspace(bool val)
   {
-    options._skipinitialspace = val;
+    options.enable_skipinitialspace(val);
     return *this;
   }
 
@@ -1107,7 +1106,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& skip_blank_lines(bool val)
   {
-    options._skip_blank_lines = val;
+    options.enable_skip_blank_lines(val);
     return *this;
   }
 
@@ -1119,7 +1118,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& quoting(quote_style style)
   {
-    options._quoting = style;
+    options.set_quoting(style);
     return *this;
   }
 
@@ -1131,7 +1130,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& quotechar(char ch)
   {
-    options._quotechar = ch;
+    options.set_quotechar(ch);
     return *this;
   }
 
@@ -1143,7 +1142,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& doublequote(bool val)
   {
-    options._doublequote = val;
+    options.enable_doublequote(val);
     return *this;
   }
 
@@ -1156,7 +1155,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& detect_whitespace_around_quotes(bool val)
   {
-    options._detect_whitespace_around_quotes = val;
+    options.enable_detect_whitespace_around_quotes(val);
     return *this;
   }
 
@@ -1168,7 +1167,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_dates(std::vector<std::string> col_names)
   {
-    options._parse_dates_names = std::move(col_names);
+    options.set_parse_dates(std::move(col_names));
     return *this;
   }
 
@@ -1180,7 +1179,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_dates(std::vector<int> col_indices)
   {
-    options._parse_dates_indexes = std::move(col_indices);
+    options.set_parse_dates(std::move(col_indices));
     return *this;
   }
 
@@ -1192,7 +1191,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_hex(std::vector<std::string> col_names)
   {
-    options._parse_hex_names = std::move(col_names);
+    options.set_parse_hex(std::move(col_names));
     return *this;
   }
 
@@ -1204,7 +1203,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_hex(std::vector<int> col_indices)
   {
-    options._parse_hex_indexes = std::move(col_indices);
+    options.set_parse_hex(std::move(col_indices));
     return *this;
   }
 
@@ -1216,7 +1215,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dtypes(std::map<std::string, data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -1228,7 +1227,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dtypes(std::vector<data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -1240,7 +1239,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& true_values(std::vector<std::string> vals)
   {
-    options._true_values.insert(options._true_values.end(), vals.begin(), vals.end());
+    options.set_true_values(std::move(vals));
     return *this;
   }
 
@@ -1252,7 +1251,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& false_values(std::vector<std::string> vals)
   {
-    options._false_values.insert(options._false_values.end(), vals.begin(), vals.end());
+    options.set_false_values(std::move(vals));
     return *this;
   }
 
@@ -1300,7 +1299,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dayfirst(bool val)
   {
-    options._dayfirst = val;
+    options.enable_dayfirst(val);
     return *this;
   }
 
@@ -1312,7 +1311,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& timestamp_type(data_type type)
   {
-    options._timestamp_type = type;
+    options.set_timestamp_type(type);
     return *this;
   }
 
@@ -1619,7 +1618,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& names(std::vector<std::string> names)
   {
-    options._names = names;
+    options.set_names(std::move(names));
     return *this;
   }
 
@@ -1631,7 +1630,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& na_rep(std::string val)
   {
-    options._na_rep = val;
+    options.set_na_rep(std::move(val));
     return *this;
   };
 
@@ -1643,7 +1642,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& include_header(bool val)
   {
-    options._include_header = val;
+    options.enable_include_header(val);
     return *this;
   }
 
@@ -1655,7 +1654,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& rows_per_chunk(int val)
   {
-    options._rows_per_chunk = val;
+    options.set_rows_per_chunk(val);
     return *this;
   }
 
@@ -1667,7 +1666,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& line_terminator(std::string term)
   {
-    options._line_terminator = term;
+    options.set_line_terminator(std::move(term));
     return *this;
   }
 
@@ -1679,7 +1678,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& inter_column_delimiter(char delim)
   {
-    options._inter_column_delimiter = delim;
+    options.set_inter_column_delimiter(delim);
     return *this;
   }
 
@@ -1691,7 +1690,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& true_value(std::string val)
   {
-    options._true_value = val;
+    options.set_true_value(std::move(val));
     return *this;
   }
 
@@ -1703,7 +1702,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& false_value(std::string val)
   {
-    options._false_value = val;
+    options.set_false_value(std::move(val));
     return *this;
   }
 

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -614,7 +614,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::vector<data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -626,7 +626,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::map<std::string, data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -638,7 +638,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::map<std::string, schema_element> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -662,7 +662,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& compression(compression_type comp_type)
   {
-    options._compression = comp_type;
+    options.set_compression(comp_type);
     return *this;
   }
 
@@ -674,7 +674,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& byte_range_offset(size_type offset)
   {
-    options._byte_range_offset = offset;
+    options.set_byte_range_offset(offset);
     return *this;
   }
 
@@ -686,7 +686,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& byte_range_size(size_type size)
   {
-    options._byte_range_size = size;
+    options.set_byte_range_size(size);
     return *this;
   }
 
@@ -710,7 +710,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& lines(bool val)
   {
-    options._lines = val;
+    options.enable_lines(val);
     return *this;
   }
 
@@ -723,7 +723,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& mixed_types_as_string(bool val)
   {
-    options._mixed_types_as_string = val;
+    options.enable_mixed_types_as_string(val);
     return *this;
   }
 
@@ -739,7 +739,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& prune_columns(bool val)
   {
-    options._prune_columns = val;
+    options.enable_prune_columns(val);
     return *this;
   }
 
@@ -754,7 +754,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& experimental(bool val)
   {
-    options._experimental = val;
+    options.enable_experimental(val);
     return *this;
   }
 
@@ -766,7 +766,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dayfirst(bool val)
   {
-    options._dayfirst = val;
+    options.enable_dayfirst(val);
     return *this;
   }
 
@@ -779,7 +779,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& keep_quotes(bool val)
   {
-    options._keep_quotes = val;
+    options.enable_keep_quotes(val);
     return *this;
   }
 
@@ -792,7 +792,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& normalize_single_quotes(bool val)
   {
-    options._normalize_single_quotes = val;
+    options.enable_normalize_single_quotes(val);
     return *this;
   }
 
@@ -805,7 +805,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& normalize_whitespace(bool val)
   {
-    options._normalize_whitespace = val;
+    options.enable_normalize_whitespace(val);
     return *this;
   }
 
@@ -817,7 +817,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& recovery_mode(json_recovery_mode_t val)
   {
-    options._recovery_mode = val;
+    options.set_recovery_mode(val);
     return *this;
   }
 
@@ -1302,7 +1302,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& table(table_view tbl)
   {
-    options._table = tbl;
+    options.set_table(tbl);
     return *this;
   }
 
@@ -1314,7 +1314,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& compression(compression_type comptype)
   {
-    options._compression = comptype;
+    options.set_compression(comptype);
     return *this;
   }
 
@@ -1326,7 +1326,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& metadata(table_metadata metadata)
   {
-    options._metadata = std::move(metadata);
+    options.set_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1338,7 +1338,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& na_rep(std::string val)
   {
-    options._na_rep = std::move(val);
+    options.set_na_rep(std::move(val));
     return *this;
   };
 
@@ -1350,7 +1350,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& include_nulls(bool val)
   {
-    options._include_nulls = val;
+    options.enable_include_nulls(val);
     return *this;
   }
 
@@ -1364,7 +1364,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& utf8_escaped(bool val)
   {
-    options._enable_utf8_escaped = val;
+    options.enable_utf8_escaped(val);
     return *this;
   }
 
@@ -1376,7 +1376,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& lines(bool val)
   {
-    options._lines = val;
+    options.enable_lines(val);
     return *this;
   }
 
@@ -1388,7 +1388,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& rows_per_chunk(int val)
   {
-    options._rows_per_chunk = val;
+    options.set_rows_per_chunk(val);
     return *this;
   }
 
@@ -1400,7 +1400,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& true_value(std::string val)
   {
-    options._true_value = std::move(val);
+    options.set_true_value(std::move(val));
     return *this;
   }
 
@@ -1412,7 +1412,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& false_value(std::string val)
   {
-    options._false_value = std::move(val);
+    options.set_false_value(std::move(val));
     return *this;
   }
 

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -288,6 +288,16 @@ class orc_reader_options {
   {
     _decimal128_columns = std::move(val);
   }
+
+  /**
+   * @brief Sets whether to ignore writer timezone in the stripe footer.
+   *
+   * @param val Boolean value to enable/disable ignoring writer timezone
+   */
+  void enable_ignore_timezone_in_stripe_footer(bool val)
+  {
+    _ignore_timezone_in_stripe_footer = val;
+  }
 };
 
 /**
@@ -319,7 +329,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& columns(std::vector<std::string> col_names)
   {
-    options._columns = std::move(col_names);
+    options.set_columns(std::move(col_names));
     return *this;
   }
 
@@ -367,7 +377,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& use_index(bool use)
   {
-    options._use_index = use;
+    options.enable_use_index(use);
     return *this;
   }
 
@@ -379,7 +389,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& use_np_dtypes(bool use)
   {
-    options._use_np_dtypes = use;
+    options.enable_use_np_dtypes(use);
     return *this;
   }
 
@@ -391,7 +401,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& timestamp_type(data_type type)
   {
-    options._timestamp_type = type;
+    options.set_timestamp_type(type);
     return *this;
   }
 
@@ -403,7 +413,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& decimal128_columns(std::vector<std::string> val)
   {
-    options._decimal128_columns = std::move(val);
+    options.set_decimal128_columns(std::move(val));
     return *this;
   }
 
@@ -415,7 +425,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& ignore_timezone_in_stripe_footer(bool ignore)
   {
-    options._ignore_timezone_in_stripe_footer = ignore;
+    options.enable_ignore_timezone_in_stripe_footer(ignore);
     return *this;
   }
 
@@ -932,7 +942,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& enable_statistics(statistics_freq val)
   {
-    options._stats_freq = val;
+    options.enable_statistics(val);
     return *this;
   }
 
@@ -980,7 +990,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& table(table_view tbl)
   {
-    options._table = tbl;
+    options.set_table(tbl);
     return *this;
   }
 
@@ -992,7 +1002,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& metadata(table_input_metadata meta)
   {
-    options._metadata = std::move(meta);
+    options.set_metadata(std::move(meta));
     return *this;
   }
 
@@ -1004,7 +1014,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& key_value_metadata(std::map<std::string, std::string> metadata)
   {
-    options._user_data = std::move(metadata);
+    options.set_key_value_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1017,7 +1027,7 @@ class orc_writer_options_builder {
   orc_writer_options_builder& compression_statistics(
     std::shared_ptr<writer_compression_statistics> const& comp_stats)
   {
-    options._compression_stats = comp_stats;
+    options.set_compression_statistics(comp_stats);
     return *this;
   }
 
@@ -1029,7 +1039,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& enable_dictionary_sort(bool val)
   {
-    options._enable_dictionary_sort = val;
+    options.set_enable_dictionary_sort(val);
     return *this;
   }
 
@@ -1352,7 +1362,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& enable_statistics(statistics_freq val)
   {
-    options._stats_freq = val;
+    options.enable_statistics(val);
     return *this;
   }
 
@@ -1400,7 +1410,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& metadata(table_input_metadata meta)
   {
-    options._metadata = std::move(meta);
+    options.metadata(std::move(meta));
     return *this;
   }
 
@@ -1413,7 +1423,7 @@ class chunked_orc_writer_options_builder {
   chunked_orc_writer_options_builder& key_value_metadata(
     std::map<std::string, std::string> metadata)
   {
-    options._user_data = std::move(metadata);
+    options.set_key_value_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1426,7 +1436,7 @@ class chunked_orc_writer_options_builder {
   chunked_orc_writer_options_builder& compression_statistics(
     std::shared_ptr<writer_compression_statistics> const& comp_stats)
   {
-    options._compression_stats = comp_stats;
+    options.set_compression_statistics(comp_stats);
     return *this;
   }
 
@@ -1438,7 +1448,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& enable_dictionary_sort(bool val)
   {
-    options._enable_dictionary_sort = val;
+    options.set_enable_dictionary_sort(val);
     return *this;
   }
 

--- a/cpp/include/cudf/join/direct_join.hpp
+++ b/cpp/include/cudf/join/direct_join.hpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/export.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <memory>
+#include <utility>
+
+namespace CUDF_EXPORT cudf {
+
+/**
+ * @addtogroup column_join
+ * @{
+ * @file
+ * @brief Direct join APIs for pre-hashed integer keys
+ */
+
+/**
+ * @brief Returns the row indices that can be used to construct the result of performing an inner
+ * join between two key columns whose values directly determine the matched row index
+ *
+ * The right keys are treated as a perfect hash of the right rows: a lookup table of `capacity`
+ * entries maps each key value to its row index, and each left key probes that table directly. No
+ * hashing or key comparison is performed. Left keys that do not occur in the right keys produce no
+ * output pair.
+ *
+ * @note Behavior is undefined if any key value is not less than `capacity`, or if the right keys
+ * contain duplicates.
+ *
+ * @throw cudf::data_type_error if the key columns are not of type UINT32
+ * @throw std::invalid_argument if the key columns contain nulls
+ * @throw std::invalid_argument if `capacity` is less than the number of right keys
+ *
+ * @param left_keys The left key column containing pre-hashed keys in `[0, capacity)`, from which
+ * the keys are probed
+ * @param right_keys The right key column containing distinct pre-hashed keys in `[0, capacity)`
+ * @param capacity The number of entries in the lookup table
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned indices' device memory
+ *
+ * @return A pair of vectors [`left_indices`, `right_indices`] that can be used to construct the
+ * result of performing an inner join between two tables with `left_keys` and `right_keys` as the
+ * join keys
+ */
+[[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+                        std::unique_ptr<rmm::device_uvector<size_type>>>
+direct_inner_join(column_view const& left_keys,
+                  column_view const& right_keys,
+                  std::size_t capacity,
+                  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/** @} */  // end of group
+
+}  // namespace CUDF_EXPORT cudf

--- a/cpp/src/join/direct_join.cu
+++ b/cpp/src/join/direct_join.cu
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/detail/algorithms/copy_if.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/join/direct_join.hpp>
+#include <cudf/join/join.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <cub/device/device_for.cuh>
+#include <cub/device/device_transform.cuh>
+#include <cuda/iterator>
+#include <cuda/std/iterator>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+// Scatters each right row index to the lookup slot addressed by its key value
+struct scatter_right_index {
+  size_type* lookup;
+  std::uint32_t const* right_keys;
+
+  __device__ void operator()(size_type right_idx) const
+  {
+    lookup[right_keys[right_idx]] = right_idx;
+  }
+};
+
+// Writes the (left, right) index pair of the `out_idx`-th match, given a matched left row index
+struct emit_match_pair {
+  size_type* left_out;
+  size_type* right_out;
+  size_type const* lookup;
+  std::uint32_t const* left_keys;
+
+  __device__ void operator()(size_type out_idx, size_type left_idx) const
+  {
+    left_out[out_idx]  = left_idx;
+    right_out[out_idx] = lookup[left_keys[left_idx]];
+  }
+};
+
+// Returns true if the left row's key hits a right row in the lookup table
+struct is_match {
+  size_type const* lookup;
+  std::uint32_t const* left_keys;
+
+  __device__ bool operator()(size_type left_idx) const
+  {
+    return lookup[left_keys[left_idx]] != JoinNoMatch;
+  }
+};
+
+}  // namespace
+
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+direct_inner_join(column_view const& left_keys,
+                  column_view const& right_keys,
+                  std::size_t capacity,
+                  rmm::cuda_stream_view stream,
+                  rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(
+    left_keys.type().id() == type_id::UINT32 and right_keys.type().id() == type_id::UINT32,
+    "direct_inner_join keys must be of type UINT32",
+    cudf::data_type_error);
+  CUDF_EXPECTS(not left_keys.has_nulls() and not right_keys.has_nulls(),
+               "direct_inner_join keys must not contain nulls",
+               std::invalid_argument);
+  CUDF_EXPECTS(static_cast<std::size_t>(right_keys.size()) <= capacity,
+               "capacity must be at least the number of right keys",
+               std::invalid_argument);
+
+  if (left_keys.is_empty() or right_keys.is_empty()) {
+    return std::pair(std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr),
+                     std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr));
+  }
+
+  // Build: scatter each right row index to the slot addressed by its key value
+  auto lookup =
+    rmm::device_uvector<size_type>(capacity, stream, cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(
+    cub::DeviceTransform::Fill(lookup.begin(), lookup.size(), JoinNoMatch, stream.value()));
+  CUDF_CUDA_TRY(
+    cub::DeviceFor::Bulk(right_keys.size(),
+                         scatter_right_index{lookup.data(), right_keys.begin<std::uint32_t>()},
+                         stream.value()));
+
+  // Probe: a single pass emitting the (left index, matched right index) pairs
+  auto left_indices =
+    std::make_unique<rmm::device_uvector<size_type>>(left_keys.size(), stream, mr);
+  auto right_indices =
+    std::make_unique<rmm::device_uvector<size_type>>(left_keys.size(), stream, mr);
+
+  auto const d_left_keys = left_keys.begin<std::uint32_t>();
+  auto const out_iter    = cuda::tabulate_output_iterator{
+    emit_match_pair{left_indices->data(), right_indices->data(), lookup.data(), d_left_keys}};
+
+  auto const out_end = cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
+                                             cuda::counting_iterator<size_type>{left_keys.size()},
+                                             out_iter,
+                                             is_match{lookup.data(), d_left_keys},
+                                             stream);
+
+  auto const num_matches = cuda::std::distance(out_iter, out_end);
+  left_indices->resize(num_matches, stream);
+  right_indices->resize(num_matches, stream);
+
+  return std::pair(std::move(left_indices), std::move(right_indices));
+}
+
+}  // namespace detail
+
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+direct_inner_join(column_view const& left_keys,
+                  column_view const& right_keys,
+                  std::size_t capacity,
+                  rmm::cuda_stream_view stream,
+                  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::direct_inner_join(left_keys, right_keys, capacity, stream, mr);
+}
+
+}  // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ ConfigureTest(
   join/cross_join_tests.cpp
   join/semi_anti_join_tests.cpp
   join/mixed_join_tests.cu
+  join/direct_join_tests.cpp
   join/distinct_join_tests.cpp
   join/key_remapping_tests.cpp
   GPUS 1

--- a/cpp/tests/join/direct_join_tests.cpp
+++ b/cpp/tests/join/direct_join_tests.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/join/direct_join.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <cstdint>
+#include <numeric>
+#include <stdexcept>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+using key_wrapper = cudf::test::fixed_width_column_wrapper<std::uint32_t>;
+
+struct DirectJoinTest : public cudf::test::BaseFixture {
+  // Runs the join and checks the returned pairs against a host-side reference
+  void compare_to_reference(std::vector<std::uint32_t> const& left_keys,
+                            std::vector<std::uint32_t> const& right_keys,
+                            std::size_t capacity)
+  {
+    auto const left  = key_wrapper(left_keys.begin(), left_keys.end());
+    auto const right = key_wrapper(right_keys.begin(), right_keys.end());
+
+    auto const [left_indices, right_indices] = cudf::direct_inner_join(left, right, capacity);
+
+    auto const stream          = cudf::get_default_stream();
+    auto const h_left_indices  = cudf::detail::make_std_vector(*left_indices, stream);
+    auto const h_right_indices = cudf::detail::make_std_vector(*right_indices, stream);
+
+    auto right_row_of = std::unordered_map<std::uint32_t, cudf::size_type>{};
+    for (std::size_t i = 0; i < right_keys.size(); ++i) {
+      right_row_of[right_keys[i]] = static_cast<cudf::size_type>(i);
+    }
+
+    auto expected_left  = std::vector<cudf::size_type>{};
+    auto expected_right = std::vector<cudf::size_type>{};
+    for (std::size_t i = 0; i < left_keys.size(); ++i) {
+      if (auto const it = right_row_of.find(left_keys[i]); it != right_row_of.end()) {
+        expected_left.push_back(static_cast<cudf::size_type>(i));
+        expected_right.push_back(it->second);
+      }
+    }
+
+    // The probe is a single stable pass over the left keys, so output order is deterministic
+    EXPECT_EQ(h_left_indices, expected_left);
+    EXPECT_EQ(h_right_indices, expected_right);
+  }
+};
+
+TEST_F(DirectJoinTest, DenseKeys)
+{
+  auto right_keys = std::vector<std::uint32_t>(1000);
+  std::iota(right_keys.begin(), right_keys.end(), 0);
+
+  auto left_keys = std::vector<std::uint32_t>{};
+  for (std::uint32_t i = 0; i < 3000; ++i) {
+    left_keys.push_back(i % 1500);  // keys in [1000, 1500) are unmatched
+  }
+
+  compare_to_reference(left_keys, right_keys, 1500);
+}
+
+TEST_F(DirectJoinTest, SparseKeys)
+{
+  auto const right_keys = std::vector<std::uint32_t>{7, 0, 42, 999, 512, 3};
+  auto const left_keys  = std::vector<std::uint32_t>{42, 42, 1, 999, 0, 998, 3, 7, 100};
+
+  compare_to_reference(left_keys, right_keys, 1000);
+}
+
+TEST_F(DirectJoinTest, EmptyInputs)
+{
+  auto const empty    = key_wrapper{};
+  auto const nonempty = key_wrapper{0, 1, 2};
+
+  {
+    auto const [left_indices, right_indices] = cudf::direct_inner_join(empty, nonempty, 3);
+    EXPECT_EQ(left_indices->size(), 0);
+    EXPECT_EQ(right_indices->size(), 0);
+  }
+  {
+    auto const [left_indices, right_indices] = cudf::direct_inner_join(nonempty, empty, 3);
+    EXPECT_EQ(left_indices->size(), 0);
+    EXPECT_EQ(right_indices->size(), 0);
+  }
+}
+
+TEST_F(DirectJoinTest, InvalidKeyType)
+{
+  auto const keys = cudf::test::fixed_width_column_wrapper<std::int32_t>{0, 1, 2};
+
+  EXPECT_THROW(std::ignore = cudf::direct_inner_join(keys, keys, 3), cudf::data_type_error);
+}
+
+TEST_F(DirectJoinTest, NullKeys)
+{
+  auto const valid      = key_wrapper{0, 1, 2};
+  auto const with_nulls = key_wrapper{{0, 1, 2}, cudf::test::iterators::null_at(1)};
+
+  EXPECT_THROW(std::ignore = cudf::direct_inner_join(with_nulls, valid, 3), std::invalid_argument);
+  EXPECT_THROW(std::ignore = cudf::direct_inner_join(valid, with_nulls, 3), std::invalid_argument);
+}
+
+TEST_F(DirectJoinTest, InsufficientCapacity)
+{
+  auto const keys = key_wrapper{0, 1, 2};
+
+  EXPECT_THROW(std::ignore = cudf::direct_inner_join(keys, keys, 2), std::invalid_argument);
+}

--- a/cpp/tests/streams/join_test.cpp
+++ b/cpp/tests/streams/join_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,6 +11,7 @@
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column.hpp>
 #include <cudf/join/conditional_join.hpp>
+#include <cudf/join/direct_join.hpp>
 #include <cudf/join/filtered_join.hpp>
 #include <cudf/join/hash_join.hpp>
 #include <cudf/join/join.hpp>
@@ -22,6 +23,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <tuple>
 
 class JoinTest : public cudf::test::BaseFixture {
   static inline cudf::table make_table()
@@ -84,6 +86,13 @@ TEST_F(JoinTest, LeftAntiJoin)
 }
 
 TEST_F(JoinTest, CrossJoin) { cudf::cross_join(table0, table1, cudf::test::get_default_stream()); }
+
+TEST_F(JoinTest, DirectInnerJoin)
+{
+  cudf::test::fixed_width_column_wrapper<uint32_t> left_keys{{0, 1, 2, 5}};
+  cudf::test::fixed_width_column_wrapper<uint32_t> right_keys{{0, 1, 2, 3}};
+  std::ignore = cudf::direct_inner_join(left_keys, right_keys, 6, cudf::test::get_default_stream());
+}
 
 TEST_F(JoinTest, ConditionalInnerJoin)
 {

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -285,7 +285,7 @@ class ParquetOptions:
         default_factory=_make_default_factory(
             f"{_env_prefix}__PREFETCH_FILE_METADATA",
             _bool_converter,
-            default=False,
+            default=True,
         )
     )
     use_jit_filter: bool = dataclasses.field(


### PR DESCRIPTION
This updates the cudf-polars configuration to enable parquet metadata prefetching by default. It can be disabled through the environment variable

    CUDF_POLARS__PARQUET_OPTIONS__PREFETCH_FILE_METADATA=0

or through Python when constructing the ParquetOptions.

We need to do some benchmarking to make sure this is beneficial everywhere.

Closes https://github.com/rapidsai/cudf/issues/22826

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
