### PR TITLE
[POC] Optimize length-based dispatch in `strings::contains`

### DIFF
--- a/cpp/benchmarks/common/generate_skewed_data.cpp
+++ b/cpp/benchmarks/common/generate_skewed_data.cpp
@@ -158,7 +158,6 @@ std::unique_ptr<cudf::column> create_skewed_string_column(cudf::size_type num_ro
 {
   CUDF_EXPECTS(num_rows >= 0, "num_rows must be at least 0");
   CUDF_EXPECTS(short_length >= 16, "short_length must be at least 16");
-  CUDF_EXPECTS(long_tail_length >= 1024, "long tail length must be at least 1024");
   CUDF_EXPECTS(short_string_pct >= 0 && short_string_pct <= 100,
                "short_string_pct must be in the range [0, 100]");
   CUDF_EXPECTS(hit_rate >= 0 && hit_rate <= 100, "hit_rate must be in the range [0, 100]");

--- a/cpp/benchmarks/common/generate_skewed_data.cpp
+++ b/cpp/benchmarks/common/generate_skewed_data.cpp
@@ -158,6 +158,7 @@ std::unique_ptr<cudf::column> create_skewed_string_column(cudf::size_type num_ro
 {
   CUDF_EXPECTS(num_rows >= 0, "num_rows must be at least 0");
   CUDF_EXPECTS(short_length >= 16, "short_length must be at least 16");
+  CUDF_EXPECTS(long_tail_length >= 1024, "long tail length must be at least 1024");
   CUDF_EXPECTS(short_string_pct >= 0 && short_string_pct <= 100,
                "short_string_pct must be in the range [0, 100]");
   CUDF_EXPECTS(hit_rate >= 0 && hit_rate <= 100, "hit_rate must be in the range [0, 100]");

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -9,12 +9,126 @@
 
 #include <cudf_test/column_wrapper.hpp>
 
+#include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/attributes.hpp>
 #include <cudf/strings/find.hpp>
+#include <cudf/strings/slice.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <nvbench/nvbench.cuh>
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace {
+
+constexpr cudf::size_type skewed_template_width{16};
+constexpr cudf::size_type minimum_generated_long_length{1024};
+constexpr int64_t target_input_bytes{160 * 1024 * 1024};
+
+cudf::size_type round_up_to_template(cudf::size_type n)
+{
+  return ((n + skewed_template_width - 1) / skewed_template_width) * skewed_template_width;
+}
+
+/**
+ * @brief Build skewed input, rounding lengths up to the generator's template width and then
+ * slicing down to the requested lengths when needed.
+ *
+ * The generator requires lengths that are multiples of 16. Callers may request arbitrary lengths
+ * (e.g. uniform mean=52); this helper generates at the next valid size and truncates.
+ */
+std::unique_ptr<cudf::column> make_skewed_benchmark_column(cudf::size_type num_rows,
+                                                           cudf::size_type short_length,
+                                                           cudf::size_type long_tail_length,
+                                                           double long_string_pct,
+                                                           int32_t hit_rate)
+{
+  auto const gen_short = std::max(skewed_template_width, round_up_to_template(short_length));
+  auto gen_long = std::max(minimum_generated_long_length, round_up_to_template(long_tail_length));
+  if (gen_long <= gen_short) { gen_long = gen_short + skewed_template_width; }
+
+  auto const short_string_pct = static_cast<cudf::size_type>(100.0 - long_string_pct);
+  auto col = create_skewed_string_column(num_rows, gen_short, gen_long, short_string_pct, hit_rate);
+  if (gen_short == short_length && gen_long == long_tail_length) { return col; }
+
+  // Truncate generated rows to the requested lengths. For ASCII rows, character positions match
+  // byte lengths; UTF-8 template rows are approximate but still usable for length sweeps.
+  if (long_string_pct <= 0.0) {
+    return cudf::strings::slice_strings(cudf::strings_column_view(col->view()),
+                                        std::optional<cudf::size_type>{0},
+                                        std::optional<cudf::size_type>{short_length});
+  }
+  if (long_string_pct >= 100.0) {
+    return cudf::strings::slice_strings(cudf::strings_column_view(col->view()),
+                                        std::optional<cudf::size_type>{0},
+                                        std::optional<cudf::size_type>{long_tail_length});
+  }
+
+  auto const bytes    = cudf::strings::count_bytes(cudf::strings_column_view(col->view()));
+  auto const is_short = cudf::binary_operation(bytes->view(),
+                                               cudf::numeric_scalar<cudf::size_type>(gen_short),
+                                               cudf::binary_operator::EQUAL,
+                                               cudf::data_type{cudf::type_id::BOOL8});
+  auto const short_stops =
+    cudf::make_column_from_scalar(cudf::numeric_scalar<cudf::size_type>(short_length), num_rows);
+  auto const long_stops = cudf::make_column_from_scalar(
+    cudf::numeric_scalar<cudf::size_type>(long_tail_length), num_rows);
+  auto const stops = cudf::copy_if_else(short_stops->view(), long_stops->view(), is_short->view());
+  auto const starts =
+    cudf::make_column_from_scalar(cudf::numeric_scalar<cudf::size_type>(0), num_rows);
+  return cudf::strings::slice_strings(
+    cudf::strings_column_view(col->view()), starts->view(), stops->view());
+}
+
+struct mean_length_config {
+  cudf::size_type num_rows;
+  cudf::size_type short_length;
+  cudf::size_type long_tail_length;
+  double long_string_pct;
+};
+
+/**
+ * @brief Solve the long-row length needed to produce the requested mean row length.
+ */
+cudf::size_type long_length_for_mean(cudf::size_type mean_length,
+                                     cudf::size_type short_length,
+                                     double long_string_pct)
+{
+  auto const long_fraction = long_string_pct / 100.0;
+  auto const long_length   = (mean_length - ((1.0 - long_fraction) * short_length)) / long_fraction;
+  return static_cast<cudf::size_type>(
+           std::round(long_length / static_cast<double>(skewed_template_width))) *
+         skewed_template_width;
+}
+
+/**
+ * @brief Build a uniform or skewed configuration with approximately constant total input bytes.
+ */
+mean_length_config make_mean_length_config(cudf::size_type mean_length, double long_string_pct)
+{
+  constexpr cudf::size_type minimum_rows{1024};
+  constexpr cudf::size_type skewed_short_length{16};
+
+  auto const short_length = long_string_pct == 0.0 ? mean_length : skewed_short_length;
+  auto const long_tail_length =
+    long_string_pct == 0.0 ? mean_length + skewed_template_width
+                           : long_length_for_mean(mean_length, short_length, long_string_pct);
+  auto const long_fraction = long_string_pct / 100.0;
+  auto const actual_mean =
+    ((1.0 - long_fraction) * short_length) + (long_fraction * long_tail_length);
+  auto const num_rows =
+    std::max(minimum_rows, static_cast<cudf::size_type>(target_input_bytes / actual_mean));
+
+  return {num_rows, short_length, long_tail_length, long_string_pct};
+}
+
+}  // namespace
 
 static void bench_find_string(nvbench::state& state)
 {
@@ -121,3 +235,38 @@ NVBENCH_BENCH(bench_find_string_skewed)
   .add_int64_axis("num_rows", {32768, 262144, 2097152})
   .add_int64_axis("short_string_pct", {90, 95, 99})
   .add_int64_axis("hit_rate", {20, 80});
+
+static void bench_find_string_skewed_by_mean(nvbench::state& state)
+{
+  auto const mean_length     = static_cast<cudf::size_type>(state.get_int64("mean_length"));
+  auto const long_string_pct = static_cast<double>(state.get_int64("long_string_pct"));
+  auto const hit_rate        = static_cast<int32_t>(state.get_int64("hit_rate"));
+  auto const config          = make_mean_length_config(mean_length, long_string_pct);
+
+  auto const stream = cudf::get_default_stream();
+  auto const col    = make_skewed_benchmark_column(config.num_rows,
+                                                config.short_length,
+                                                config.long_tail_length,
+                                                config.long_string_pct,
+                                                hit_rate);
+  auto const input  = cudf::strings_column_view(col->view());
+  auto target       = cudf::string_scalar(skewed_string_target_substring);
+
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.add_global_memory_reads<nvbench::int8_t>(col->alloc_size());
+  state.add_global_memory_writes<nvbench::int8_t>(input.size());
+
+  auto const mem_stats_logger = cudf::memory_stats_logger();
+  state.exec(nvbench::exec_tag::sync,
+             [&](nvbench::launch&) { cudf::strings::contains(input, target); });
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+}
+
+NVBENCH_BENCH(bench_find_string_skewed_by_mean)
+  .set_name("find_string_skewed_by_mean")
+  .add_int64_axis("mean_length",
+                  {32, 34, 36, 38, 40, 42, 44, 46,  48,  50,  52,  54,  56,  58,  60,  62,  64, 66,
+                   68, 70, 72, 74, 76, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256})
+  .add_int64_axis("long_string_pct", {0, 1, 10})
+  .add_int64_axis("hit_rate", {0});

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -27,6 +27,10 @@
 
 namespace {
 
+// create_skewed_string_column requires long_tail_length >= 1024; generate at least that size
+// then slice down to the requested lengths for the mean-length sweep.
+constexpr cudf::size_type minimum_generated_long_length{1024};
+
 cudf::size_type round_up_to_template(cudf::size_type n, cudf::size_type template_width)
 {
   return ((n + template_width - 1) / template_width) * template_width;
@@ -36,8 +40,9 @@ cudf::size_type round_up_to_template(cudf::size_type n, cudf::size_type template
  * @brief Build skewed input, rounding lengths up to the generator's template width and then
  * slicing down to the requested lengths when needed.
  *
- * The generator requires lengths that are multiples of 16. Callers may request arbitrary lengths
- * (e.g. uniform mean=52); this helper generates at the next valid size and truncates.
+ * The generator requires lengths that are multiples of 16 and long_tail_length >= 1024.
+ * Callers may request shorter lengths (e.g. uniform mean=52); this helper generates at the
+ * next valid size and truncates.
  */
 std::unique_ptr<cudf::column> make_skewed_benchmark_column(cudf::size_type num_rows,
                                                            cudf::size_type short_length,
@@ -48,7 +53,8 @@ std::unique_ptr<cudf::column> make_skewed_benchmark_column(cudf::size_type num_r
 {
   auto const gen_short =
     std::max(template_width, round_up_to_template(short_length, template_width));
-  auto gen_long = std::max(template_width, round_up_to_template(long_tail_length, template_width));
+  auto gen_long = std::max(minimum_generated_long_length,
+                           round_up_to_template(long_tail_length, template_width));
   if (gen_long <= gen_short) { gen_long = gen_short + template_width; }
 
   auto const short_string_pct = static_cast<int32_t>(100.0 - long_string_pct);

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -27,13 +27,9 @@
 
 namespace {
 
-constexpr cudf::size_type skewed_template_width{16};
-constexpr cudf::size_type minimum_generated_long_length{1024};
-constexpr int64_t target_input_bytes{160 * 1024 * 1024};
-
-cudf::size_type round_up_to_template(cudf::size_type n)
+cudf::size_type round_up_to_template(cudf::size_type n, cudf::size_type template_width)
 {
-  return ((n + skewed_template_width - 1) / skewed_template_width) * skewed_template_width;
+  return ((n + template_width - 1) / template_width) * template_width;
 }
 
 /**
@@ -46,14 +42,16 @@ cudf::size_type round_up_to_template(cudf::size_type n)
 std::unique_ptr<cudf::column> make_skewed_benchmark_column(cudf::size_type num_rows,
                                                            cudf::size_type short_length,
                                                            cudf::size_type long_tail_length,
+                                                           cudf::size_type template_width,
                                                            double long_string_pct,
                                                            int32_t hit_rate)
 {
-  auto const gen_short = std::max(skewed_template_width, round_up_to_template(short_length));
-  auto gen_long = std::max(minimum_generated_long_length, round_up_to_template(long_tail_length));
-  if (gen_long <= gen_short) { gen_long = gen_short + skewed_template_width; }
+  auto const gen_short =
+    std::max(template_width, round_up_to_template(short_length, template_width));
+  auto gen_long = std::max(template_width, round_up_to_template(long_tail_length, template_width));
+  if (gen_long <= gen_short) { gen_long = gen_short + template_width; }
 
-  auto const short_string_pct = static_cast<cudf::size_type>(100.0 - long_string_pct);
+  auto const short_string_pct = static_cast<int32_t>(100.0 - long_string_pct);
   auto col = create_skewed_string_column(num_rows, gen_short, gen_long, short_string_pct, hit_rate);
   if (gen_short == short_length && gen_long == long_tail_length) { return col; }
 
@@ -98,32 +96,36 @@ struct mean_length_config {
  */
 cudf::size_type long_length_for_mean(cudf::size_type mean_length,
                                      cudf::size_type short_length,
-                                     double long_string_pct)
+                                     double long_string_pct,
+                                     cudf::size_type template_width)
 {
   auto const long_fraction = long_string_pct / 100.0;
   auto const long_length   = (mean_length - ((1.0 - long_fraction) * short_length)) / long_fraction;
   return static_cast<cudf::size_type>(
-           std::round(long_length / static_cast<double>(skewed_template_width))) *
-         skewed_template_width;
+           std::round(long_length / static_cast<double>(template_width))) *
+         template_width;
 }
 
 /**
  * @brief Build a uniform or skewed configuration with approximately constant total input bytes.
  */
-mean_length_config make_mean_length_config(cudf::size_type mean_length, double long_string_pct)
+mean_length_config make_mean_length_config(cudf::size_type mean_length,
+                                           double long_string_pct,
+                                           cudf::size_type template_width,
+                                           int64_t input_bytes)
 {
   constexpr cudf::size_type minimum_rows{1024};
-  constexpr cudf::size_type skewed_short_length{16};
 
-  auto const short_length = long_string_pct == 0.0 ? mean_length : skewed_short_length;
+  auto const short_length = long_string_pct == 0.0 ? mean_length : template_width;
   auto const long_tail_length =
-    long_string_pct == 0.0 ? mean_length + skewed_template_width
-                           : long_length_for_mean(mean_length, short_length, long_string_pct);
+    long_string_pct == 0.0
+      ? mean_length + template_width
+      : long_length_for_mean(mean_length, short_length, long_string_pct, template_width);
   auto const long_fraction = long_string_pct / 100.0;
   auto const actual_mean =
     ((1.0 - long_fraction) * short_length) + (long_fraction * long_tail_length);
   auto const num_rows =
-    std::max(minimum_rows, static_cast<cudf::size_type>(target_input_bytes / actual_mean));
+    std::max(minimum_rows, static_cast<cudf::size_type>(input_bytes / actual_mean));
 
   return {num_rows, short_length, long_tail_length, long_string_pct};
 }
@@ -240,13 +242,17 @@ static void bench_find_string_skewed_by_mean(nvbench::state& state)
 {
   auto const mean_length     = static_cast<cudf::size_type>(state.get_int64("mean_length"));
   auto const long_string_pct = static_cast<double>(state.get_int64("long_string_pct"));
+  auto const template_width  = static_cast<cudf::size_type>(state.get_int64("template_width"));
+  auto const input_bytes     = state.get_int64("input_bytes");
   auto const hit_rate        = static_cast<int32_t>(state.get_int64("hit_rate"));
-  auto const config          = make_mean_length_config(mean_length, long_string_pct);
+  auto const config =
+    make_mean_length_config(mean_length, long_string_pct, template_width, input_bytes);
 
   auto const stream = cudf::get_default_stream();
   auto const col    = make_skewed_benchmark_column(config.num_rows,
                                                 config.short_length,
                                                 config.long_tail_length,
+                                                template_width,
                                                 config.long_string_pct,
                                                 hit_rate);
   auto const input  = cudf::strings_column_view(col->view());
@@ -269,4 +275,6 @@ NVBENCH_BENCH(bench_find_string_skewed_by_mean)
                   {32, 34, 36, 38, 40, 42, 44, 46,  48,  50,  52,  54,  56,  58,  60,  62,  64, 66,
                    68, 70, 72, 74, 76, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256})
   .add_int64_axis("long_string_pct", {0, 1, 10})
+  .add_int64_axis("template_width", {16})
+  .add_int64_axis("input_bytes", {160 * 1024 * 1024})
   .add_int64_axis("hit_rate", {0});

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -5,11 +5,15 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/detail/utilities/cuda.hpp>
 #include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/find.hpp>
@@ -20,17 +24,21 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
 #include <cuda/atomic>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/limits>
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -47,6 +55,14 @@ namespace {
  * Note that this value is shared by find, rfind, and contains functions.
  */
 constexpr size_type AVG_CHAR_BYTES_THRESHOLD = 64;
+
+/**
+ * @brief Per-row byte-length threshold for heterogeneous contains.
+ *
+ * Rows with `size_bytes < HETERO_LENGTH_THRESHOLD` are searched thread-per-row;
+ * rows with `size_bytes >= HETERO_LENGTH_THRESHOLD` are deferred to warp-per-row.
+ */
+constexpr size_type HETERO_LENGTH_THRESHOLD = 96;
 
 /**
  * @brief Find function handles a string per thread
@@ -321,9 +337,219 @@ namespace detail {
 namespace {
 
 /**
+ * @brief Search short rows and collect long-row indices in a single pass.
+ *
+ * Executes one thread per string/row, fusing the length-based partitioning with the thread-per-row
+ * search of the short rows:
+ *  - null rows: write `false` (the output null mask already marks these rows invalid)
+ *  - short rows (`size_bytes < length_threshold`): run the thread-per-row contains scan and write
+ *    the result directly
+ *  - long rows (`size_bytes >= length_threshold`): append the row index to `d_long_indices` for the
+ *    subsequent warp-parallel pass
+ *
+ * The long-index append uses a warp-aggregated atomic so each group of coalesced long-row threads
+ * performs a single `atomicAdd` on `d_long_count`, minimizing global-atomic contention.
+ *
+ * @param d_strings Column of input strings
+ * @param d_target String to search for in each row of `d_strings`
+ * @param d_results Indicates which rows contain `d_target`
+ * @param length_threshold Rows with at least this many bytes use the warp-parallel pass
+ * @param d_long_indices Output list of deferred long-row indices (capacity == d_strings.size())
+ * @param d_long_count Output count of entries written to `d_long_indices`
+ */
+CUDF_KERNEL void contains_string_per_thread_heterogeneous(column_device_view const d_strings,
+                                                          string_view const d_target,
+                                                          bool* d_results,
+                                                          size_type const length_threshold,
+                                                          size_type* d_long_indices,
+                                                          size_type* d_long_count)
+{
+  auto const tidx = cudf::detail::grid_1d::global_thread_id();
+  if (tidx >= static_cast<cudf::thread_index_type>(d_strings.size())) { return; }
+  auto const str_idx = static_cast<size_type>(tidx);
+
+  if (d_strings.is_null(str_idx)) {
+    d_results[str_idx] = false;
+    return;
+  }
+
+  auto const d_str = d_strings.element<string_view>(str_idx);
+
+  if (d_str.size_bytes() < length_threshold) {
+    auto const target_bytes = d_target.size_bytes();
+    auto found              = false;
+    for (size_type i = 0; !found && ((i + target_bytes) <= d_str.size_bytes()); ++i) {
+      found = d_target.compare(d_str.data() + i, target_bytes) == 0;
+    }
+    d_results[str_idx] = found;
+    return;
+  }
+
+  // Long row: defer to the warp-parallel pass. Coalesced long-row threads aggregate their appends
+  // into a single atomicAdd, then each writes its index at a distinct offset.
+  namespace cg      = cooperative_groups;
+  auto const active = cg::coalesced_threads();
+  size_type offset  = 0;
+  if (active.thread_rank() == 0) {
+    offset = atomicAdd(d_long_count, static_cast<size_type>(active.num_threads()));
+  }
+  offset                                                                = active.shfl(offset, 0);
+  d_long_indices[offset + static_cast<size_type>(active.thread_rank())] = str_idx;
+}
+
+/**
+ * @brief Check if `d_target` appears in each deferred long row of `d_strings`.
+ *
+ * This executes as a warp per string/row and performs well for longer strings. Only the (non-null)
+ * long-row indices collected by ::contains_string_per_thread_heterogeneous are processed.
+ * @see AVG_CHAR_BYTES_THRESHOLD
+ *
+ * The row count is read from `d_long_count` on the device so the two passes launch back-to-back on
+ * the stream with no intervening host synchronization. A fixed (grid-stride) launch is used: each
+ * warp strides over the deferred rows, so the second pass works for any `*d_long_count` without the
+ * host needing to know the value to size the grid.
+ *
+ * @param d_strings Column of input strings
+ * @param d_target String to search for in each row of `d_strings`
+ * @param d_results Indicates which rows contain `d_target`
+ * @param d_long_indices Indices of the long (non-null) rows to process
+ * @param d_long_count Number of entries in `d_long_indices` (read on the device)
+ */
+CUDF_KERNEL void contains_warp_parallel_fn_heterogeneous(column_device_view const d_strings,
+                                                         string_view const d_target,
+                                                         bool* d_results,
+                                                         size_type const* d_long_indices,
+                                                         size_type const* d_long_count)
+{
+  auto const long_count = *d_long_count;
+
+  namespace cg        = cooperative_groups;
+  auto const warp     = cg::tiled_partition<cudf::detail::warp_size>(cg::this_thread_block());
+  auto const lane_idx = warp.thread_rank();
+
+  // Grid-stride over the deferred long rows, one warp per row.
+  auto const first_warp = cudf::detail::grid_1d::global_thread_id() / cudf::detail::warp_size;
+  auto const warp_stride =
+    (static_cast<cudf::thread_index_type>(gridDim.x) * blockDim.x) / cudf::detail::warp_size;
+
+  for (auto str_idx = first_warp; str_idx < static_cast<cudf::thread_index_type>(long_count);
+       str_idx += warp_stride) {
+    // Long indices are guaranteed non-null by the partitioning kernel.
+    auto const real_str_idx = d_long_indices[str_idx];
+    auto const d_str        = d_strings.element<string_view>(real_str_idx);
+
+    auto constexpr bytes_per_warp = 4;
+    auto found                    = false;
+    // All lanes must participate in every warp.any() call. Using `!found` or a per-lane bounds
+    // check as the loop condition would cause lanes to exit at different iterations, leaving the
+    // remaining warp.any() calls with only a partial tile. Instead, keep all lanes in lockstep
+    // via an unconditional while(true) and guard per-lane work with in-loop predicates.
+    auto i = static_cast<cudf::size_type>(lane_idx * bytes_per_warp);
+    while (true) {
+      bool const in_bounds = (i + d_target.size_bytes()) <= d_str.size_bytes();
+      // All lanes converge: stop when no lane has unchecked positions.
+      if (!warp.any(in_bounds && !found)) break;
+      if (in_bounds && !found) {
+        for (auto j = 0; !found && (j < bytes_per_warp); j++) {
+          if (((i + j + d_target.size_bytes()) <= d_str.size_bytes()) &&
+              d_target.compare(d_str.data() + i + j, d_target.size_bytes()) == 0) {
+            found = true;
+          }
+        }
+      }
+      // All lanes converge: early-exit as soon as any lane finds the target.
+      if (warp.any(found)) break;
+      i += cudf::detail::warp_size * bytes_per_warp;
+    }
+
+    auto const result = warp.any(found);
+    if (lane_idx == 0) { d_results[real_str_idx] = result; }
+  }
+}
+
+std::unique_ptr<column> contains_heterogeneous(strings_column_view const& input,
+                                               string_scalar const& target,
+                                               size_type long_row_count,
+                                               rmm::cuda_stream_view stream,
+                                               rmm::device_async_resource_ref mr)
+{
+  auto strings_count = input.size();
+  if (strings_count == 0) return make_empty_column(type_id::BOOL8);
+
+  CUDF_EXPECTS(target.is_valid(stream), "Parameter target must be valid.");
+
+  auto d_target = string_view(target.data(), target.size());
+
+  // create output column
+  auto results      = make_numeric_column(data_type{type_id::BOOL8},
+                                     strings_count,
+                                     cudf::detail::copy_bitmask(input.parent(), stream, mr),
+                                     input.null_count(),
+                                     stream,
+                                     mr);
+  auto results_view = results->mutable_view();
+  auto d_results    = results_view.data<bool>();
+
+  // Handle empty target
+  if (d_target.empty()) {
+    thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 results_view.begin<bool>(),
+                 results_view.end<bool>(),
+                 true);
+    results->set_null_count(input.null_count());
+    return results;
+  }
+
+  auto strings_column = column_device_view::create(input.parent(), stream);
+  auto d_strings      = *strings_column;
+
+  constexpr int block_size = 256;
+
+  // First pass (thread-per-string): search the short rows in place and collect the indices of the
+  // long rows (>= length_threshold bytes) for the warp-parallel pass. `long_row_count` was computed
+  // by the dispatch reduction, so the index buffer is exactly sized.
+  size_type const length_threshold = HETERO_LENGTH_THRESHOLD;
+  rmm::device_uvector<size_type> long_indices(long_row_count, stream);
+  cudf::detail::device_scalar<size_type> d_long_count(0, stream);
+
+  auto const grid = cudf::detail::grid_1d{strings_count, block_size};
+  contains_string_per_thread_heterogeneous<<<grid.num_blocks,
+                                             grid.num_threads_per_block,
+                                             0,
+                                             stream.value()>>>(
+    d_strings, d_target, d_results, length_threshold, long_indices.data(), d_long_count.data());
+  CUDF_CUDA_TRY(cudaGetLastError());
+
+  // Second pass (warp-per-string): search the deferred long rows. The deferred count is read on the
+  // device inside the kernel, so this launches back-to-back with the first pass and never
+  // synchronizes the stream (a host readback here dominates the runtime on small columns).
+  //
+  // A fixed grid-stride launch is used: size it for full occupancy but never exceed the worst case
+  // of one warp per row, so short-heavy columns launch only a handful of blocks that read
+  // `*d_long_count == 0` and exit immediately.
+  auto constexpr warps_per_block = block_size / cudf::detail::warp_size;
+  int max_blocks_per_sm          = 0;
+  CUDF_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    &max_blocks_per_sm, contains_warp_parallel_fn_heterogeneous, block_size, 0));
+  auto const persistent_blocks =
+    static_cast<int64_t>(max_blocks_per_sm) * cudf::detail::num_multiprocessors();
+  auto const worst_case_blocks =
+    cudf::util::div_rounding_up_safe<int64_t>(long_row_count, warps_per_block);
+  auto const num_warp_blocks = std::max<int64_t>(1, std::min(persistent_blocks, worst_case_blocks));
+
+  contains_warp_parallel_fn_heterogeneous<<<num_warp_blocks, block_size, 0, stream.value()>>>(
+    d_strings, d_target, d_results, long_indices.data(), d_long_count.data());
+  CUDF_CUDA_TRY(cudaGetLastError());
+
+  results->set_null_count(input.null_count());
+  return results;
+}
+
+/**
  * @brief Check if `d_target` appears in a row in `d_strings`.
  *
  * This executes as a warp per string/row and performs well for longer strings.
+ * Used when every non-null input row is long.
  * @see AVG_CHAR_BYTES_THRESHOLD
  *
  * @param d_strings Column of input strings
@@ -401,6 +627,30 @@ std::unique_ptr<column> contains_warp_parallel(strings_column_view const& input,
   }
   results->set_null_count(input.null_count());
   return results;
+}
+
+/**
+ * @brief Number of strings at least `HETERO_LENGTH_THRESHOLD` bytes long.
+ *
+ * Computed from adjacent offset differences. Null rows conventionally have equal adjacent offsets
+ * and contribute 0. The returned host value sizes the long-index buffer exactly and selects the
+ * all-short and all-long fast paths.
+ */
+size_type count_long_strings(strings_column_view const& input, rmm::cuda_stream_view stream)
+{
+  if (input.is_empty()) { return 0; }
+  auto const offsets_itr =
+    cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
+  return thrust::transform_reduce(
+    rmm::exec_policy(stream),
+    thrust::counting_iterator<size_type>{0},
+    thrust::counting_iterator<size_type>{input.size()},
+    [offsets_itr] __device__(size_type idx) -> size_type {
+      return static_cast<size_type>(
+        (offsets_itr[idx + 1] - offsets_itr[idx]) >= HETERO_LENGTH_THRESHOLD);
+    },
+    size_type{0},
+    cuda::std::plus<size_type>{});
 }
 
 /**
@@ -530,21 +780,22 @@ std::unique_ptr<column> contains(strings_column_view const& input,
                                  rmm::cuda_stream_view stream,
                                  rmm::device_async_resource_ref mr)
 {
-  // use warp parallel when the average string width is greater than the threshold
-  if ((input.null_count() < input.size()) &&
-      ((input.chars_size(stream) / (input.size() - input.null_count())) >
-       AVG_CHAR_BYTES_THRESHOLD)) {
-    return contains_warp_parallel(input, target, stream, mr);
-  }
-
-  // benchmark measurements showed this to be faster for smaller strings
   auto pfn = [] __device__(string_view d_string, string_view d_target) {
     for (size_type i = 0; i <= (d_string.size_bytes() - d_target.size_bytes()); ++i) {
       if (d_target.compare(d_string.data() + i, d_target.size_bytes()) == 0) { return true; }
     }
     return false;
   };
-  return contains_fn(input, target, pfn, stream, mr);
+
+  auto const long_row_count = count_long_strings(input, stream);
+  if (long_row_count == 0) { return contains_fn(input, target, pfn, stream, mr); }
+
+  // If every non-null row is long, partitioning and indirect indices add no value.
+  auto const null_count = input.null_count();
+  if (null_count >= 0 && long_row_count == (input.size() - null_count)) {
+    return contains_warp_parallel(input, target, stream, mr);
+  }
+  return contains_heterogeneous(input, target, long_row_count, stream, mr);
 }
 
 std::unique_ptr<column> contains(strings_column_view const& strings,


### PR DESCRIPTION
## Description

Update on #21917. 

### `contains` changes
* Runs a `count_long` reduction to determine best execution mode
* Dispatch to the existing fast paths for thread-parallel and warp-parallel `contains` when lengths are uniform
* Use `count_long` to allocate exactly the space needed to `long_indices`, avoiding overhead misses from oversized allocations
* For mixed distributions, run a thread-parallel first pass to compute short strings and mark long strings, then a warp-parallel second pass to compute long strings.

### Benchmark changes
* Add a benchmark to sweep avg length and percent long. Holding total bytes constant and hit rate zero. Using short strings of 16 bytes and letting the long length float to hit the avg target 

### Discussion points
1. `contains` always runs `count_long` reduction for a small cost (~30us), OR `contains` exposes API to let users compute and pass the count in. I chose the former in this POC because I think the reduction is fast enough and a lot like a "sizes" pass we do in other places.
2. I don't like the constraint for string lengths to be forced in intervals of 16 and long strings barred from being shorter than 1024. Either relax these constraints in the data generators OR slice them in a dedicated benchmark. I chose the latter in this POC
3. if we have >80% long strings, we probably want to dispatch to the dedicated warp-parallel kernel rather than indexing so many rows. Right now the code just goes warp-parallel when all are long. Needs testing.
4. I chose 96 instead of 128 for the heterogeneous length pivot. Needs testing.

### Results

All run on A100

<img width="931" height="642" alt="image" src="https://github.com/user-attachments/assets/7684dba8-5a82-4c99-93af-c0257361bfca" />
Uniform lengths show about 3% throughput loss for short and long strings. Plus a 60% thoughput boost for 60-80 avg length.

<img width="937" height="643" alt="image" src="https://github.com/user-attachments/assets/54571fc8-daa8-4ff8-b580-e0d3631b759e" />
With 1% long strings, we see about 2.4x to +40% higher throughput with new algorithm versus main.

<img width="908" height="634" alt="image" src="https://github.com/user-attachments/assets/87f00c23-f127-406f-9b00-b3f4aa71a530" />
With 10% long strings, we see about 20-80% higher throughput with new algorithm versus main.

