### PR TITLE
[MINOR][cudf_polars] Validation summary skips query failures

### DIFF
--- a/python/cudf/cudf/pandas/_benchmarks/utils.py
+++ b/python/cudf/cudf/pandas/_benchmarks/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Utility functions/classes for running the PDS-H and PDS-DS benchmarks."""
@@ -755,6 +755,11 @@ def run_pandas(
         if validation_failures:
             print(  # noqa: T201
                 f"{len(validation_failures)} queries failed validation: {sorted(set(validation_failures))}"
+            )
+        elif query_failures:
+            print(  # noqa: T201
+                "Validation was skipped for queries that failed to run: "
+                f"{sorted({q_id for q_id, _ in query_failures})}"
             )
         else:
             print("All validated queries passed.")  # noqa: T201

--- a/python/cudf/cudf/pandas/_benchmarks/utils.py
+++ b/python/cudf/cudf/pandas/_benchmarks/utils.py
@@ -756,12 +756,12 @@ def run_pandas(
             print(  # noqa: T201
                 f"{len(validation_failures)} queries failed validation: {sorted(set(validation_failures))}"
             )
-        elif query_failures:
+        if query_failures:
             print(  # noqa: T201
                 "Validation was skipped for queries that failed to run: "
                 f"{sorted({q_id for q_id, _ in query_failures})}"
             )
-        else:
+        if not validation_failures and not query_failures:
             print("All validated queries passed.")  # noqa: T201
 
     args.output.write(json.dumps(run_config.serialize()))

--- a/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
@@ -1232,6 +1232,11 @@ def _finalize_benchmark_run(
                 f"{len(validation_failures)} queries failed validation: "
                 f"{sorted(set(validation_failures))}"
             )
+        elif query_failures:
+            print(
+                "⚠️  Validation was skipped for queries that failed to run: "
+                f"{sorted({q_id for q_id, _ in query_failures})}"
+            )
         else:
             print("✅ All validated queries passed.")
     args.output.write(json.dumps(run_config.serialize(engine=engine)))

--- a/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
@@ -1232,12 +1232,12 @@ def _finalize_benchmark_run(
                 f"{len(validation_failures)} queries failed validation: "
                 f"{sorted(set(validation_failures))}"
             )
-        elif query_failures:
+        if query_failures:
             print(
                 "⚠️  Validation was skipped for queries that failed to run: "
                 f"{sorted({q_id for q_id, _ in query_failures})}"
             )
-        else:
+        if not validation_failures and not query_failures:
             print("✅ All validated queries passed.")
     args.output.write(json.dumps(run_config.serialize(engine=engine)))
     args.output.write("\n")


### PR DESCRIPTION
## Description

When there are query failures, the validation summary shows, 
```
Validation Summary
==================
✅ All validated queries passed.
```

This is technically correct, but masks the fact that some queries failed. Need to inspect the json to find out what really happened. This is misleading.  

This PR, fixes the reporting string when there are failed queries. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
