### PR TITLE
Add approx_distinct_count API to cudf_streaming

### DIFF
--- a/cpp/libcudf_streaming/CMakeLists.txt
+++ b/cpp/libcudf_streaming/CMakeLists.txt
@@ -71,8 +71,16 @@ include(../cmake/thirdparty/get_cucollections.cmake)
 # * library target --------------------------------------------------------------------------------
 add_library(
   cudf_streaming SHARED
-  src/bloom_filter.cpp src/channel_metadata.cpp src/detail/device_bloom_filter.cu src/parquet.cpp
-  src/partition.cpp src/partition_utils.cpp src/table_chunk.cpp src/utils.cpp
+  src/approx_distinct_count.cpp
+  src/bloom_filter.cpp
+  src/channel_metadata.cpp
+  src/detail/approx_distinct_count.cu
+  src/detail/device_bloom_filter.cu
+  src/parquet.cpp
+  src/partition.cpp
+  src/partition_utils.cpp
+  src/table_chunk.cpp
+  src/utils.cpp
 )
 
 # ##################################################################################################

--- a/cpp/libcudf_streaming/include/cudf_streaming/approx_distinct_count.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/approx_distinct_count.hpp
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/streaming/core/actor.hpp>
+#include <rapidsmpf/streaming/core/channel.hpp>
+#include <rapidsmpf/streaming/core/context.hpp>
+#include <rapidsmpf/streaming/core/message.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace cudf_streaming {
+
+/**
+ * @brief Global row-count and approximate distinct-row statistics.
+ */
+struct cardinality_estimate {
+  std::size_t row_count{};       ///< Exact number of input rows across all ranks.
+  std::size_t distinct_count{};  ///< Approximate number of distinct rows across all ranks.
+};
+
+/**
+ * @brief Convert a cardinality estimate into a streaming message.
+ *
+ * @param sequence_number Ordering identifier for the message.
+ * @param estimate Estimate payload.
+ * @return Message containing the estimate.
+ */
+[[nodiscard]] rapidsmpf::streaming::Message to_message(
+  std::uint64_t sequence_number, std::unique_ptr<cardinality_estimate> estimate);
+
+/**
+ * @brief Distributed approximate distinct-row estimator.
+ *
+ * Each rank builds a local HyperLogLog sketch. The sketches are merged
+ * register-wise and row counts are summed in a single all-reduce, producing the
+ * global union cardinality and exact global row count on every rank.
+ * Nulls and NaNs are included in the distinct-row sketch.
+ */
+class cardinality_estimator {
+ public:
+  /**
+   * @brief Construct a distributed cardinality estimator.
+   *
+   * @param ctx Streaming context.
+   * @param comm Communicator for the collective operation.
+   * @param tag Collective operation identifier.
+   * @param precision HyperLogLog precision in the range [4, 18].
+   */
+  explicit cardinality_estimator(std::shared_ptr<rapidsmpf::streaming::Context> ctx,
+                                 std::shared_ptr<rapidsmpf::Communicator> comm,
+                                 rapidsmpf::OpID tag,
+                                 std::int32_t precision = 14);
+
+  /**
+   * @brief Get the communicator associated with this estimator.
+   *
+   * @return Shared pointer to the communicator.
+   */
+  [[nodiscard]] std::shared_ptr<rapidsmpf::Communicator> const& comm() const noexcept
+  {
+    return comm_;
+  }
+
+  /**
+   * @brief Get the HyperLogLog precision.
+   *
+   * @return Precision used for the sketch.
+   */
+  [[nodiscard]] std::int32_t precision() const noexcept { return precision_; }
+
+  /**
+   * @brief Get the collective operation identifier.
+   *
+   * @return Collective operation identifier.
+   */
+  [[nodiscard]] rapidsmpf::OpID tag() const noexcept { return tag_; }
+
+  /**
+   * @brief Estimate global input cardinality.
+   *
+   * The input channel must contain `table_chunk` payloads. The output channel
+   * receives exactly one `cardinality_estimate`. When @p ch_sampled is provided, each input chunk
+   * is forwarded unchanged after it has been added to the sketch. The sampled channel must be
+   * consumed concurrently: waiting for the cardinality estimate before consuming sampled chunks
+   * can deadlock when channel backpressure blocks forwarding.
+   *
+   * @param ch_in Input channel of table chunks.
+   * @param ch_out Output channel receiving one estimate.
+   * @param ch_sampled Optional output channel receiving the input chunks.
+   * @param column_indices Columns whose row tuples are counted. An empty vector selects all
+   * columns.
+   * @return Coroutine representing the estimation.
+   */
+  [[nodiscard]] rapidsmpf::streaming::Actor estimate(
+    std::shared_ptr<rapidsmpf::streaming::Channel> ch_in,
+    std::shared_ptr<rapidsmpf::streaming::Channel> ch_out,
+    std::shared_ptr<rapidsmpf::streaming::Channel> ch_sampled = nullptr,
+    std::vector<cudf::size_type> column_indices               = {});
+
+ private:
+  std::shared_ptr<rapidsmpf::streaming::Context> ctx_{};
+  std::shared_ptr<rapidsmpf::Communicator> comm_{};
+  rapidsmpf::OpID tag_{};
+  std::int32_t precision_{};
+};
+
+}  // namespace cudf_streaming

--- a/cpp/libcudf_streaming/include/cudf_streaming/detail/approx_distinct_count.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/detail/approx_distinct_count.hpp
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cstdint>
+
+namespace cudf_streaming::detail {
+
+/**
+ * @brief Set a single value in the device-accessible pointer @p data
+ *
+ * Performs `data[0] = value`.
+ *
+ * @param data Array to set value in.
+ * @param value Value to set @p data to.
+ * @param stream CUDA stream for kernel launches and memory operations.
+ */
+void set_value(std::uint64_t* data, std::uint64_t value, rmm::cuda_stream_view stream);
+
+/**
+ * @brief Add the value in @p left into @p right.
+ *
+ * Performs `right[0] += left[0];`
+ *
+ * @param left Array to add from.
+ * @param right Array to add into.
+ * @param stream CUDA stream for kernel launches and memory operations.
+ */
+void add_values(std::uint64_t const* left, std::uint64_t* right, rmm::cuda_stream_view stream);
+
+}  // namespace cudf_streaming::detail

