### PR TITLE
Backport #23540: Enable docs version picker

### DIFF
--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -232,6 +232,10 @@ html_theme_options = {
     "navbar_align": "content",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/cudf/versions.json",
+        "version_match": version,
+    },
 }
 include_pandas_compat = True
 


### PR DESCRIPTION
## Description

Backport of #23540, contributing to #23411 for the 26.08 release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.