### PR TITLE
Fix JIT LTO linking on builds targeting only feature-set variants

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1365,6 +1365,16 @@ SECTIONS
 )
 target_link_options(cudf PRIVATE "$<HOST_LINK:${CUDF_BINARY_DIR}/fatbin.ld>")
 
+# The JIT cache must know which architectures the precompiled fragments were built for: when a
+# device's compute capability was only built as its architecture-specific variant (e.g. NATIVE
+# resolving to 121a-real), NVRTC/nvJitLink must be given sm_<cc>a rather than sm_<cc>.
+string(REPLACE ";" "," _cudf_cuda_archs "${CMAKE_CUDA_ARCHITECTURES}")
+set_source_files_properties(
+  src/jit/cache.cpp PROPERTIES COMPILE_DEFINITIONS
+                               "CUDF_CUDA_ARCHITECTURES=\"${_cudf_cuda_archs}\""
+)
+unset(_cudf_cuda_archs)
+
 add_library(cudf::cudf ALIAS cudf)
 
 # ##################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1406,6 +1406,17 @@ SECTIONS
 )
 target_link_options(cudf PRIVATE "$<HOST_LINK:${CUDF_BINARY_DIR}/fatbin.ld>")
 
+# The JIT cache must know which architectures the precompiled fragments were built for: when a
+# device's compute capability was built only as a feature-set variant (e.g.
+# CMAKE_CUDA_ARCHITECTURES=120a-real, or the 100f-real entry of the RAPIDS defaults),
+# NVRTC/nvJitLink must be given sm_<cc>a / sm_<cc>f rather than sm_<cc>.
+string(REPLACE ";" "," _cudf_cuda_archs "${CMAKE_CUDA_ARCHITECTURES}")
+set_source_files_properties(
+  src/jit/cache.cpp PROPERTIES COMPILE_DEFINITIONS
+                               "CUDF_CUDA_ARCHITECTURES=\"${_cudf_cuda_archs}\""
+)
+unset(_cudf_cuda_archs)
+
 add_library(cudf::cudf ALIAS cudf)
 
 # ##################################################################################################

--- a/cpp/src/jit/arch_name.hpp
+++ b/cpp/src/jit/arch_name.hpp
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/utilities/export.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace CUDF_EXPORT cudf {
+
+/**
+ * @brief Returns the NVRTC/nvJitLink architecture name for a compute capability given the
+ * comma-separated CMAKE_CUDA_ARCHITECTURES list this build was compiled with
+ *
+ * Keeps the baseline name (sm_<cc>) whenever the list has a baseline entry for <cc>; otherwise
+ * returns the feature-set variant the build has (sm_<cc>a, then sm_<cc>f). Entry suffixes such
+ * as -real / -virtual are ignored.
+ */
+std::string jit_arch_name_for(std::int32_t compute_capability, std::string_view archs);
+
+}  // namespace CUDF_EXPORT cudf

