### PR TITLE
Use `uint64_t` to track column chunk data size in PQ writer

### DIFF
--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -589,8 +589,8 @@ struct EncColumnChunk {
   size_type num_dict_entries;  //!< Total number of entries in dictionary
   size_type
     uniq_data_size;  //!< Size of dictionary page (set of all unique values) if dict enc is used
-  size_type plain_data_size;  //!< Size of data in this chunk if plain encoding is used
-  size_type* dict_data;       //!< Dictionary data (unique row indices)
+  size_t plain_data_size;  //!< Size of data in this chunk if plain encoding is used
+  size_type* dict_data;    //!< Dictionary data (unique row indices)
   size_type* dict_index;  //!< Index of value in dictionary page. column[dict_data[dict_index[row]]]
   uint8_t dict_rle_bits;  //!< Bit size for encoding dictionary indices
   bool use_dictionary;    //!< True if the chunk uses dictionary encoding

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1369,7 +1369,8 @@ build_chunk_dictionaries(hostdevice_2dvector<EncColumnChunk>& chunks,
       // bitpacking bitsize we efficiently support
       if (nbits > MAX_DICT_BITS) { return {false, 0}; }
 
-      auto rle_byte_size = util::div_rounding_up_safe(ck.num_values * nbits, 8);
+      auto rle_byte_size =
+        util::div_rounding_up_safe<size_t>(static_cast<size_t>(ck.num_values) * nbits, 8);
       auto dict_enc_size = ck.uniq_data_size + rle_byte_size;
       if (ck.plain_data_size <= dict_enc_size) { return {false, 0}; }
 
@@ -1912,9 +1913,10 @@ auto convert_table_to_parquet_data(table_input_metadata& table_meta,
             return l + r.num_values;
           });
         ck.plain_data_size = std::accumulate(
-          chunk_fragments.begin(), chunk_fragments.end(), 0, [](int sum, PageFragment frag) {
-            return sum + frag.fragment_data_size;
-          });
+          chunk_fragments.begin(),
+          chunk_fragments.end(),
+          size_t{0},
+          [](auto sum, PageFragment frag) { return sum + frag.fragment_data_size; });
         auto& column_chunk_meta          = row_group.columns[c].meta_data;
         column_chunk_meta.type           = parquet_columns[c].physical_type();
         column_chunk_meta.path_in_schema = parquet_columns[c].get_path_in_schema();

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1917,7 +1917,7 @@ auto convert_table_to_parquet_data(table_input_metadata& table_meta,
           chunk_fragments.begin(),
           chunk_fragments.end(),
           size_t{0},
-          [](auto sum, PageFragment frag) {
+          [](auto sum, PageFragment const& frag) {
             auto const [result, overflow] =
               cuda::add_overflow<size_t>(sum, frag.fragment_data_size);
             CUDF_EXPECTS(not overflow, "Page fragments data size overflow", std::overflow_error);

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -41,6 +41,7 @@
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuda/iterator>
+#include <cuda/numeric>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 
@@ -1916,7 +1917,12 @@ auto convert_table_to_parquet_data(table_input_metadata& table_meta,
           chunk_fragments.begin(),
           chunk_fragments.end(),
           size_t{0},
-          [](auto sum, PageFragment frag) { return sum + frag.fragment_data_size; });
+          [](auto sum, PageFragment frag) {
+            auto const [result, overflow] =
+              cuda::add_overflow<size_t>(sum, frag.fragment_data_size);
+            CUDF_EXPECTS(not overflow, "Page fragments data size overflow", std::overflow_error);
+            return result;
+          });
         auto& column_chunk_meta          = row_group.columns[c].meta_data;
         column_chunk_meta.type           = parquet_columns[c].physical_type();
         column_chunk_meta.path_in_schema = parquet_columns[c].get_path_in_schema();

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -673,9 +673,11 @@ def test_write_large_list_row_group():
     )
     metadata = plc.io.types.TableInputMetadata(table)
     sink = plc.io.SinkInfo([io.BytesIO()])
-    options = plc.io.parquet.ParquetWriterOptions.builder(sink, table).metadata(
-        metadata
-    ).build()
+    options = (
+        plc.io.parquet.ParquetWriterOptions.builder(sink, table)
+        .metadata(metadata)
+        .build()
+    )
 
     result = plc.io.parquet.write_parquet(options)
     parquet_file = pq.ParquetFile(io.BytesIO(result))

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -659,12 +659,15 @@ def test_write_parquet(
     assert isinstance(result, memoryview)
 
 
+# cupy allocates on its own stream, so this cannot honor the injected default
+# stream used by the stream-validation test pass.
+@pytest.mark.uses_custom_stream
 def test_write_large_list_row_group():
     import cupy as cp
 
-    # 800k rows of list<float32>[1024] exceed the signed 32-bit range. The
-    # writer must retain the correct plain-data size for dictionary selection.
-    rows = 800_000
+    # 524.3k list<float32>[1024] rows exceed 2 GiB plain data. The writer must retain the correct
+    # plain-data size for dictionary selection.
+    rows = 524_300
     embedding_dim = 1024
     values = cp.zeros((rows, embedding_dim), dtype=cp.float32)
     table = plc.Table(

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -659,6 +659,31 @@ def test_write_parquet(
     assert isinstance(result, memoryview)
 
 
+def test_write_large_list_row_group():
+    import cupy as cp
+
+    # 800k rows of list<float32>[1024] exceed the signed 32-bit range. The
+    # writer must retain the correct plain-data size for dictionary selection.
+    rows = 800_000
+    embedding_dim = 1024
+    values = cp.zeros((rows, embedding_dim), dtype=cp.float32)
+    table = plc.Table(
+        [plc.Column.from_cuda_array_interface(values)],
+        num_rows=rows,
+    )
+    metadata = plc.io.types.TableInputMetadata(table)
+    sink = plc.io.SinkInfo([io.BytesIO()])
+    options = plc.io.parquet.ParquetWriterOptions.builder(sink, table).metadata(
+        metadata
+    ).build()
+
+    result = plc.io.parquet.write_parquet(options)
+    parquet_file = pq.ParquetFile(io.BytesIO(result))
+
+    assert parquet_file.metadata.num_rows == rows
+    assert parquet_file.metadata.num_row_groups == 1
+
+
 @pytest.mark.parametrize("use_jit_filter", [False, True])
 @pytest.mark.parametrize(
     "pa_filter,plc_filter",


### PR DESCRIPTION
## Description

Closes #23504

This PR fixes Parquet writer's column chunk struct to use a `size_t` (instead of `uint32_t`) field to track the amount of plain leaf data it contains.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
