### PR TITLE
X-ORG-23411: Enable docs version picker

### DIFF
--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -232,6 +232,10 @@ html_theme_options = {
     "navbar_align": "content",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/cudf/versions.json",
+        "version_match": version,
+    },
 }
 include_pandas_compat = True
 


### PR DESCRIPTION
Contributes to #23411 

Let's enable the docs version picker.

N.B. I will backport this to 26.08 after the release to ensure it goes live for those docs.