--- a/cpp/libcudf_streaming/src/approx_distinct_count.cpp
+++ b/cpp/libcudf_streaming/src/approx_distinct_count.cpp
@@ -1,0 +1,186 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf/detail/utilities/cuda_memcpy.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/reduction/approx_distinct_count.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <cudf_streaming/approx_distinct_count.hpp>
+#include <cudf_streaming/detail/approx_distinct_count.hpp>
+#include <cudf_streaming/table_chunk.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <rapidsmpf/cuda_stream.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/memory/buffer_resource.hpp>
+#include <rapidsmpf/memory/memory_type.hpp>
+#include <rapidsmpf/streaming/coll/allreduce.hpp>
+#include <rapidsmpf/streaming/core/lineariser.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace cudf_streaming {
+namespace {
+
+constexpr auto null_handling = cudf::null_policy::INCLUDE;
+constexpr auto nan_handling  = cudf::nan_policy::NAN_IS_VALID;
+
+}  // namespace
+
+rapidsmpf::streaming::Message to_message(std::uint64_t sequence_number,
+                                         std::unique_ptr<cardinality_estimate> estimate)
+{
+  return {sequence_number, std::move(estimate), {}, {}};
+}
+
+cardinality_estimator::cardinality_estimator(std::shared_ptr<rapidsmpf::streaming::Context> ctx,
+                                             std::shared_ptr<rapidsmpf::Communicator> comm,
+                                             rapidsmpf::OpID tag,
+                                             std::int32_t precision)
+  : ctx_{std::move(ctx)}, comm_{std::move(comm)}, tag_{tag}, precision_{precision}
+{
+  RAPIDSMPF_EXPECTS(ctx_ != nullptr, "Cardinality estimator context must not be null");
+  RAPIDSMPF_EXPECTS(comm_ != nullptr, "Cardinality estimator communicator must not be null");
+  RAPIDSMPF_EXPECTS(precision_ >= 4 && precision_ <= 18,
+                    "Cardinality estimator precision must be in range [4, 18]",
+                    std::invalid_argument);
+}
+
+rapidsmpf::streaming::Actor cardinality_estimator::estimate(
+  std::shared_ptr<rapidsmpf::streaming::Channel> ch_in,
+  std::shared_ptr<rapidsmpf::streaming::Channel> ch_out,
+  std::shared_ptr<rapidsmpf::streaming::Channel> ch_sampled,
+  std::vector<cudf::size_type> column_indices)
+{
+  RAPIDSMPF_EXPECTS(ch_in != nullptr, "Input channel must not be null");
+  RAPIDSMPF_EXPECTS(ch_out != nullptr, "Estimate output channel must not be null");
+  std::vector<std::shared_ptr<rapidsmpf::streaming::Channel>> shutdown_channels;
+  shutdown_channels.push_back(ch_in);
+  if (ch_sampled != nullptr) { shutdown_channels.push_back(ch_sampled); }
+  shutdown_channels.push_back(ch_out);
+  rapidsmpf::streaming::ShutdownAtExit shutdown{std::move(shutdown_channels)};
+
+  co_await ctx_->executor()->schedule();
+  co_await ch_in->shutdown_metadata();
+  if (ch_sampled != nullptr) { co_await ch_sampled->shutdown_metadata(); }
+  co_await ch_out->shutdown_metadata();
+
+  auto const& br              = ctx_->br();
+  auto const sketch_stream    = br->stream_pool()->get_stream();
+  auto const sketch_bytes     = cudf::approx_distinct_count::sketch_bytes(precision_);
+  auto const row_count_offset = sketch_bytes;
+  auto const storage_bytes    = sketch_bytes + sizeof(std::uint64_t);
+  auto reservation =
+    co_await ctx_->memory(rapidsmpf::MemoryType::DEVICE)->reserve_or_wait(storage_bytes, 0);
+  auto buf = rmm::device_buffer(
+    storage_bytes, cudf::approx_distinct_count::sketch_alignment(), sketch_stream, br->device_mr());
+  RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(buf.data(), 0, storage_bytes, sketch_stream));
+  reservation.clear();
+  rapidsmpf::CudaEvent init_event;
+  rapidsmpf::CudaEvent add_event;
+  init_event.record(sketch_stream);
+  std::uint64_t rows_seen{};
+  while (!ch_out->is_shutdown()) {
+    auto msg = co_await ch_in->receive();
+    if (msg.empty()) { break; }
+
+    auto const sequence_number = msg.sequence_number();
+    auto chunk                 = msg.release<table_chunk>();
+    rows_seen += rapidsmpf::safe_cast<std::uint64_t>(chunk.shape().first);
+    chunk = co_await chunk.make_available(
+      ctx_,
+      -rapidsmpf::safe_cast<std::int64_t>(chunk.data_alloc_size(rapidsmpf::MemoryType::DEVICE)));
+    init_event.stream_wait(chunk.stream());
+    // Reserve a conservative hash-sized scratch allowance for the libcudf operation.
+    reservation =
+      co_await ctx_->memory(rapidsmpf::MemoryType::DEVICE)
+        ->reserve_or_wait(
+          rapidsmpf::safe_cast<std::size_t>(chunk.table_view().num_rows()) * sizeof(std::uint64_t),
+          0);
+    auto sketch =
+      cudf::approx_distinct_count({reinterpret_cast<cuda::std::byte*>(buf.data()), sketch_bytes},
+                                  precision_,
+                                  null_handling,
+                                  nan_handling);
+    auto const table =
+      column_indices.empty() ? chunk.table_view() : chunk.table_view().select(column_indices);
+    sketch.add(table, chunk.stream());
+    rapidsmpf::cuda_stream_join(sketch_stream, chunk.stream(), &add_event);
+    reservation.clear();
+    if (ch_sampled != nullptr) {
+      co_await ch_sampled->send(
+        to_message(sequence_number, std::make_unique<table_chunk>(std::move(chunk))));
+    }
+  }
+
+  detail::set_value(
+    reinterpret_cast<std::uint64_t*>(reinterpret_cast<std::byte*>(buf.data()) + row_count_offset),
+    rows_seen,
+    sketch_stream);
+
+  auto storage = br->move(std::make_unique<rmm::device_buffer>(std::move(buf)), sketch_stream);
+  if (comm_->nranks() > 1) {
+    reservation =
+      co_await ctx_->memory(rapidsmpf::MemoryType::DEVICE)->reserve_or_wait(storage_bytes, 0);
+    auto reducer = rapidsmpf::streaming::AllReduce(
+      ctx_,
+      comm_,
+      std::move(storage),
+      br->make_buffer(sketch_stream, std::move(reservation)),
+      tag_,
+      [precision = precision_, sketch_bytes, row_count_offset](rapidsmpf::Buffer const* left,
+                                                               rapidsmpf::Buffer* right) {
+        right->write_access([&](std::byte* out, rmm::cuda_stream_view stream) {
+          auto sketch =
+            cudf::approx_distinct_count({reinterpret_cast<cuda::std::byte*>(out), sketch_bytes},
+                                        precision,
+                                        null_handling,
+                                        nan_handling);
+          sketch.merge({reinterpret_cast<cuda::std::byte const*>(left->data()), sketch_bytes},
+                       stream);
+          detail::add_values(
+            reinterpret_cast<std::uint64_t const*>(left->data() + row_count_offset),
+            reinterpret_cast<std::uint64_t*>(out + row_count_offset),
+            stream);
+        });
+      });
+    auto result = co_await reducer.extract();
+    storage     = std::move(result.second);
+  }
+
+  auto const [distinct_count, row_count] =
+    storage->write_access([&](std::byte* data, rmm::cuda_stream_view stream) {
+      auto sketch =
+        cudf::approx_distinct_count({reinterpret_cast<cuda::std::byte*>(data), sketch_bytes},
+                                    precision_,
+                                    null_handling,
+                                    nan_handling);
+      auto const distinct_count = sketch.estimate(stream);
+      auto tmp                  = cudf::detail::make_host_vector<std::uint64_t>(1, stream);
+      cudf::detail::cuda_memcpy(
+        cudf::host_span<std::uint64_t>(tmp),
+        cudf::device_span{reinterpret_cast<std::uint64_t const*>(data + row_count_offset), 1},
+        stream);
+      return std::pair{distinct_count, tmp[0]};
+    });
+
+  co_await ch_out->send(
+    to_message(0,
+               std::make_unique<cardinality_estimate>(cardinality_estimate{
+                 rapidsmpf::safe_cast<std::size_t>(row_count), distinct_count})));
+  if (ch_sampled != nullptr) { co_await ch_sampled->drain(ctx_->executor()); }
+  co_await ch_out->drain(ctx_->executor());
+}
+
+}  // namespace cudf_streaming

