### PR TITLE
Fix how `build.sh` determines CUDA version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,8 @@ CUDF_JAR_JAVA_BUILD_DIR="$REPODIR/java/target"
 
 BUILD_DIRS="${LIB_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR} ${KAFKA_LIB_BUILD_DIR} ${CUDF_KAFKA_BUILD_DIR} ${CUSTREAMZ_BUILD_DIR} ${CUDF_JAR_JAVA_BUILD_DIR} ${PYLIBCUDF_BUILD_DIR} ${STREAMING_LIB_BUILD_DIR}"
 
+CUDA_VERSION="$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')"
+
 # Set defaults for vars modified by flags to this script
 VERBOSE_FLAG=""
 BUILD_TYPE=Release
@@ -80,7 +82,7 @@ PYTHON_ARGS_FOR_INSTALL=(
     --no-build-isolation
     --no-deps
     --config-settings="rapidsai.disable-cuda=true"
-    --config-settings="rapidsai.matrix-entry=cuda=${RAPIDS_CUDA_VERSION};cuda_suffixed=false;use_cuda_wheels=false"
+    --config-settings="rapidsai.matrix-entry=cuda=${CUDA_VERSION};cuda_suffixed=false;use_cuda_wheels=false"
 )
 
 # Set defaults for vars that may not have been defined externally

--- a/build.sh
+++ b/build.sh
@@ -65,8 +65,8 @@ BUILD_DIRS="${LIB_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR} ${KAFKA_LI
 
 CUDA_VERSION="$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')"
 if [[ -z "$CUDA_VERSION" ]]; then
-  echo "Could not determine CUDA version. Please make sure your \$PATH contains a valid nvcc."
-  exit 1
+    echo "Could not determine CUDA version. Please make sure your \$PATH contains a valid nvcc."
+    exit 1
 fi
 
 # Set defaults for vars modified by flags to this script

--- a/build.sh
+++ b/build.sh
@@ -63,9 +63,9 @@ CUDF_JAR_JAVA_BUILD_DIR="$REPODIR/java/target"
 
 BUILD_DIRS="${LIB_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR} ${KAFKA_LIB_BUILD_DIR} ${CUDF_KAFKA_BUILD_DIR} ${CUSTREAMZ_BUILD_DIR} ${CUDF_JAR_JAVA_BUILD_DIR} ${PYLIBCUDF_BUILD_DIR} ${STREAMING_LIB_BUILD_DIR}"
 
-CUDA_VERSION="$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')"
+CUDA_VERSION="${RAPIDS_CUDA_VERSION:-$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')}"
 if [[ -z "$CUDA_VERSION" ]]; then
-    echo "Could not determine CUDA version. Please make sure your \$PATH contains a valid nvcc."
+    echo "Could not determine CUDA version. Please set RAPIDS_CUDA_VERSION or make sure your \$PATH contains a valid nvcc."
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -64,6 +64,10 @@ CUDF_JAR_JAVA_BUILD_DIR="$REPODIR/java/target"
 BUILD_DIRS="${LIB_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR} ${KAFKA_LIB_BUILD_DIR} ${CUDF_KAFKA_BUILD_DIR} ${CUSTREAMZ_BUILD_DIR} ${CUDF_JAR_JAVA_BUILD_DIR} ${PYLIBCUDF_BUILD_DIR} ${STREAMING_LIB_BUILD_DIR}"
 
 CUDA_VERSION="$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')"
+if [[ -z "$CUDA_VERSION" ]]; then
+  echo "Could not determine CUDA version. Please make sure your \$PATH contains a valid nvcc."
+  exit 1
+fi
 
 # Set defaults for vars modified by flags to this script
 VERBOSE_FLAG=""


### PR DESCRIPTION
## Description
In https://github.com/rapidsai/cudf/pull/23472, we incorrectly used `RAPIDS_CUDA_VERSION` in `build.sh`. This variable comes from CI only and should not be required to build locally. If `RAPIDS_CUDA_VERSION` is not available, determine the CUDA version in a similar manner to rapids-build-backend: run `nvcc --version` and parse the output.

Fixes https://github.com/rapidsai/cudf/issues/23587

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
