### PR TITLE
Add memory resource control to valid_if

### DIFF
--- a/cpp/include/cudf/detail/valid_if.cuh
+++ b/cpp/include/cudf/detail/valid_if.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -73,7 +73,7 @@ CUDF_KERNEL void valid_if_kernel(
  * @param end The end of the sequence
  * @param p The predicate
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned device memory
+ * @param resources Memory resources used for the returned bitmask and temporary count scalar
  * @return A pair containing a `device_buffer` with the new bitmask and its null count
  */
 template <typename InputIterator, typename Predicate>
@@ -81,18 +81,18 @@ std::pair<rmm::device_buffer, size_type> valid_if(InputIterator begin,
                                                   InputIterator end,
                                                   Predicate p,
                                                   rmm::cuda_stream_view stream,
-                                                  rmm::device_async_resource_ref mr)
+                                                  cudf::memory_resources resources)
 {
   CUDF_EXPECTS(begin <= end, "Invalid range.");
 
   size_type size = cuda::std::distance(begin, end);
 
-  auto null_mask = cudf::create_null_mask(size, mask_state::UNINITIALIZED, stream, mr);
+  auto null_mask =
+    cudf::create_null_mask(size, mask_state::UNINITIALIZED, stream, resources.get_output_mr());
 
   size_type null_count{0};
   if (size > 0) {
-    cudf::detail::device_scalar<size_type> valid_count{
-      0, stream, cudf::get_current_device_resource_ref()};
+    cudf::detail::device_scalar<size_type> valid_count{0, stream, resources.get_temporary_mr()};
 
     constexpr size_type block_size{256};
     grid_1d grid{size, block_size};

--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -97,7 +97,8 @@ TEST_F(ValidIfTest, ExplicitMemoryResourceControl)
   auto stream               = cudf::get_default_stream();
   auto comparison_resources = cudf::memory_resources{harness.setup_mr(), harness.setup_mr()};
   auto iter                 = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000, comparison_resources);
+  auto expected =
+    cudf::test::detail::make_null_mask(iter, iter + 10000, stream, comparison_resources);
 
   {
     auto actual = [&] {
@@ -114,8 +115,11 @@ TEST_F(ValidIfTest, ExplicitMemoryResourceControl)
     harness.expect_output_allocations_live(stream);
     harness.expect_temporary_allocation_activity(stream);
     harness.expect_temporary_allocations_released(stream);
-    CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-      expected.first.data(), actual.first.data(), expected.first.size(), comparison_resources);
+    CUDF_TEST_EXPECT_EQUAL_BUFFERS(expected.first.data(),
+                                   actual.first.data(),
+                                   expected.first.size(),
+                                   stream,
+                                   comparison_resources);
     EXPECT_EQ(5000, actual.second);
     EXPECT_EQ(expected.second, actual.second);
   }

--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -7,6 +7,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/memory_resource_utilities.hpp>
 
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
@@ -42,6 +43,30 @@ TEST_F(ValidIfTest, EmptyRange)
   EXPECT_EQ(0, actual.second);
 }
 
+TEST_F(ValidIfTest, ExplicitMemoryResourcesEmptyRange)
+{
+  auto harness = cudf::test::memory_resource_test_harness{this->mr()};
+  auto stream  = cudf::get_default_stream();
+
+  auto actual = [&] {
+    auto current_scope = harness.fail_on_current_device_resource_use();
+    auto result        = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+                                         cuda::counting_iterator<cudf::size_type>{0},
+                                         odds_valid{},
+                                         stream,
+                                         harness.resources());
+    harness.synchronize(stream);
+    return result;
+  }();
+
+  EXPECT_EQ(0u, actual.first.size());
+  EXPECT_EQ(nullptr, actual.first.data());
+  EXPECT_EQ(0, actual.second);
+  harness.expect_no_live_allocations(stream);
+  EXPECT_EQ(0, harness.output_mr().get_bytes_counter().total);
+  EXPECT_EQ(0, harness.temporary_mr().get_bytes_counter().total);
+}
+
 TEST_F(ValidIfTest, InvalidRange)
 {
   EXPECT_THROW(cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{1},
@@ -64,6 +89,38 @@ TEST_F(ValidIfTest, OddsValid)
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(expected.first.data(), actual.first.data(), expected.first.size());
   EXPECT_EQ(5000, actual.second);
   EXPECT_EQ(expected.second, actual.second);
+}
+
+TEST_F(ValidIfTest, ExplicitMemoryResourceControl)
+{
+  auto harness              = cudf::test::memory_resource_test_harness{this->mr()};
+  auto stream               = cudf::get_default_stream();
+  auto comparison_resources = cudf::memory_resources{harness.setup_mr(), harness.setup_mr()};
+  auto iter                 = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
+  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000, comparison_resources);
+
+  {
+    auto actual = [&] {
+      auto current_scope = harness.fail_on_current_device_resource_use();
+      auto result        = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+                                           cuda::counting_iterator<cudf::size_type>{10000},
+                                           odds_valid{},
+                                           stream,
+                                           harness.resources());
+      harness.synchronize(stream);
+      return result;
+    }();
+
+    harness.expect_output_allocations_live(stream);
+    harness.expect_temporary_allocation_activity(stream);
+    harness.expect_temporary_allocations_released(stream);
+    CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+      expected.first.data(), actual.first.data(), expected.first.size(), comparison_resources);
+    EXPECT_EQ(5000, actual.second);
+    EXPECT_EQ(expected.second, actual.second);
+  }
+
+  harness.expect_no_live_allocations(stream);
 }
 
 TEST_F(ValidIfTest, AllValid)


### PR DESCRIPTION
## Description

Update `cudf::detail::valid_if` to accept `cudf::memory_resources`. The returned validity mask uses the output resource, and its temporary valid-count scalar uses the temporary resource.

This enables `cudf::label_bins`, the pilot API for temporary memory-resource control, to propagate separate output and temporary resources through validity-mask construction without falling back to the current device resource.

This is a non-breaking change for existing callers of `valid_if`.

Part of https://github.com/rapidsai/cudf/issues/20780

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.