--- a/cpp/libcudf_streaming/src/detail/approx_distinct_count.cu
+++ b/cpp/libcudf_streaming/src/detail/approx_distinct_count.cu
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf_streaming/detail/approx_distinct_count.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <rapidsmpf/error.hpp>
+
+namespace cudf_streaming::detail {
+namespace {
+
+__global__ void set_value_kernel(std::uint64_t* data, std::uint64_t value)
+{
+  if (threadIdx.x == 0) { data[0] = value; }
+}
+
+__global__ void add_values_kernel(std::uint64_t const* left, std::uint64_t* right)
+{
+  if (threadIdx.x == 0) { right[0] += left[0]; }
+}
+
+}  // namespace
+
+void set_value(std::uint64_t* data, std::uint64_t value, rmm::cuda_stream_view stream)
+{
+  set_value_kernel<<<1, 1, 0, stream.value()>>>(data, value);
+  RAPIDSMPF_CUDA_TRY(cudaPeekAtLastError());
+}
+
+void add_values(std::uint64_t const* left, std::uint64_t* right, rmm::cuda_stream_view stream)
+{
+  add_values_kernel<<<1, 1, 0, stream.value()>>>(left, right);
+  RAPIDSMPF_CUDA_TRY(cudaPeekAtLastError());
+}
+
+}  // namespace cudf_streaming::detail

--- a/cpp/libcudf_streaming/tests/CMakeLists.txt
+++ b/cpp/libcudf_streaming/tests/CMakeLists.txt
@@ -70,7 +70,8 @@ target_compile_options(
 )
 target_sources(
   libcudf_streaming_test_sources
-  PRIVATE streaming/test_bloom_filter.cu
+  PRIVATE streaming/test_approx_distinct_count.cpp
+          streaming/test_bloom_filter.cu
           streaming/test_bloom_filter_config.cpp
           streaming/test_table_chunk.cpp
           streaming/test_read_parquet.cpp

--- a/cpp/libcudf_streaming/tests/streaming/test_approx_distinct_count.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_approx_distinct_count.cpp
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../utils.hpp"
+#include "base_streaming_fixture.hpp"
+
+#include <cudf_test/column_wrapper.hpp>
+
+#include <cudf/table/table.hpp>
+
+#include <cudf_streaming/approx_distinct_count.hpp>
+#include <cudf_streaming/table_chunk.hpp>
+
+#include <gtest/gtest.h>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/streaming/core/actor.hpp>
+#include <rapidsmpf/streaming/core/leaf_actor.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace {
+
+using CardinalityEstimatorTest = BaseStreamingFixture;
+
+TEST_F(CardinalityEstimatorTest, EstimatesGlobalUnionAndCountsRows)
+{
+  constexpr std::size_t distinct_values = 10'000;
+  constexpr std::size_t repetitions     = 2;
+  auto values                           = iota_vector<std::int64_t>(distinct_values);
+  auto const dups                       = values;
+  values.insert(values.end(), dups.begin(), dups.end());
+
+  cudf::test::fixed_width_column_wrapper<std::int64_t> column(values.begin(), values.end());
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(column.release());
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  std::vector<rapidsmpf::streaming::Message> inputs;
+  inputs.push_back(cudf_streaming::to_message(
+    0, std::make_unique<cudf_streaming::table_chunk>(std::move(table), stream)));
+
+  auto ch_in  = ctx->create_channel();
+  auto ch_out = ctx->create_channel();
+  cudf_streaming::cardinality_estimator estimator{
+    ctx, GlobalEnvironment->comm_, rapidsmpf::OpID{0}, 14};
+
+  std::vector<rapidsmpf::streaming::Message> outputs;
+  std::vector<rapidsmpf::streaming::Actor> actors;
+  actors.push_back(rapidsmpf::streaming::actor::push_to_channel(ctx, ch_in, std::move(inputs)));
+  actors.push_back(estimator.estimate(ch_in, ch_out));
+  actors.push_back(rapidsmpf::streaming::actor::pull_from_channel(ctx, ch_out, outputs));
+
+  rapidsmpf::streaming::run_actor_network(std::move(actors));
+
+  ASSERT_EQ(outputs.size(), 1);
+  auto const estimate = outputs.front().release<cudf_streaming::cardinality_estimate>();
+  EXPECT_EQ(estimate.row_count,
+            distinct_values * repetitions *
+              rapidsmpf::safe_cast<std::size_t>(GlobalEnvironment->comm_->nranks()));
+  EXPECT_NEAR(
+    estimate.distinct_count, distinct_values, static_cast<double>(distinct_values) * 0.05);
+}
+
+TEST_F(CardinalityEstimatorTest, EmptyInput)
+{
+  auto ch_in  = ctx->create_channel();
+  auto ch_out = ctx->create_channel();
+  cudf_streaming::cardinality_estimator estimator{
+    ctx, GlobalEnvironment->comm_, rapidsmpf::OpID{0}};
+
+  std::vector<rapidsmpf::streaming::Message> outputs;
+  std::vector<rapidsmpf::streaming::Actor> actors;
+  actors.push_back(rapidsmpf::streaming::actor::push_to_channel(ctx, ch_in, {}));
+  actors.push_back(estimator.estimate(ch_in, ch_out));
+  actors.push_back(rapidsmpf::streaming::actor::pull_from_channel(ctx, ch_out, outputs));
+
+  rapidsmpf::streaming::run_actor_network(std::move(actors));
+
+  ASSERT_EQ(outputs.size(), 1);
+  auto const estimate = outputs.front().release<cudf_streaming::cardinality_estimate>();
+  EXPECT_EQ(estimate.row_count, 0);
+  EXPECT_EQ(estimate.distinct_count, 0);
+}
+
+TEST_F(CardinalityEstimatorTest, SamplesSelectedColumnsAndForwardsInput)
+{
+  cudf::test::fixed_width_column_wrapper<std::int64_t> keys{0, 0, 1, 1};
+  cudf::test::fixed_width_column_wrapper<std::int64_t> values{0, 1, 2, 3};
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(keys.release());
+  columns.push_back(values.release());
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  std::vector<rapidsmpf::streaming::Message> inputs;
+  inputs.push_back(cudf_streaming::to_message(
+    7, std::make_unique<cudf_streaming::table_chunk>(std::move(table), stream)));
+
+  auto ch_in      = ctx->create_channel();
+  auto ch_sampled = ctx->create_channel();
+  auto ch_out     = ctx->create_channel();
+  cudf_streaming::cardinality_estimator estimator{
+    ctx, GlobalEnvironment->comm_, rapidsmpf::OpID{0}, 14};
+
+  std::vector<rapidsmpf::streaming::Message> sampled;
+  std::vector<rapidsmpf::streaming::Message> estimates;
+  std::vector<rapidsmpf::streaming::Actor> actors;
+  actors.push_back(rapidsmpf::streaming::actor::push_to_channel(ctx, ch_in, std::move(inputs)));
+  actors.push_back(estimator.estimate(ch_in, ch_out, ch_sampled, {0}));
+  actors.push_back(rapidsmpf::streaming::actor::pull_from_channel(ctx, ch_sampled, sampled));
+  actors.push_back(rapidsmpf::streaming::actor::pull_from_channel(ctx, ch_out, estimates));
+
+  rapidsmpf::streaming::run_actor_network(std::move(actors));
+
+  ASSERT_EQ(sampled.size(), 1);
+  EXPECT_EQ(sampled.front().sequence_number(), 7);
+  ASSERT_EQ(estimates.size(), 1);
+  auto const estimate = estimates.front().release<cudf_streaming::cardinality_estimate>();
+  EXPECT_EQ(estimate.row_count,
+            4 * rapidsmpf::safe_cast<std::size_t>(GlobalEnvironment->comm_->nranks()));
+  EXPECT_NEAR(estimate.distinct_count, 2, 1);
+}
+
+TEST_F(CardinalityEstimatorTest, RejectsInvalidPrecision)
+{
+  EXPECT_THROW(
+    cudf_streaming::cardinality_estimator(ctx, GlobalEnvironment->comm_, rapidsmpf::OpID{0}, 3),
+    std::invalid_argument);
+  EXPECT_THROW(
+    cudf_streaming::cardinality_estimator(ctx, GlobalEnvironment->comm_, rapidsmpf::OpID{0}, 19),
+    std::invalid_argument);
+}
+
+}  // namespace

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
@@ -659,14 +659,7 @@ async def _aggregate_estimates(
 ) -> tuple[TableSizeStats, TableSizeStats]:
     """Aggregate table-size and row estimates across ranks."""
     # AllGather size, row, and chunk count estimates across ranks