--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -16,14 +16,46 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <future>
+#include <string>
+#include <string_view>
 
 namespace CUDF_EXPORT cudf {
 
 namespace {
+
+/**
+ * @brief Returns the architecture name to pass to NVRTC and nvJitLink for this device
+ *
+ * The precompiled JIT fragments only contain entries for the architectures this build
+ * targeted (CUDF_CUDA_ARCHITECTURES). When the build targeted only the
+ * architecture-specific variant of the device's compute capability -- which is what
+ * CMAKE_CUDA_ARCHITECTURES=NATIVE produces on such devices (e.g. 121a-real on GB10) --
+ * their fatbins hold only sm_<cc>a entries, and linking with plain sm_<cc> makes
+ * nvJitLink fail with NVJITLINK_ERROR_INVALID_INPUT. Use the architecture-specific name
+ * exactly when it is what this build was compiled for.
+ */
+std::string jit_arch_name(std::int32_t compute_capability)
+{
+  auto const specific = std::format("{}a", compute_capability);
+#if defined(CUDF_CUDA_ARCHITECTURES)
+  for (auto archs = std::string_view{CUDF_CUDA_ARCHITECTURES}; !archs.empty();) {
+    auto const comma = archs.find(',');
+    auto entry       = archs.substr(0, comma);
+    archs = comma == std::string_view::npos ? std::string_view{} : archs.substr(comma + 1);
+    // entries look like "121a-real", "120", or "90a-virtual"
+    if (auto const dash = entry.find('-'); dash != std::string_view::npos) {
+      entry = entry.substr(0, dash);
+    }
+    if (entry == specific) { return std::format("sm_{}", specific); }
+  }
+#endif
+  return std::format("sm_{}", compute_capability);
+}
 
 void hash(XXH3_state_t* ctx, std::span<char const> input)
 {
@@ -228,7 +260,7 @@ std::tuple<rtcx::library, rtcx::blob> compile_library(
     options.emplace_back(std::format("-I{}", include_dir));
   }
 
-  options.emplace_back(std::format("--gpu-architecture=sm_{}", sm));
+  options.emplace_back(std::format("--gpu-architecture={}", jit_arch_name(sm)));
 
   options.emplace_back("--diag-suppress=47");
   options.emplace_back("--device-int128");
@@ -313,7 +345,7 @@ rtcx::blob compile_fragment(char const* name,
     options.emplace_back(std::format("-I{}", include_dir));
   }
 
-  options.emplace_back(std::format("--gpu-architecture=sm_{}", sm));
+  options.emplace_back(std::format("--gpu-architecture={}", jit_arch_name(sm)));
 
   options.emplace_back("--diag-suppress=47");
   options.emplace_back("--device-int128");
@@ -507,7 +539,7 @@ std::tuple<rtcx::library, rtcx::blob> link_library_uncached(
   std::vector<std::string> options;
 
   options.emplace_back("-lto");
-  options.emplace_back(std::format("-arch=sm_{}", sm));
+  options.emplace_back(std::format("-arch={}", jit_arch_name(sm)));
 
   if (cfg.disable_cuda_cache) { options.emplace_back("--no-cache"); }
 

--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -16,14 +16,67 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <future>
+#include <string>
+#include <string_view>
 
 namespace CUDF_EXPORT cudf {
 
+std::string jit_arch_name_for(std::int32_t compute_capability, std::string_view archs)
+{
+  auto const baseline = std::format("{}", compute_capability);
+  auto has_baseline = false, has_arch_specific = false, has_family_specific = false;
+  while (!archs.empty()) {
+    auto const comma = archs.find(',');
+    auto entry       = archs.substr(0, comma);
+    archs = comma == std::string_view::npos ? std::string_view{} : archs.substr(comma + 1);
+    // entries look like "120a-real", "100f-real", "120", or "90a-virtual"
+    if (auto const dash = entry.find('-'); dash != std::string_view::npos) {
+      entry = entry.substr(0, dash);
+    }
+    if (!entry.starts_with(baseline)) { continue; }
+    auto const suffix = entry.substr(baseline.size());
+    if (suffix.empty()) {
+      has_baseline = true;
+    } else if (suffix == "a") {
+      has_arch_specific = true;
+    } else if (suffix == "f") {
+      has_family_specific = true;
+    }
+  }
+  if (has_baseline || !(has_arch_specific || has_family_specific)) {
+    return std::format("sm_{}", compute_capability);
+  }
+  return std::format("sm_{}{}", compute_capability, has_arch_specific ? "a" : "f");
+}
+
 namespace {
+
+/**
+ * @brief Returns the architecture name to pass to NVRTC and nvJitLink for this device
+ *
+ * The precompiled JIT fragments only contain entries for the architectures this build
+ * targeted (CUDF_CUDA_ARCHITECTURES). A build compiled with a feature-set target only,
+ * e.g. CMAKE_CUDA_ARCHITECTURES=120a-real (or the 100f-real entry of the RAPIDS
+ * defaults), produces fatbins holding only sm_<cc>a / sm_<cc>f entries; the link name
+ * derived from the device's compute capability alone ("sm_120") carries no feature-set
+ * flag, so nvJitLink finds no compatible entry and fails with
+ * NVJITLINK_ERROR_INVALID_INPUT. The baseline name is kept whenever the build has a
+ * baseline entry for the compute capability; otherwise the feature-set variant the
+ * build was compiled with is used.
+ */
+std::string jit_arch_name(std::int32_t compute_capability)
+{
+#if defined(CUDF_CUDA_ARCHITECTURES)
+  return jit_arch_name_for(compute_capability, CUDF_CUDA_ARCHITECTURES);
+#else
+  return jit_arch_name_for(compute_capability, std::string_view{});
+#endif
+}
 
 void hash(XXH3_state_t* ctx, std::span<char const> input)
 {
@@ -228,7 +281,7 @@ std::tuple<rtcx::library, rtcx::blob> compile_library(
     options.emplace_back(std::format("-I{}", include_dir));
   }
 
-  options.emplace_back(std::format("--gpu-architecture=sm_{}", sm));
+  options.emplace_back(std::format("--gpu-architecture={}", jit_arch_name(sm)));
 
   options.emplace_back("--diag-suppress=47");
   options.emplace_back("--device-int128");
@@ -313,7 +366,7 @@ rtcx::blob compile_fragment(char const* name,
     options.emplace_back(std::format("-I{}", include_dir));
   }
 
-  options.emplace_back(std::format("--gpu-architecture=sm_{}", sm));
+  options.emplace_back(std::format("--gpu-architecture={}", jit_arch_name(sm)));
 
   options.emplace_back("--diag-suppress=47");
   options.emplace_back("--device-int128");
@@ -403,7 +456,7 @@ kernel_instance={}
                           name,
                           runtime,
                           driver,
-                          sm,
+                          jit_arch_name(sm),
                           bundle_hash,
                           source_file,
                           kernel_instance);
@@ -464,7 +517,7 @@ kernel_instance={}
                           name,
                           runtime,
                           driver,
-                          sm,
+                          jit_arch_name(sm),
                           bundle_hash,
                           source_file,
                           kernel_instance);
@@ -507,7 +560,7 @@ std::tuple<rtcx::library, rtcx::blob> link_library_uncached(
   std::vector<std::string> options;
 
   options.emplace_back("-lto");
-  options.emplace_back(std::format("-arch=sm_{}", sm));
+  options.emplace_back(std::format("-arch={}", jit_arch_name(sm)));
 
   if (cfg.disable_cuda_cache) { options.emplace_back("--no-cache"); }
 
@@ -560,7 +613,7 @@ bundle={}
                           name,
                           runtime,
                           driver,
-                          sm,
+                          jit_arch_name(sm),
                           bundle_hash);
 
   XXH3_state_t state;

--- a/cpp/src/jit/cache.hpp
+++ b/cpp/src/jit/cache.hpp
@@ -4,6 +4,8 @@
  */
 
 #pragma once
+#include "jit/arch_name.hpp"
+
 #include <cudf/utilities/export.hpp>
 
 #include <rmm/cuda_stream_view.hpp>

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -754,7 +754,7 @@ ConfigureTest(LABEL_BINS_TEST labeling/label_bins_tests.cpp)
 
 # ##################################################################################################
 # * jit tests ----------------------------------------------------------------------------------
-ConfigureTest(JIT_PARSER_TEST jit/parse_ptx_function.cpp)
+ConfigureTest(JIT_PARSER_TEST jit/parse_ptx_function.cpp jit/arch_name.cpp)
 target_include_directories(JIT_PARSER_TEST PRIVATE "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>")
 
 ConfigureTest(ROW_IR_TEST jit/row_ir.cpp)

--- a/cpp/tests/jit/arch_name.cpp
+++ b/cpp/tests/jit/arch_name.cpp
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "jit/arch_name.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(JitArchName, BaselineOnly) { EXPECT_EQ(cudf::jit_arch_name_for(90, "90-real"), "sm_90"); }
+
+TEST(JitArchName, ArchSpecificOnly)
+{
+  EXPECT_EQ(cudf::jit_arch_name_for(120, "120a-real"), "sm_120a");
+  EXPECT_EQ(cudf::jit_arch_name_for(90, "90a-virtual"), "sm_90a");
+}
+
+TEST(JitArchName, FamilySpecificOnly)
+{
+  EXPECT_EQ(cudf::jit_arch_name_for(100, "100f-real"), "sm_100f");
+}
+
+TEST(JitArchName, BaselineWins)
+{
+  EXPECT_EQ(cudf::jit_arch_name_for(120, "120-real,120a-real"), "sm_120");
+  EXPECT_EQ(cudf::jit_arch_name_for(120, "120a-real,120"), "sm_120");
+}
+
+TEST(JitArchName, ArchSpecificWinsOverFamily)
+{
+  EXPECT_EQ(cudf::jit_arch_name_for(100, "100a-real,100f-real"), "sm_100a");
+}
+
+TEST(JitArchName, RapidsDefaults)
+{
+  auto const defaults = "75-real,80-real,86-real,90a-real,100f-real,120a-real,120";
+  EXPECT_EQ(cudf::jit_arch_name_for(80, defaults), "sm_80");
+  EXPECT_EQ(cudf::jit_arch_name_for(90, defaults), "sm_90a");
+  EXPECT_EQ(cudf::jit_arch_name_for(100, defaults), "sm_100f");
+  EXPECT_EQ(cudf::jit_arch_name_for(120, defaults), "sm_120");
+}
+
+TEST(JitArchName, UnlistedCapabilityFallsBack)
+{
+  EXPECT_EQ(cudf::jit_arch_name_for(121, "120a-real,120"), "sm_121");
+  EXPECT_EQ(cudf::jit_arch_name_for(121, ""), "sm_121");
+}
+
+TEST(JitArchName, PrefixDoesNotMatchLongerCapability)
+{
+  // "120a" must not be taken as a feature-set entry for compute capability 12.
+  EXPECT_EQ(cudf::jit_arch_name_for(12, "120a-real"), "sm_12");
+}


### PR DESCRIPTION
## Description

The JIT cache derived the NVRTC and nvJitLink architecture from the device's
compute capability alone (`sm_<cc>`). That name carries no feature-set flag, so
a build compiled only with a feature-set target — e.g.
`-DCMAKE_CUDA_ARCHITECTURES=120a-real`, or the `100f-real` entry that the RAPIDS
CUDA 13 defaults carry for compute capability 10.0 — produces precompiled JIT
fragment fatbins holding only `sm_<cc>a` / `sm_<cc>f` entries, `nvJitLinkAddData`
finds no compatible entry, and every LTO transform fails with
`NVJITLINK_ERROR_INVALID_INPUT`.

This derives the architecture name from the `CMAKE_CUDA_ARCHITECTURES` list the
build was compiled with (`jit_arch_name_for`): the baseline `sm_<cc>` is kept
whenever the list has a baseline entry for the capability; otherwise the
feature-set variant the build has is used (`sm_<cc>a`, then `sm_<cc>f`). Entry
suffixes such as `-real` / `-virtual` are ignored.

The same name now also qualifies the three persistent cache keys
(`get_kernel`, `get_kernel_fragment`, `get_lto_linked_kernel`), so CUBIN / LTO
IR produced for `sm_120` and `sm_120a` builds no longer share cache entries.

## Validation

* New `JitArchName` tests (JIT_PARSER_TEST; the pure function lives in
  `src/jit/arch_name.hpp` so the test does not pull the rtcx-dependent
  `cache.hpp`) cover: baseline only, `a` only, `f`
  only, baseline + `a` (baseline wins), `a` + `f` (`a` wins), the RAPIDS CUDA 13
  default list (`75,80,86,90a,100f,120a,120`), an unlisted capability, and the
  prefix case (`120a` is not an entry for capability 12).
* On a `121a-real`-only build (CUDA 13.3, nvJitLink 13.3.33): TRANSFORM_LTO_TEST
  passes 6/6 with this change and fails 6/6 without it; feeding the embedded
  `invsqrt` UDF fatbin to nvJitLink directly succeeds with `-arch=sm_121a` and
  reproduces error 3 with `-arch=sm_121`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
