### PR TITLE
Fix uninitialized page info for column chunks without a dictionary page

### DIFF
--- a/cpp/include/cudf/io/experimental/hybrid_scan.hpp
+++ b/cpp/include/cudf/io/experimental/hybrid_scan.hpp
@@ -406,7 +406,8 @@ class hybrid_scan_reader {
    * @brief Filter the row groups using column chunk dictionary pages
    *
    * @param dictionary_page_data Device spans of dictionary page data of column chunks with an
-   *                             (in)equality predicate
+   * (in)equality predicate, in the same order as the byte ranges returned by
+   * `secondary_filters_byte_ranges` including empty spans against empty byte ranges
    * @param row_group_indices Input row groups indices
    * @param options Parquet reader options
    * @param stream CUDA stream used for device memory operations and kernel launches

--- a/cpp/include/cudf/io/experimental/hybrid_scan_multifile.hpp
+++ b/cpp/include/cudf/io/experimental/hybrid_scan_multifile.hpp
@@ -470,8 +470,8 @@ class hybrid_scan_multifile {
    * @brief Filter the row groups using column chunk dictionary pages
    *
    * @param dictionary_page_data Device spans of dictionary page data of column chunks with an
-   *                             (in)equality predicate, ordered to match the dictionary page byte
-   *                             ranges returned by `dictionary_pages_byte_ranges`
+   * (in)equality predicate, in the same order as the byte ranges returned by
+   * `dictionary_pages_byte_ranges` including empty spans against empty byte ranges
    * @param row_group_indices Span of vectors of input row group indices, one per source
    * @param options Parquet reader options
    * @param stream CUDA stream used for device memory operations and kernel launches

--- a/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
@@ -12,6 +12,7 @@
 #include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
@@ -64,15 +65,18 @@ void decode_dictionary_page_headers(cudf::detail::hostdevice_span<ColumnChunkDes
               parquet::kernel_error::to_string(error));
   }
 
-  // Setup dictionary page for each chunk
-  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                   pages.device_begin(),
-                   pages.device_end(),
-                   [chunks = chunks.device_begin()] __device__(PageInfo const& p) {
-                     if (p.flags & parquet::detail::PAGEINFO_FLAGS_DICTIONARY) {
-                       chunks[p.chunk_idx].dict_page = &p;
-                     }
-                   });
+  // Setup dictionary page for each chunk. One page per column chunk, zeroed out struct if a column
+  // is not fully dictionary encoded.
+  thrust::for_each(
+    policy,
+    cuda::counting_iterator<cuda::std::size_t>(0),
+    cuda::counting_iterator<cuda::std::size_t>(chunks.size()),
+    [chunks = chunks.device_begin(), pages = pages.device_begin()] __device__(auto chunk_idx) {
+      auto const& page = pages[chunk_idx];
+      if (page.flags & parquet::detail::PAGEINFO_FLAGS_DICTIONARY) {
+        chunks[chunk_idx].dict_page = &page;
+      }
+    });
 
   pages.device_to_host_async(stream);
   chunks.device_to_host_async(stream);