-    (
-        left_total,
-        right_total,
-        left_total_rows,
-        right_total_rows,
-        left_total_chunks,
-        right_total_chunks,
-    ) = await allgather_reduce(
+    totals = await allgather_reduce(
         context,
         comm,
         collective_ids.pop(0),
@@ -676,24 +669,40 @@ async def _aggregate_estimates(
         right_sample.total_rows,
         left_sample.total_chunks,
         right_sample.total_chunks,
+        int(left_sample.is_complete),
+        int(right_sample.is_complete),
     )
+    (
+        left_total,
+        right_total,
+        left_total_rows,
+        right_total_rows,
+        left_total_chunks,
+        right_total_chunks,
+        left_complete_count,
+        right_complete_count,
+    ) = totals
 
     new_left_sample = TableSizeStats(
         chunks=left_sample.chunks,
         total_size=left_total,
         total_rows=left_total_rows,
         total_chunks=left_total_chunks,
+        is_complete=left_complete_count == comm.nranks,
+        cardinality=left_sample.cardinality,
     )
     new_right_sample = TableSizeStats(
         chunks=right_sample.chunks,
         total_size=right_total,
         total_rows=right_total_rows,
         total_chunks=right_total_chunks,
+        is_complete=right_complete_count == comm.nranks,
+        cardinality=right_sample.cardinality,
     )
     return new_left_sample, new_right_sample
 
 
-async def _choose_strategy_from_samples(
+def _choose_strategy_from_samples(
     comm: Communicator,
     ir: Join,
     left_metadata: ChannelMetadata,
@@ -912,7 +921,7 @@ async def _choose_strategy(
             collective_ids,
         )
 
-    strategy = await _choose_strategy_from_samples(
+    strategy = _choose_strategy_from_samples(
         comm,
         ir,
         left_metadata,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
@@ -1040,14 +1040,7 @@ async def _aggregate_estimates(
 ) -> tuple[TableSizeStats, TableSizeStats]:
     """Aggregate table-size and row estimates across ranks."""
     # AllGather size, row, and chunk count estimates across ranks
-    (
-        left_total,
-        right_total,
-        left_total_rows,
-        right_total_rows,
-        left_total_chunks,
-        right_total_chunks,
-    ) = await allgather_reduce(
+    totals = await allgather_reduce(
         context,
         comm,
         collective_ids.pop(0),
@@ -1057,24 +1050,40 @@ async def _aggregate_estimates(
         right_sample.total_rows,
         left_sample.total_chunks,
         right_sample.total_chunks,
+        int(left_sample.is_complete),
+        int(right_sample.is_complete),
     )
+    (
+        left_total,
+        right_total,
+        left_total_rows,
+        right_total_rows,
+        left_total_chunks,
+        right_total_chunks,
+        left_complete_count,
+        right_complete_count,
+    ) = totals
 
     new_left_sample = TableSizeStats(
         chunks=left_sample.chunks,
         total_size=left_total,
         total_rows=left_total_rows,
         total_chunks=left_total_chunks,
+        is_complete=left_complete_count == comm.nranks,
+        cardinality=left_sample.cardinality,
     )
     new_right_sample = TableSizeStats(
         chunks=right_sample.chunks,
         total_size=right_total,
         total_rows=right_total_rows,
         total_chunks=right_total_chunks,
+        is_complete=right_complete_count == comm.nranks,
+        cardinality=right_sample.cardinality,
     )
     return new_left_sample, new_right_sample
 
 
-async def _choose_strategy_from_samples(
+def _choose_strategy_from_samples(
     comm: Communicator,
     ir: Join,
     left_metadata: ChannelMetadata,
@@ -1293,7 +1302,7 @@ async def _choose_strategy(
             collective_ids,
         )
 
-    strategy = await _choose_strategy_from_samples(
+    strategy = _choose_strategy_from_samples(
         comm,
         ir,
         left_metadata,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 import pylibcudf as plc
 import rmm.mr
+from cudf_streaming import CardinalityEstimate
 from cudf_streaming.channel_metadata import (
     ChannelMetadata,
     HashScheme,
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
         Sequence,
     )
 
+    from cudf_streaming import CardinalityEstimator
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.channel import Channel
@@ -171,6 +173,10 @@ class ChunkStore:
     def __init__(self, ctx: Context) -> None:
         self._mids: deque[int] = deque()
         self._store = ctx.spillable_messages()
+
+    def __len__(self) -> int:
+        """Return the number of messages in the store."""
+        return len(self._mids)
 
     def insert(self, msg: Message) -> None:
         """Insert a message into the store."""
@@ -1021,6 +1027,138 @@ class TableSizeStats:
     """The estimated number of rows for the represented scope."""
     total_chunks: int = 0
     """The estimated number of chunks for the represented scope."""
+    is_complete: bool = False
+    """Whether the sample contains the entire table for the represented scope."""
+    cardinality: CardinalityEstimate | None = None
+    """Global cardinality statistics for the sampled rows, when requested."""
+
+
+@dataclass(frozen=True)
+class ChunkSampler:
+    """Object for obtaining statistics from a channel of TableChunks."""
+
+    context: Context
+    ch_in: Channel[TableChunk]
+    max_chunks: int
+    max_bytes: int
+    ch_in_chunk_count: int
+    cardinality_estimator: CardinalityEstimator | None = None
+    cardinality_columns: tuple[int, ...] = ()
+
+    async def sample_channel(
+        self,
+        ch_out: Channel[TableChunk],
+    ) -> tuple[bool, int, int]:
+        """
+        Sample a prefix from the input channel.
+
+        Parameters
+        ----------
+        ch_out
+            Channel to forward samples into.
+
+        Returns
+        -------
+        bool
+            Whether sampling exhausted the input.
+        int
+            Number of bytes in the sampled chunks.
+        int
+            Number of rows in the sampled chunks.
+        """
+        sampled_bytes = 0
+        sampled_rows = 0
+        exhausted = False
+        await ch_out.shutdown_metadata(self.context)
+        for _ in range(self.max_chunks):
+            msg = await self.ch_in.recv(self.context)
+            if msg is None:
+                exhausted = True
+                break
+            chunk = TableChunk.from_message(msg, br=self.context.br())
+            sampled_bytes += chunk.data_alloc_size()
+            sampled_rows += chunk.shape[0]
+            await ch_out.send(self.context, Message(msg.sequence_number, chunk))
+            if sampled_bytes >= self.max_bytes:
+                break
+        await ch_out.drain(self.context)
+        return exhausted, sampled_bytes, sampled_rows
+
+    async def store_sample(
+        self,
+        ch_in: Channel[TableChunk],
+    ) -> ChunkStore:
+        """
+        Store chunks from a channel.
+
+        Parameters
+        ----------
+        ch_in
+            Channel to store
+
+        Returns
+        -------
+        ChunkStore containing the chunks from the channel.
+        """
+        chunks = ChunkStore(self.context)
+        while (msg := await ch_in.recv(self.context)) is not None:
+            chunk = TableChunk.from_message(msg, br=self.context.br())
+            chunks.insert(Message(msg.sequence_number, chunk))
+        return chunks
+
+    async def sample(self) -> TableSizeStats:
+        """Sample the configured channel and return extrapolated statistics."""
+        ch_sampled = self.context.create_channel()
+        temporary_channels = [ch_sampled]
+        tasks: list[Coroutine[Any, Any, Any]]
+        if self.cardinality_estimator is None:
+            tasks = [self.sample_channel(ch_sampled), self.store_sample(ch_sampled)]
+        else:
+            ch_cardinality_input = self.context.create_channel()
+            ch_cardinality = self.context.create_channel()
+            temporary_channels.extend((ch_cardinality_input, ch_cardinality))
+            # The sampled output must be consumed concurrently with estimation:
+            # backpressure there can prevent the cardinality result from being
+            # produced.
+            tasks = [
+                self.sample_channel(ch_cardinality_input),
+                self.cardinality_estimator.estimate(
+                    self.context,
+                    ch_cardinality_input,
+                    ch_cardinality,
+                    ch_sampled,
+                    self.cardinality_columns,
+                ),
+                self.store_sample(ch_sampled),
+                ch_cardinality.recv(self.context),
+            ]
+
+        async with shutdown_channels_on_error(self.context, *temporary_channels):
+            results = await gather_in_task_group(*tasks)
+        if self.cardinality_estimator is None:
+            (is_complete, sample_bytes, sample_rows), chunks = results
+            cardinality = None
+        else:
+            (is_complete, sample_bytes, sample_rows), _, chunks, msg = results
+            if msg is None:
+                raise RuntimeError("Cardinality estimator did not produce an estimate")
+            cardinality = CardinalityEstimate.from_message(msg)
+
+        sample_count = len(chunks)
+        if sample_count and not is_complete:
+            total_size = int((sample_bytes / sample_count) * self.ch_in_chunk_count)
+            total_rows = int((sample_rows / sample_count) * self.ch_in_chunk_count)
+        else:
+            total_size = sample_bytes
+            total_rows = sample_rows
+        return TableSizeStats(
+            chunks=chunks,
+            total_size=total_size,
+            total_rows=total_rows,
+            total_chunks=(sample_count if is_complete else self.ch_in_chunk_count),
+            is_complete=is_complete,
+            cardinality=cardinality,
+        )
 
 
 async def _sample_chunks(
@@ -1029,6 +1167,9 @@ async def _sample_chunks(
     max_sample_chunks: int,
     max_sample_bytes: int,
     local_count: int,
+    *,
+    cardinality_estimator: CardinalityEstimator | None = None,
+    cardinality_columns: Sequence[int] = (),
 ) -> TableSizeStats:
     """
     Sample chunks from a channel and extrapolate to a per-rank size estimate.
@@ -1045,35 +1186,26 @@ async def _sample_chunks(
         The maximum number of bytes to sample.
     local_count
         The expected number of local chunks (used for extrapolation).
+    cardinality_estimator
+        Optional distributed cardinality estimator. When provided, cardinality
+        is estimated from the same fixed chunk prefix used for size sampling.
+    cardinality_columns
+        Column indices whose row tuples are counted. An empty sequence selects
+        all columns.
 
     Returns
     -------
-    Sampled chunks and the extrapolated total size/rows for this rank.
+    Sampled chunks, extrapolated size/rows, and optional global cardinality.
     """
-    sampled_chunks = ChunkStore(context)
-    sampled_count = 0
-    total_size = 0
-    total_rows = 0
-    for _ in range(max_sample_chunks):
-        msg = await ch.recv(context)
-        if msg is None:
-            break
-        chunk = TableChunk.from_message(msg, br=context.br())
-        total_size += chunk.data_alloc_size()
-        total_rows += chunk.shape[0]
-        sampled_count += 1
-        sampled_chunks.insert(Message(msg.sequence_number, chunk))
-        if total_size >= max_sample_bytes:
-            break
-    if sampled_count:
-        total_size = int((total_size / sampled_count) * local_count)
-        total_rows = int((total_rows / sampled_count) * local_count)
-    return TableSizeStats(
-        chunks=sampled_chunks,
-        total_size=total_size,
-        total_rows=total_rows,
-        total_chunks=local_count,
-    )
+    return await ChunkSampler(
+        context=context,
+        ch_in=ch,
+        max_chunks=max_sample_chunks,
+        max_bytes=max_sample_bytes,
+        ch_in_chunk_count=local_count,
+        cardinality_estimator=cardinality_estimator,
+        cardinality_columns=tuple(cardinality_columns),
+    ).sample()
 
 
 async def replay_buffered_channel(

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 import pylibcudf as plc
 import rmm.mr
+from cudf_streaming import CardinalityEstimate
 from cudf_streaming.channel_metadata import (
     ChannelMetadata,
     HashScheme,
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
         Sequence,
     )
 
+    from cudf_streaming import CardinalityEstimator
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.channel import Channel
@@ -171,6 +173,10 @@ class ChunkStore:
     def __init__(self, ctx: Context) -> None:
         self._mids: deque[int] = deque()
         self._store = ctx.spillable_messages()
+
+    def __len__(self) -> int:
+        """Return the number of messages in the store."""
+        return len(self._mids)
 
     def insert(self, msg: Message) -> None:
         """Insert a message into the store."""
@@ -1022,6 +1028,138 @@ class TableSizeStats:
     """The estimated number of rows for the represented scope."""
     total_chunks: int = 0
     """The estimated number of chunks for the represented scope."""
+    is_complete: bool = False
+    """Whether the sample contains the entire table for the represented scope."""
+    cardinality: CardinalityEstimate | None = None
+    """Global cardinality statistics for the sampled rows, when requested."""
+
+
+@dataclass(frozen=True)
+class ChunkSampler:
+    """Object for obtaining statistics from a channel of TableChunks."""
+
+    context: Context
+    ch_in: Channel[TableChunk]
+    max_chunks: int
+    max_bytes: int
+    ch_in_chunk_count: int
+    cardinality_estimator: CardinalityEstimator | None = None
+    cardinality_columns: tuple[int, ...] = ()
+
+    async def sample_channel(
+        self,
+        ch_out: Channel[TableChunk],
+    ) -> tuple[bool, int, int]:
+        """
+        Sample a prefix from the input channel.
+
+        Parameters
+        ----------
+        ch_out
+            Channel to forward samples into.
+
+        Returns
+        -------
+        bool
+            Whether sampling exhausted the input.
+        int
+            Number of bytes in the sampled chunks.
+        int
+            Number of rows in the sampled chunks.
+        """
+        sampled_bytes = 0
+        sampled_rows = 0
+        exhausted = False
+        await ch_out.shutdown_metadata(self.context)
+        for _ in range(self.max_chunks):
+            msg = await self.ch_in.recv(self.context)
+            if msg is None:
+                exhausted = True
+                break
+            chunk = TableChunk.from_message(msg, br=self.context.br())
+            sampled_bytes += chunk.data_alloc_size()
+            sampled_rows += chunk.shape[0]
+            await ch_out.send(self.context, Message(msg.sequence_number, chunk))
+            if sampled_bytes >= self.max_bytes:
+                break
+        await ch_out.drain(self.context)
+        return exhausted, sampled_bytes, sampled_rows
+
+    async def store_sample(
+        self,
+        ch_in: Channel[TableChunk],
+    ) -> ChunkStore:
+        """
+        Store chunks from a channel.
+
+        Parameters
+        ----------
+        ch_in
+            Channel to store
+
+        Returns
+        -------
+        ChunkStore containing the chunks from the channel.
+        """
+        chunks = ChunkStore(self.context)
+        while (msg := await ch_in.recv(self.context)) is not None:
+            chunk = TableChunk.from_message(msg, br=self.context.br())
+            chunks.insert(Message(msg.sequence_number, chunk))
+        return chunks
+
+    async def sample(self) -> TableSizeStats:
+        """Sample the configured channel and return extrapolated statistics."""
+        ch_sampled = self.context.create_channel()
+        temporary_channels = [ch_sampled]
+        tasks: list[Coroutine[Any, Any, Any]]
+        if self.cardinality_estimator is None:
+            tasks = [self.sample_channel(ch_sampled), self.store_sample(ch_sampled)]
+        else:
+            ch_cardinality_input = self.context.create_channel()
+            ch_cardinality = self.context.create_channel()
+            temporary_channels.extend((ch_cardinality_input, ch_cardinality))
+            # The sampled output must be consumed concurrently with estimation:
+            # backpressure there can prevent the cardinality result from being
+            # produced.
+            tasks = [
+                self.sample_channel(ch_cardinality_input),
+                self.cardinality_estimator.estimate(
+                    self.context,
+                    ch_cardinality_input,
+                    ch_cardinality,
+                    ch_sampled,
+                    self.cardinality_columns,
+                ),
+                self.store_sample(ch_sampled),
+                ch_cardinality.recv(self.context),
+            ]
+
+        async with shutdown_channels_on_error(self.context, *temporary_channels):
+            results = await gather_in_task_group(*tasks)
+        if self.cardinality_estimator is None:
+            (is_complete, sample_bytes, sample_rows), chunks = results
+            cardinality = None
+        else:
+            (is_complete, sample_bytes, sample_rows), _, chunks, msg = results
+            if msg is None:
+                raise RuntimeError("Cardinality estimator did not produce an estimate")
+            cardinality = CardinalityEstimate.from_message(msg)
+
+        sample_count = len(chunks)
+        if sample_count and not is_complete:
+            total_size = int((sample_bytes / sample_count) * self.ch_in_chunk_count)
+            total_rows = int((sample_rows / sample_count) * self.ch_in_chunk_count)
+        else:
+            total_size = sample_bytes
+            total_rows = sample_rows
+        return TableSizeStats(
+            chunks=chunks,
+            total_size=total_size,
+            total_rows=total_rows,
+            total_chunks=(sample_count if is_complete else self.ch_in_chunk_count),
+            is_complete=is_complete,
+            cardinality=cardinality,
+        )
 
 
 async def _sample_chunks(
@@ -1030,6 +1168,9 @@ async def _sample_chunks(
     max_sample_chunks: int,
     max_sample_bytes: int,
     local_count: int,
+    *,
+    cardinality_estimator: CardinalityEstimator | None = None,
+    cardinality_columns: Sequence[int] = (),
 ) -> TableSizeStats:
     """
     Sample chunks from a channel and extrapolate to a per-rank size estimate.
@@ -1046,35 +1187,26 @@ async def _sample_chunks(
         The maximum number of bytes to sample.
     local_count
         The expected number of local chunks (used for extrapolation).
+    cardinality_estimator
+        Optional distributed cardinality estimator. When provided, cardinality
+        is estimated from the same fixed chunk prefix used for size sampling.
+    cardinality_columns
+        Column indices whose row tuples are counted. An empty sequence selects
+        all columns.
 
     Returns
     -------
-    Sampled chunks and the extrapolated total size/rows for this rank.
+    Sampled chunks, extrapolated size/rows, and optional global cardinality.
     """
-    sampled_chunks = ChunkStore(context)
-    sampled_count = 0
-    total_size = 0
-    total_rows = 0
-    for _ in range(max_sample_chunks):
-        msg = await ch.recv(context)
-        if msg is None:
-            break
-        chunk = TableChunk.from_message(msg, br=context.br())
-        total_size += chunk.data_alloc_size()
-        total_rows += chunk.shape[0]
-        sampled_count += 1
-        sampled_chunks.insert(Message(msg.sequence_number, chunk))
-        if total_size >= max_sample_bytes:
-            break
-    if sampled_count:
-        total_size = int((total_size / sampled_count) * local_count)
-        total_rows = int((total_rows / sampled_count) * local_count)
-    return TableSizeStats(
-        chunks=sampled_chunks,
-        total_size=total_size,
-        total_rows=total_rows,
-        total_chunks=local_count,
-    )
+    return await ChunkSampler(
+        context=context,
+        ch_in=ch,
+        max_chunks=max_sample_chunks,
+        max_bytes=max_sample_bytes,
+        ch_in_chunk_count=local_count,
+        cardinality_estimator=cardinality_estimator,
+        cardinality_columns=tuple(cardinality_columns),
+    ).sample()
 
 
 async def replay_buffered_channel(

--- a/python/cudf_streaming/CMakeLists.txt
+++ b/python/cudf_streaming/CMakeLists.txt
@@ -37,8 +37,13 @@ include(rapids-cython-core)
 rapids_cython_init()
 
 set(cython_sources
-    cudf_streaming/bloom_filter.pyx cudf_streaming/channel_metadata.pyx cudf_streaming/parquet.pyx
-    cudf_streaming/partition.pyx cudf_streaming/partition_utils.pyx cudf_streaming/table_chunk.pyx
+    cudf_streaming/approx_distinct_count.pyx
+    cudf_streaming/bloom_filter.pyx
+    cudf_streaming/channel_metadata.pyx
+    cudf_streaming/parquet.pyx
+    cudf_streaming/partition.pyx
+    cudf_streaming/partition_utils.pyx
+    cudf_streaming/table_chunk.pyx
 )
 set(linked_libraries cudf_streaming::cudf_streaming)
 

--- a/python/cudf_streaming/cudf_streaming/__init__.pxd
+++ b/python/cudf_streaming/cudf_streaming/__init__.pxd
@@ -1,6 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from cudf_streaming.approx_distinct_count cimport (
+    CardinalityEstimate,
+    CardinalityEstimator,
+    cpp_CardinalityEstimate,
+    cpp_CardinalityEstimator,
+)
 from cudf_streaming.bloom_filter cimport BloomFilter, cpp_BloomFilter
 from cudf_streaming.channel_metadata cimport (
     ChannelMetadata,

--- a/python/cudf_streaming/cudf_streaming/__init__.py
+++ b/python/cudf_streaming/cudf_streaming/__init__.py
@@ -12,6 +12,10 @@ else:
     libcudf_streaming.load_library()
     del libcudf_streaming
 
+from cudf_streaming.approx_distinct_count import (
+    CardinalityEstimate,
+    CardinalityEstimator,
+)
 from cudf_streaming.bloom_filter import BloomFilter
 from cudf_streaming.channel_metadata import (
     ChannelMetadata,
@@ -39,6 +43,8 @@ from cudf_streaming.table_chunk import (
 
 __all__ = [
     "BloomFilter",
+    "CardinalityEstimate",
+    "CardinalityEstimator",
     "ChannelMetadata",
     "Filter",
     "HashScheme",

--- a/python/cudf_streaming/cudf_streaming/approx_distinct_count.pxd
+++ b/python/cudf_streaming/cudf_streaming/approx_distinct_count.pxd
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from libc.stddef cimport size_t
+from libc.stdint cimport int32_t
+from libcpp.memory cimport shared_ptr, unique_ptr
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.communicator.communicator cimport Communicator, cpp_Communicator
+from rapidsmpf.streaming.core.context cimport cpp_Context
+
+
+cdef extern from "<cudf_streaming/approx_distinct_count.hpp>" \
+        namespace "cudf_streaming" nogil:
+    cdef cppclass cpp_CardinalityEstimate \
+            "cudf_streaming::cardinality_estimate":
+        size_t row_count
+        size_t distinct_count
+
+    cdef cppclass cpp_CardinalityEstimator \
+            "cudf_streaming::cardinality_estimator":
+        cpp_CardinalityEstimator(
+            shared_ptr[cpp_Context] ctx,
+            shared_ptr[cpp_Communicator] comm,
+            int32_t tag,
+            int32_t precision,
+        ) except +ex_handler
+        const shared_ptr[cpp_Communicator]& comm() noexcept
+        int32_t tag() noexcept
+        int32_t precision() noexcept
+
+
+cdef class CardinalityEstimate:
+    cdef unique_ptr[cpp_CardinalityEstimate] _handle
+
+    @staticmethod
+    cdef CardinalityEstimate from_handle(
+        unique_ptr[cpp_CardinalityEstimate] handle
+    )
+
+
+cdef class CardinalityEstimator:
+    cdef unique_ptr[cpp_CardinalityEstimator] _handle
+    cdef Communicator _comm

--- a/python/cudf_streaming/cudf_streaming/approx_distinct_count.pyi
+++ b/python/cudf_streaming/cudf_streaming/approx_distinct_count.pyi
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Self
+
+from cudf_streaming.table_chunk import TableChunk
+from rapidsmpf.communicator.communicator import Communicator
+from rapidsmpf.streaming.core.channel import Channel
+from rapidsmpf.streaming.core.context import Context
+from rapidsmpf.streaming.core.message import Message
+
+class CardinalityEstimate:
+    @classmethod
+    def from_message(
+        cls: type[Self], message: Message[Self]
+    ) -> CardinalityEstimate: ...
+    @property
+    def row_count(self) -> int: ...
+    @property
+    def distinct_count(self) -> int: ...
+
+class CardinalityEstimator:
+    def __init__(
+        self,
+        ctx: Context,
+        comm: Communicator,
+        tag: int,
+        precision: int = 14,
+    ) -> None: ...
+    @property
+    def comm(self) -> Communicator: ...
+    @property
+    def tag(self) -> int: ...
+    @property
+    def precision(self) -> int: ...
+    async def estimate(
+        self,
+        ctx: Context,
+        ch_in: Channel[TableChunk],
+        ch_out: Channel[CardinalityEstimate],
+        ch_sampled: Channel[TableChunk] | None = None,
+        column_indices: tuple[int, ...] = (),
+    ) -> None: ...

--- a/python/cudf_streaming/cudf_streaming/approx_distinct_count.pyx
+++ b/python/cudf_streaming/cudf_streaming/approx_distinct_count.pyx
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_INCREF
+from cython.operator cimport dereference as deref
+from libc.stdint cimport int32_t
+from libcpp.memory cimport make_unique, shared_ptr, unique_ptr
+from libcpp.utility cimport move
+from libcpp.vector cimport vector
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.communicator.communicator cimport Communicator
+from rapidsmpf.owning_wrapper cimport cpp_OwningWrapper
+from rapidsmpf.streaming._detail.libcoro_spawn_task cimport cpp_set_py_future
+from rapidsmpf.streaming.chunks.utils cimport py_deleter
+from rapidsmpf.streaming.core.channel cimport Channel, cpp_Channel
+from rapidsmpf.streaming.core.context cimport Context, cpp_Context
+from rapidsmpf.streaming.core.message cimport Message, cpp_Message
+from rapidsmpf.streaming.core.cancellation import (
+    await_cpp_future,
+    shutdown_channels,
+)
+
+import asyncio
+
+
+cdef extern from * nogil:
+    """
+    namespace {
+    std::unique_ptr<cudf_streaming::cardinality_estimate>
+    cpp_cardinality_estimate_from_message(
+        rapidsmpf::streaming::Message msg
+    ) {
+        return std::make_unique<cudf_streaming::cardinality_estimate>(
+            msg.release<cudf_streaming::cardinality_estimate>()
+        );
+    }
+
+    void cpp_estimate_cardinality(
+        std::shared_ptr<rapidsmpf::streaming::Context> ctx,
+        cudf_streaming::cardinality_estimator& estimator,
+        std::shared_ptr<rapidsmpf::streaming::Channel> ch_in,
+        std::shared_ptr<rapidsmpf::streaming::Channel> ch_out,
+        std::shared_ptr<rapidsmpf::streaming::Channel> ch_sampled,
+        std::vector<cudf::size_type> column_indices,
+        void (*cpp_set_py_future)(void*, const char *),
+        rapidsmpf::OwningWrapper py_future
+    ) {
+        RAPIDSMPF_EXPECTS(
+            ctx->executor()->spawn_detached(
+                cython_libcoro_task_wrapper(
+                    cpp_set_py_future,
+                    std::move(py_future),
+                    estimator.estimate(
+                        std::move(ch_in),
+                        std::move(ch_out),
+                        std::move(ch_sampled),
+                        std::move(column_indices)
+                    )
+                )
+            ),
+            "libcoro's spawn_detached() failed to spawn task"
+        );
+    }
+
+    }  // namespace
+    """
+    unique_ptr[cpp_CardinalityEstimate] cpp_cardinality_estimate_from_message(
+        cpp_Message
+    ) except +ex_handler
+    void cpp_estimate_cardinality(
+        shared_ptr[cpp_Context] ctx,
+        cpp_CardinalityEstimator& estimator,
+        shared_ptr[cpp_Channel] ch_in,
+        shared_ptr[cpp_Channel] ch_out,
+        shared_ptr[cpp_Channel] ch_sampled,
+        vector[int32_t] column_indices,
+        void (*cpp_set_py_future)(void*, const char *),
+        cpp_OwningWrapper py_future,
+    ) except +ex_handler
+
+
+cdef class CardinalityEstimate:
+    """Global row-count and approximate distinct-row statistics."""
+
+    def __init__(self):
+        raise ValueError("use `CardinalityEstimate.from_message`")
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
+    @staticmethod
+    cdef CardinalityEstimate from_handle(
+        unique_ptr[cpp_CardinalityEstimate] handle,
+    ):
+        cdef CardinalityEstimate ret = CardinalityEstimate.__new__(
+            CardinalityEstimate
+        )
+        ret._handle = move(handle)
+        return ret
+
+    @staticmethod
+    def from_message(Message message not None):
+        """Construct by consuming a message."""
+        return CardinalityEstimate.from_handle(
+            cpp_cardinality_estimate_from_message(move(message._handle))
+        )
+
+    @property
+    def row_count(self):
+        """Exact global count of rows incorporated into the estimate."""
+        return self._handle.get().row_count
+
+    @property
+    def distinct_count(self):
+        """Approximate global distinct-row count."""
+        return self._handle.get().distinct_count
+
+cdef class CardinalityEstimator:
+    """Distributed approximate distinct-row estimator."""
+
+    def __init__(
+        self,
+        Context ctx not None,
+        Communicator comm not None,
+        int32_t tag,
+        int32_t precision=14,
+    ):
+        self._comm = comm
+        with nogil:
+            self._handle = make_unique[cpp_CardinalityEstimator](
+                ctx._handle,
+                comm._handle,
+                tag,
+                precision,
+            )
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
+    @property
+    def comm(self):
+        """Communicator used by the estimator."""
+        return self._comm
+
+    @property
+    def tag(self):
+        """Collective operation identifier."""
+        return self._handle.get().tag()
+
+    @property
+    def precision(self):
+        """HyperLogLog precision."""
+        return self._handle.get().precision()
+
+    async def estimate(
+        self,
+        Context ctx not None,
+        Channel ch_in not None,
+        Channel ch_out not None,
+        Channel ch_sampled=None,
+        column_indices=(),
+    ):
+        """
+        Estimate the global row count and distinct-row count.
+
+        Parameters
+        ----------
+        ctx
+            The streaming context.
+        ch_in
+            Channel providing TableChunks to add to the estimator.
+        ch_out
+            Output receiving a single CardinalityEstimate.
+        ch_sampled
+            If not None, input chunks are forwarded here. Must be consumed
+            concurrently with ch_out if provided.
+        column_indices
+            Optional column indices of the input tables to use in the
+            estimate. If not provided defaults to the entire table.
+        """
+        cdef shared_ptr[cpp_Channel] cpp_ch_sampled
+        cdef vector[int32_t] cpp_column_indices = column_indices
+        if ch_sampled is not None:
+            cpp_ch_sampled = (<Channel>ch_sampled)._handle
+        ret = asyncio.get_running_loop().create_future()
+        Py_INCREF(ret)
+        with nogil:
+            cpp_estimate_cardinality(
+                ctx._handle,
+                deref(self._handle),
+                ch_in._handle,
+                ch_out._handle,
+                cpp_ch_sampled,
+                move(cpp_column_indices),
+                cpp_set_py_future,
+                move(cpp_OwningWrapper(<void*><PyObject*>ret, py_deleter)),
+            )
+        await await_cpp_future(
+            ret,
+            on_cancel=lambda: shutdown_channels(
+                ctx,
+                ch_in,
+                ch_out,
+                *(() if ch_sampled is None else (ch_sampled,)),
+            ),
+        )

--- a/python/cudf_streaming/cudf_streaming/tests/test_approx_distinct_count.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_approx_distinct_count.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pylibcudf as plc
+import pytest
+
+from cudf_streaming import CardinalityEstimate, CardinalityEstimator
+from cudf_streaming.table_chunk import TableChunk
+from rapidsmpf.streaming.core.actor import run_actor_network
+from rapidsmpf.streaming.core.leaf_actor import (
+    pull_from_channel,
+    push_to_channel,
+)
+from rapidsmpf.streaming.core.message import Message
+
+if TYPE_CHECKING:
+    from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.streaming.core.context import Context
+
+
+def make_table(values: np.ndarray, context: Context) -> TableChunk:
+    stream = context.br().stream_pool.get_stream()
+    table = plc.Table([plc.Column.from_array(values, stream=stream)])
+    return TableChunk.from_pylibcudf_table(
+        table, stream, exclusive_view=True, br=context.br()
+    )
+
+
+def estimate(
+    context: Context,
+    comm: Communicator,
+    chunks: list[TableChunk],
+    *,
+    precision: int = 14,
+) -> CardinalityEstimate:
+    estimator = CardinalityEstimator(context, comm, tag=0, precision=precision)
+    ch_in = context.create_channel()
+    ch_out = context.create_channel()
+    inputs = [Message(i, chunk) for i, chunk in enumerate(chunks)]
+    pull_actor, deferred = pull_from_channel(context, ch_out)
+    run_actor_network(
+        context,
+        actors=[
+            push_to_channel(context, ch_in, inputs),
+            estimator.estimate(context, ch_in, ch_out),
+            pull_actor,
+        ],
+    )
+    outputs = deferred.release()
+    assert len(outputs) == 1
+    return CardinalityEstimate.from_message(outputs[0])
+
+
+def sample(
+    context: Context,
+    comm: Communicator,
+    chunks: list[TableChunk],
+    *,
+    max_chunks: int,
+    column_indices: tuple[int, ...] = (),
+) -> tuple[list[Message], CardinalityEstimate]:
+    estimator = CardinalityEstimator(context, comm, tag=0)
+    ch_in = context.create_channel()
+    ch_sampled = context.create_channel()
+    ch_out = context.create_channel()
+    inputs = [Message(i, chunk) for i, chunk in enumerate(chunks[:max_chunks])]
+
+    sampled_actor, sampled_deferred = pull_from_channel(context, ch_sampled)
+    estimate_actor, estimate_deferred = pull_from_channel(context, ch_out)
+    run_actor_network(
+        context,
+        actors=[
+            push_to_channel(context, ch_in, inputs),
+            estimator.estimate(
+                context,
+                ch_in,
+                ch_out,
+                ch_sampled,
+                column_indices,
+            ),
+            sampled_actor,
+            estimate_actor,
+        ],
+    )
+    estimates = estimate_deferred.release()
+    assert len(estimates) == 1
+    return (
+        sampled_deferred.release(),
+        CardinalityEstimate.from_message(estimates[0]),
+    )
+
+
+def test_estimate_global_cardinality(
+    context: Context, comm: Communicator
+) -> None:
+    distinct_count = 10_000
+    values = np.tile(np.arange(distinct_count, dtype=np.int64), 2)
+    result = estimate(
+        context,
+        comm,
+        [make_table(part, context) for part in np.array_split(values, 3)],
+    )
+
+    assert result.row_count == values.size * comm.nranks
+    assert result.distinct_count == pytest.approx(distinct_count, rel=0.05)
+
+
+def test_estimate_empty_input(context: Context, comm: Communicator) -> None:
+    result = estimate(context, comm, [])
+
+    assert result.row_count == 0
+    assert result.distinct_count == 0
+
+
+def test_estimate_forwards_input(context: Context, comm: Communicator) -> None:
+    values = np.arange(100, dtype=np.int64)
+    sampled, result = sample(
+        context,
+        comm,
+        [make_table(values, context)],
+        max_chunks=2,
+    )
+
+    assert len(sampled) == 1
+    assert result.row_count == values.size * comm.nranks
+    assert result.distinct_count == pytest.approx(values.size, rel=0.05)
+
+
+def test_precision(context: Context, comm: Communicator) -> None:
+    assert CardinalityEstimator(context, comm, tag=7).tag == 7
+    assert CardinalityEstimator(context, comm, tag=7).precision == 14
+    assert (
+        CardinalityEstimator(context, comm, tag=7, precision=12).precision
+        == 12
+    )
+
+
+@pytest.mark.parametrize("precision", [3, 19])
+def test_invalid_precision(
+    context: Context, comm: Communicator, precision: int
+) -> None:
+    with pytest.raises(
+        ValueError, match=r"precision must be in range \[4, 18\]"
+    ):
+        CardinalityEstimator(context, comm, tag=0, precision=precision)


### PR DESCRIPTION
## Description

We will use this to estimate cardinalities of tables in join prefiltering. Hence to that end also introduce ChunkSampler in cudf-polars streaming to manage the various input/output channels.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
