### PR TITLE
Correctly synchronise device_buffer construction from host data

### DIFF
--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -121,6 +121,7 @@ auto make_index_column(cudf::size_type num_rows, rmm::cuda_stream_view stream)
   std::vector<cudf::size_type> data(num_rows);
   std::iota(data.begin(), data.end(), 0);
   auto buffer = rmm::device_buffer(data.data(), num_rows * sizeof(int64_t), stream);
+  stream.synchronize();
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<cudf::size_type>()},
                                         num_rows,
                                         std::move(buffer),
@@ -141,6 +142,7 @@ template <typename T>
 auto make_column(cudf::host_span<T const> host_data, rmm::cuda_stream_view stream)
 {
   auto device_buffer = rmm::device_buffer(host_data.data(), host_data.size() * sizeof(T), stream);
+  stream.synchronize();
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<T>()},
                                         host_data.size(),
                                         std::move(device_buffer),
@@ -174,6 +176,7 @@ auto make_page_data_list_column(cudf::host_span<T const> data,
 
   auto page_data_buffer =
     rmm::device_buffer(data.data(), num_pages_this_column * sizeof(int64_t), stream);
+  stream.synchronize();
 
   auto page_data_column =
     std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<int64_t>()},
@@ -285,6 +288,7 @@ void write_rowgroup_metadata(cudf::io::parquet::FileMetaData const& metadata,
   auto byte_offsets_buffer =
     rmm::device_buffer(row_group_byte_offsets.data(), num_row_groups * sizeof(int64_t), stream);
 
+  stream.synchronize();
   columns.emplace_back(std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<int64_t>()},
                                                       num_row_groups,
                                                       std::move(row_offsets_buffer),

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -160,8 +160,10 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<ElementTo>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{
-    elements.data(), size * sizeof(ElementTo), cudf::test::get_default_stream()};
+  auto ret =
+    rmm::device_buffer{elements.data(), size * sizeof(ElementTo), cudf::test::get_default_stream()};
+  ret.stream().synchronize();
+  return ret;
 }
 
 // The two signatures below are identical to the above overload apart from
@@ -190,8 +192,10 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<RepType>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{
-    elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
+  auto ret =
+    rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
+  ret.stream().synchronize();
+  return ret;
 }
 
 /**
@@ -221,8 +225,10 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transformer_begin = thrust::make_transform_iterator(begin, to_rep);
   auto const size        = cudf::distance(begin, end);
   auto const elements = thrust::host_vector<RepType>(transformer_begin, transformer_begin + size);
-  return rmm::device_buffer{
-    elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
+  auto ret =
+    rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
+  ret.stream().synchronize();
+  return ret;
 }
 //! @endcond
 
@@ -280,6 +286,7 @@ std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(ValidityIterator b
   auto d_mask                  = rmm::device_buffer{null_mask.data(),
                                    cudf::bitmask_allocation_size_bytes(cudf::distance(begin, end)),
                                    cudf::test::get_default_stream()};
+  d_mask.stream().synchronize();
   return {std::move(d_mask), null_count};
 }
 
@@ -635,6 +642,7 @@ class fixed_point_column_wrapper : public detail::column_wrapper {
       rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::test::get_default_stream()},
       std::move(null_mask),
       null_count});
+    cudf::test::get_default_stream().synchronize();
   }
 
   /**
@@ -765,6 +773,7 @@ class strings_column_wrapper : public detail::column_wrapper {
         offsets, cudf::test::get_default_stream(), cudf::get_current_device_resource_ref()),
       rmm::device_buffer{},
       0);
+    cudf::test::get_default_stream().synchronize();
     wrapped =
       cudf::make_strings_column(num_strings, std::move(d_offsets), d_chars.release(), 0, {});
   }
@@ -817,6 +826,7 @@ class strings_column_wrapper : public detail::column_wrapper {
       0);
     auto d_bitmask = cudf::detail::make_device_uvector(
       null_mask, cudf::test::get_default_stream(), cudf::get_current_device_resource_ref());
+    cudf::test::get_default_stream().synchronize();
     wrapped = cudf::make_strings_column(
       num_strings, std::move(d_offsets), d_chars.release(), null_count, d_bitmask.release());
   }
@@ -1653,6 +1663,7 @@ class lists_column_wrapper : public detail::column_wrapper {
     // construct the list column
     wrapped = make_lists_column(
       cols.size(), std::move(offsets), std::move(data), null_count, std::move(null_mask));
+    cudf::test::get_default_stream().synchronize();
   }
 
   /**

--- a/cpp/libcudf_streaming/tests/streaming/test_channel_metadata.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_channel_metadata.cpp
@@ -167,6 +167,7 @@ class StreamingChannelMetadataGPU : public ::testing::Test {
   std::shared_ptr<table_chunk> make_chunk(std::vector<int32_t> vals)
   {
     rmm::device_buffer buf(vals.data(), vals.size() * sizeof(int32_t), stream);
+    stream.synchronize();
     auto col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                               static_cast<cudf::size_type>(vals.size()),
                                               std::move(buf),

--- a/cpp/tests/io/json/json_quote_normalization_test.cpp
+++ b/cpp/tests/io/json/json_quote_normalization_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,6 +27,7 @@ void run_test(std::string const& host_input,
 {
   auto stream_view  = cudf::test::get_default_stream();
   auto device_input = rmm::device_buffer(host_input.c_str(), host_input.size(), stream_view);
+  stream_view.synchronize();
 
   // Preprocessing FST
   cudf::io::datasource::owning_buffer<rmm::device_buffer> device_data(std::move(device_input));


### PR DESCRIPTION
## Description
Constructing an rmm::device_buffer is stream-ordered with respect to the provided stream. Notably, when initialising from host data, no synchronisation is performed after the async memcpy to device. Previously, in a number of cases, we were implicitly relying on the fact that async memcopies from pageable host memory to device memory would complete synchronously. However, this has never been guaranteed by the programming model, and has therefore always been a bug waiting to happen. On some hardware, pageable memcopies are now async with respect to the host. So, we need to synchronise before the host data goes out of scope and is destructed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