@@ -185,7 +189,8 @@ void hybrid_scan_reader_impl::setup_compressed_data(
   auto const total_pages = _has_offset_index ? count_page_headers_with_pgidx(chunks, _stream)
                                              : count_page_headers(chunks, _stream);
   if (total_pages <= 0) { return; }
-  rmm::device_uvector<PageInfo> unsorted_pages(total_pages, _stream);
+  auto unsorted_pages = cudf::detail::make_zeroed_device_uvector_async<PageInfo>(
+    total_pages, _stream, cudf::get_current_device_resource_ref());
 
   // decoding of column/page information
   parquet::detail::decode_page_headers(pass, unsorted_pages, _has_offset_index, _stream);
@@ -293,8 +298,11 @@ hybrid_scan_reader_impl::prepare_dictionaries(
   // Copy the column chunk descriptors to the device
   chunks.host_to_device_async(stream);
 
-  // Create page infos for each column chunk's dictionary page
+  // Create page infos for each column chunk's dictionary page. Zero out as
+  // `decode_dictionary_page_headers()` does not touch `PageInfo`s for non-dictionary
+  // encoded column chunks.
   cudf::detail::hostdevice_vector<PageInfo> pages(total_column_chunks, stream);
+  CUDF_CUDA_TRY(cudaMemsetAsync(pages.device_ptr(), 0, pages.size_bytes(), stream.value()));
 
   // Decode dictionary page headers
   decode_dictionary_page_headers(chunks, pages, stream);

--- a/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
@@ -32,7 +32,6 @@ namespace cudf::io::parquet::experimental::detail {
 
 namespace {
 
-using parquet::detail::chunk_page_info;
 using parquet::detail::ColumnChunkDesc;
 using parquet::detail::PageInfo;
 
@@ -41,24 +40,38 @@ using parquet::detail::PageInfo;
  *
  * @param chunks Host device span of column chunk descriptors, one per input column chunk
  * @param pages Host device span of empty page headers to fill in, one per input column chunk
+ * @param dict_page_data Device spans of dictionary page data, one per input column chunk. Empty
+ *                       for column chunks without a dictionary page
  * @param stream CUDA stream
  */
-void decode_dictionary_page_headers(cudf::detail::hostdevice_span<ColumnChunkDesc> chunks,
-                                    cudf::detail::hostdevice_span<PageInfo> pages,
-                                    rmm::cuda_stream_view stream)
+void decode_dictionary_page_headers(
+  cudf::detail::hostdevice_span<ColumnChunkDesc> chunks,
+  cudf::detail::hostdevice_span<PageInfo> pages,
+  cudf::host_span<cudf::device_span<uint8_t const> const> dict_page_data,
+  rmm::cuda_stream_view stream)
 {
   CUDF_FUNC_RANGE();
 
-  rmm::device_uvector<chunk_page_info> chunk_page_info(chunks.size(), stream);
-  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                   cuda::counting_iterator<cuda::std::size_t>{0},
-                   cuda::counting_iterator{chunks.size()},
-                   [cpi = chunk_page_info.begin(), pages = pages.device_begin()] __device__(
-                     auto page_idx) { cpi[page_idx].pages = &pages[page_idx]; });
+  auto const page_data = cudf::detail::make_device_uvector_async(
+    dict_page_data, stream, cudf::get_current_device_resource_ref());
+
+  // Exactly one dictionary page per column chunk
+  rmm::device_uvector<size_type> chunk_page_offsets(chunks.size() + 1, stream);
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   chunk_page_offsets.begin(),
+                   chunk_page_offsets.end(),
+                   0);
 
   parquet::kernel_error error_code(stream);
 
-  parquet::detail::decode_page_headers(chunks, chunk_page_info, error_code.data(), stream);
+  // Decode dictionary page headers, one thread per page
+  parquet::detail::decode_page_headers_from_page_data(
+    cudf::device_span<ColumnChunkDesc const>{chunks.device_ptr(), chunks.size()},
+    cudf::device_span<PageInfo>{pages.device_ptr(), pages.size()},
+    page_data,
+    chunk_page_offsets,
+    error_code.data(),
+    stream);
 
   if (auto const error = error_code.value_sync(stream); error != 0) {
     CUDF_FAIL("Parquet header parsing failed with code(s) " +
@@ -68,7 +81,7 @@ void decode_dictionary_page_headers(cudf::detail::hostdevice_span<ColumnChunkDes
   // Setup dictionary page for each chunk. One page per column chunk, zeroed out struct if a column
   // is not fully dictionary encoded.
   thrust::for_each(
-    policy,
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cuda::std::size_t>(0),
     cuda::counting_iterator<cuda::std::size_t>(chunks.size()),
     [chunks = chunks.device_begin(), pages = pages.device_begin()] __device__(auto chunk_idx) {
@@ -298,14 +311,17 @@ hybrid_scan_reader_impl::prepare_dictionaries(
   // Copy the column chunk descriptors to the device
   chunks.host_to_device_async(stream);
 
-  // Create page infos for each column chunk's dictionary page. Zero out as
-  // `decode_dictionary_page_headers()` does not touch `PageInfo`s for non-dictionary
-  // encoded column chunks.
+  // Create page infos for each column chunk's dictionary page
   cudf::detail::hostdevice_vector<PageInfo> pages(total_column_chunks, stream);
-  CUDF_CUDA_TRY(cudaMemsetAsync(pages.device_ptr(), 0, pages.size_bytes(), stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(pages.device_ptr(), 0, pages.size() * sizeof(PageInfo), stream));
 
   // Decode dictionary page headers
-  decode_dictionary_page_headers(chunks, pages, stream);
+  decode_dictionary_page_headers(
+    chunks,
+    pages,
+    cudf::host_span<cudf::device_span<uint8_t const> const>{dictionary_page_data.data(),
+                                                           dictionary_page_data.size()},
+    stream);
 
   return {has_compressed_data, std::move(chunks), std::move(pages)};
 }

--- a/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
@@ -319,8 +319,7 @@ hybrid_scan_reader_impl::prepare_dictionaries(
   decode_dictionary_page_headers(
     chunks,
     pages,
-    cudf::host_span<cudf::device_span<uint8_t const> const>{dictionary_page_data.data(),
-                                                           dictionary_page_data.size()},
+    cudf::host_span{dictionary_page_data.data(), dictionary_page_data.size()},
     stream);
 
   return {has_compressed_data, std::move(chunks), std::move(pages)};

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
@@ -20,6 +20,7 @@
 #include <cuda/iterator>
 #include <cuda/std/algorithm>
 #include <thrust/for_each.h>
+#include <thrust/gather.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
@@ -401,12 +402,11 @@ cudf::detail::hostdevice_vector<PageInfo> sort_pages(device_span<PageInfo const>
     sort_indices.begin(),
     cuda::std::less<int>());
   auto pass_pages = cudf::detail::hostdevice_vector<PageInfo>(unsorted_pages.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                    sort_indices.begin(),
-                    sort_indices.end(),
-                    pass_pages.d_begin(),
-                    cuda::proclaim_return_type<PageInfo>(
-                      [p = unsorted_pages.data()] __device__(int32_t i) { return p[i]; }));
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 sort_indices.begin(),
+                 sort_indices.end(),
+                 unsorted_pages.data(),
+                 pass_pages.d_begin());
   stream.synchronize();
   return pass_pages;
 }

--- a/cpp/tests/io/experimental/hybrid_scan_filters_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_filters_test.cpp
@@ -19,13 +19,18 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <cuda/iterator>
+
 #include <src/io/parquet/parquet_gpu.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <iterator>
 #include <memory>
+#include <string>
 #include <vector>
 
 // Base test fixture for tests
@@ -1768,3 +1773,123 @@ TEST_F(HybridScanFiltersTest, RowGroupPasses)
     });
   }
 }
+
+class DictionaryFilterGapTest : public HybridScanFiltersTest,
+                                public ::testing::WithParamInterface<cudf::io::compression_type> {};
+
+TEST_P(DictionaryFilterGapTest, FilterRowGroupsWithMissingDictPages)
+{
+  auto const compression                = GetParam();
+  auto constexpr num_rows_per_row_group = 20'000;
+  // RG 0 holds a single distinct value so it is dict encoded
+  // RG 1 holds all distinct values so it falls back
+  auto const strings = cudf::detail::make_counting_transform_iterator(0, [](auto const i) {
+    return i < num_rows_per_row_group ? std::string{"dict_value"}
+                                      : "plain_value_" + std::to_string(i - num_rows_per_row_group);
+  });
+
+  auto const column =
+    cudf::test::strings_column_wrapper(strings, strings + 2 * num_rows_per_row_group);
+  auto const table = cudf::table_view{{column}};
+
+  auto table_metadata = cudf::io::table_input_metadata{table};
+  table_metadata.column_metadata[0].set_name("col0");
+
+  auto const filepath = temp_env->get_temp_filepath("DictionaryFilterGapTest.parquet");
+  auto const write_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, table)
+      .metadata(std::move(table_metadata))
+      .row_group_size_rows(num_rows_per_row_group)
+      .dictionary_policy(cudf::io::dictionary_policy::ADAPTIVE)
+      .max_dictionary_size(1024)
+      .stats_level(cudf::io::statistics_freq::STATISTICS_COLUMN)
+      .compression(compression)
+      .write_v2_headers(false)
+      .build();
+  cudf::io::write_parquet(write_opts);
+
+  // Input datasource
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
+
+  auto const datasource     = cudf::io::datasource::create(filepath);
+  auto const datasource_ref = std::ref(*datasource);
+
+  // Hybrid scan reader
+  auto const default_options = cudf::io::parquet_reader_options::builder().build();
+  auto const footer_buffer   = cudf::io::parquet::fetch_footer_to_host(*datasource);
+  auto const reader = std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(
+    *footer_buffer, default_options);
+
+  auto const reader_ref = std::ref(*reader);
+  auto const col0_ref   = cudf::ast::column_name_reference("col0");
+
+  // Sanity check: exactly one dictionary page byte range per row group and the second one is empty
+  {
+    auto literal_value = cudf::string_scalar("dict_value", true, stream);
+    auto literal       = cudf::ast::literal(literal_value);
+    auto const filter_expression =
+      cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col0_ref, literal);
+    auto const options =
+      cudf::io::parquet_reader_options::builder().filter(filter_expression).build();
+
+    reader->reset_column_selection();
+    auto const row_group_indices = reader->all_row_groups(options);
+    ASSERT_EQ(row_group_indices.size(), 2);
+
+    auto const dict_page_byte_ranges =
+      reader->secondary_filters_byte_ranges(row_group_indices, options).second;
+    ASSERT_EQ(dict_page_byte_ranges.size(), 2);
+    EXPECT_GT(dict_page_byte_ranges[0].size(), 0);
+    EXPECT_EQ(dict_page_byte_ranges[1].size(), 0);
+  }
+
+  // Filtering - col0 == "plain_value_5": row group 0 is pruned by its dictionary, row group 1
+  // cannot be pruned as it has no dictionary page
+  {
+    auto literal_value = cudf::string_scalar("plain_value_5", true, stream);
+    auto literal       = cudf::ast::literal(literal_value);
+    auto const filter_expression =
+      cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col0_ref, literal);
+    auto const options =
+      cudf::io::parquet_reader_options::builder().filter(filter_expression).build();
+
+    auto const expected = std::vector<cudf::size_type>{1};
+    EXPECT_EQ(filter_row_groups_with_dictionaries(datasource_ref, reader_ref, options, stream, mr),
+              expected);
+  }
+
+  // Filtering - col0 == "dict_value": both row groups survive
+  {
+    auto literal_value = cudf::string_scalar("dict_value", true, stream);
+    auto literal       = cudf::ast::literal(literal_value);
+    auto const filter_expression =
+      cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col0_ref, literal);
+    auto const options =
+      cudf::io::parquet_reader_options::builder().filter(filter_expression).build();
+
+    auto const expected = std::vector<cudf::size_type>{0, 1};
+    EXPECT_EQ(filter_row_groups_with_dictionaries(datasource_ref, reader_ref, options, stream, mr),
+              expected);
+  }
+
+  // Filtering - col0 != "dict_value": row group 0 is pruned as its dictionary holds only that one
+  // value, row group 1 cannot be pruned
+  {
+    auto literal_value = cudf::string_scalar("dict_value", true, stream);
+    auto literal       = cudf::ast::literal(literal_value);
+    auto const filter_expression =
+      cudf::ast::operation(cudf::ast::ast_operator::NOT_EQUAL, col0_ref, literal);
+    auto const options =
+      cudf::io::parquet_reader_options::builder().filter(filter_expression).build();
+
+    auto const expected = std::vector<cudf::size_type>{1};
+    EXPECT_EQ(filter_row_groups_with_dictionaries(datasource_ref, reader_ref, options, stream, mr),
+              expected);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(Compression,
+                         DictionaryFilterGapTest,
+                         ::testing::Values(cudf::io::compression_type::NONE,
+                                           cudf::io::compression_type::ZSTD));


### PR DESCRIPTION
## Description

This PR zero-initializes page info buffers in dictionary page row group filtering to ensure empty buffers (no pages) are reliably discarded by the decoder instead of reading uninitialized data. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
