### PR TITLE
Select few large segments in segmented_top_k with cub::DeviceTopK ins…

### DIFF
--- a/cpp/benchmarks/sort/segmented_top_k.cpp
+++ b/cpp/benchmarks/sort/segmented_top_k.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,15 +13,13 @@
 
 #include <nvbench/nvbench.cuh>
 
-template <typename DataType>
-void bench_segmented_top_k(nvbench::state& state, nvbench::type_list<DataType>)
+void run_segmented_top_k(nvbench::state& state,
+                         cudf::type_id data_type,
+                         cudf::size_type num_rows,
+                         cudf::size_type segment,
+                         cudf::size_type k,
+                         bool ordered)
 {
-  auto const ordered   = static_cast<bool>(state.get_int64("ordered"));
-  auto const num_rows  = static_cast<cudf::size_type>(state.get_int64("num_rows"));
-  auto const segment   = static_cast<cudf::size_type>(state.get_int64("segment"));
-  auto const k         = static_cast<cudf::size_type>(state.get_int64("k"));
-  auto const data_type = cudf::type_to_id<DataType>();
-
   data_profile const profile = data_profile_builder().no_validity().distribution(
     data_type, distribution_id::UNIFORM, 0, segment);
   auto const input = create_random_column(data_type, row_count{num_rows}, profile);
@@ -47,6 +45,28 @@ void bench_segmented_top_k(nvbench::state& state, nvbench::type_list<DataType>)
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
+template <typename DataType>
+void bench_segmented_top_k(nvbench::state& state, nvbench::type_list<DataType>)
+{
+  auto const ordered  = static_cast<bool>(state.get_int64("ordered"));
+  auto const num_rows = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const segment  = static_cast<cudf::size_type>(state.get_int64("segment"));
+  auto const k        = static_cast<cudf::size_type>(state.get_int64("k"));
+  run_segmented_top_k(state, cudf::type_to_id<DataType>(), num_rows, segment, k, ordered);
+}
+
+// The shape the per-segment DeviceTopK path targets: few large segments.
+template <typename DataType>
+void bench_segmented_top_k_few_large(nvbench::state& state, nvbench::type_list<DataType>)
+{
+  auto const ordered      = static_cast<bool>(state.get_int64("ordered"));
+  auto const num_segments = static_cast<cudf::size_type>(state.get_int64("num_segments"));
+  auto const segment      = static_cast<cudf::size_type>(state.get_int64("segment"));
+  auto const k            = static_cast<cudf::size_type>(state.get_int64("k"));
+  run_segmented_top_k(
+    state, cudf::type_to_id<DataType>(), num_segments * segment, segment, k, ordered);
+}
+
 NVBENCH_DECLARE_TYPE_STRINGS(cudf::timestamp_s, "time_s", "time_s");
 
 using Types = nvbench::type_list<int32_t, float, cudf::timestamp_s>;
@@ -56,4 +76,11 @@ NVBENCH_BENCH_TYPES(bench_segmented_top_k, NVBENCH_TYPE_AXES(Types))
   .add_int64_axis("num_rows", {262144, 2097152, 16777216, 67108864})
   .add_int64_axis("segment", {1024, 2048})
   .add_int64_axis("k", {100, 1000})
+  .add_int64_axis("ordered", {0, 1});
+
+NVBENCH_BENCH_TYPES(bench_segmented_top_k_few_large, NVBENCH_TYPE_AXES(Types))
+  .set_name("segmented_top_k_few_large")
+  .add_int64_axis("num_segments", {4, 16, 64})
+  .add_int64_axis("segment", {16384, 131072, 1048576})
+  .add_int64_axis("k", {100, 2048})
   .add_int64_axis("ordered", {0, 1});

--- a/cpp/include/cudf/sorting.hpp
+++ b/cpp/include/cudf/sorting.hpp
@@ -419,6 +419,8 @@ std::unique_ptr<column> top_k_order(
  * Returns the top k values (largest or smallest) within each segment of the given column.
  * The values within each segment may not necessarily be sorted.
  * If a segment contain less than k elements then all values for that segment are returned.
+ * When several rows of a segment hold the same value at the k boundary, which of them are
+ * selected is unspecified; the returned values are the same either way.
  *
  * @code{.pseudo}
  * Example:
@@ -466,6 +468,8 @@ std::unique_ptr<column> segmented_top_k(
  * The indices will represent the top k elements within each segment but may not represent
  * those elements as k sorted values.
  * If a segment contain less than k elements then all values for that segment are returned.
+ * When several rows of a segment hold the same value at the k boundary, which of their
+ * indices are selected, and the order of indices of equal values, is unspecified.
  *
  * @code{.pseudo}
  * Example:

--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -18,12 +18,23 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/device/device_topk.cuh>
+#include <cuda/iterator>
+#include <cuda/std/execution>
 #include <cuda/std/iterator>
 #include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/remove.h>
+#include <thrust/sequence.h>
+
+#include <algorithm>
+#include <vector>
 
 namespace cudf {
 namespace detail {
@@ -68,30 +79,16 @@ CUDF_KERNEL void resolve_segment_indices(device_span<size_type const> d_offsets,
     d_segment_sizes[segment_index] = cuda::std::min(k, segment_size);
   }
 }
-}  // namespace
 
-std::unique_ptr<column> segmented_top_k_order(column_view const& col,
-                                              column_view const& segment_offsets,
-                                              size_type k,
-                                              order topk_order,
-                                              cuda::stream_ref stream,
-                                              rmm::device_async_resource_ref mr)
+/** @brief Computes top-k indices per segment using a full segmented sort. */
+std::unique_ptr<column> sort_based_segmented_top_k_order(column_view const& col,
+                                                         column_view const& segment_offsets,
+                                                         size_type k,
+                                                         order topk_order,
+                                                         cuda::stream_ref stream,
+                                                         rmm::device_async_resource_ref mr)
 {
-  CUDF_EXPECTS(k >= 0, "k must be greater than or equal to 0", std::invalid_argument);
-
   auto const size_data_type = data_type{type_to_id<size_type>()};
-  if (k == 0 || col.is_empty()) { return cudf::make_empty_lists_column(size_data_type); }
-
-  CUDF_EXPECTS(segment_offsets.size() > 0,
-               "segment_offsets must have at least one element",
-               std::invalid_argument);
-
-  CUDF_EXPECTS(segment_offsets.type() == size_data_type,
-               "segment_offsets must be of type INT32",
-               cudf::data_type_error);
-  CUDF_EXPECTS(segment_offsets.null_count() == 0,
-               "segment_offsets must not have nulls",
-               std::invalid_argument);
 
   auto const nulls   = topk_order == order::ASCENDING ? null_order::AFTER : null_order::BEFORE;
   auto const temp_mr = cudf::get_current_device_resource_ref();
@@ -124,6 +121,193 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
   auto const num_rows = static_cast<size_type>(offsets->size() - 1);
   return make_lists_column(
     num_rows, std::move(offsets), std::move(result), 0, rmm::device_buffer{});
+}
+
+// Limit the number of host-launched DeviceTopK calls.
+constexpr size_type cub_max_segments = 64;
+
+// Below this average segment size the segmented sort is faster.
+constexpr size_type cub_min_avg_segment_size = 16384;
+
+// Largest selected fraction; as k approaches the segment size the post-selection
+// sort approaches the full sort this path avoids.
+constexpr size_type cub_max_k_fraction = 8;
+
+bool is_fast_path(column_view const& column)
+{
+  return !column.has_nulls() && cudf::is_fixed_width(column.type()) &&
+         !cudf::is_floating_point(column.type());  // requires NaN-aware ordering
+}
+
+/** @brief Selects top-k indices with one DeviceTopK call per segment. */
+template <typename T>
+std::unique_ptr<column> cub_segmented_top_k_order(column_view const& col,
+                                                  host_span<size_type const> h_offsets,
+                                                  size_type k,
+                                                  order topk_order,
+                                                  cuda::stream_ref stream,
+                                                  rmm::device_async_resource_ref mr)
+{
+  auto const num_segments = static_cast<size_type>(h_offsets.size()) - 1;
+
+  auto h_out_offsets = std::vector<size_type>(num_segments + 1);
+  h_out_offsets[0]   = 0;
+  for (size_type i = 0; i < num_segments; ++i) {
+    auto const size      = h_offsets[i + 1] - h_offsets[i];
+    h_out_offsets[i + 1] = h_out_offsets[i] + cuda::std::min(size, k);
+  }
+
+  // Synchronous copy before any CUB work is queued: h_out_offsets is stack-local and an
+  // async copy would defer the read.
+  auto offsets = std::make_unique<column>(
+    cudf::detail::make_device_uvector(h_out_offsets, stream, mr), rmm::device_buffer{}, 0);
+
+  auto const temp_mr = cudf::get_current_device_resource_ref();
+  auto indices       = rmm::device_uvector<size_type>(h_out_offsets[num_segments], stream, temp_mr);
+  auto const in      = col.begin<T>();
+  auto keys_out      = cuda::make_discard_iterator();
+
+  auto requirements = cuda::execution::require(cuda::execution::determinism::not_guaranteed,
+                                               cuda::execution::output_ordering::unsorted);
+  auto env          = cuda::std::execution::env{stream, requirements};
+
+  auto run = [&](void* tmp, std::size_t& tmp_size, size_type i) {
+    auto const begin    = h_offsets[i];
+    auto const size     = h_offsets[i + 1] - begin;
+    auto const keys_in  = in + begin;
+    auto const vals_in  = cuda::counting_iterator<size_type>{begin};
+    auto const vals_out = indices.data() + h_out_offsets[i];
+    return topk_order == order::ASCENDING
+             ? cub::DeviceTopK::MinPairs(
+                 tmp, tmp_size, keys_in, keys_out, vals_in, vals_out, size, k, env)
+             : cub::DeviceTopK::MaxPairs(
+                 tmp, tmp_size, keys_in, keys_out, vals_in, vals_out, size, k, env);
+  };
+
+  // Reuse temporary storage across segments.
+  auto max_tmp_size = std::size_t{0};
+  for (size_type i = 0; i < num_segments; ++i) {
+    if (h_offsets[i + 1] - h_offsets[i] <= k) { continue; }
+    auto tmp_size = std::size_t{0};
+    CUDF_CUDA_TRY(run(nullptr, tmp_size, i));
+    max_tmp_size = cuda::std::max(max_tmp_size, tmp_size);
+  }
+  auto tmp = rmm::device_buffer(max_tmp_size, stream);
+
+  for (size_type i = 0; i < num_segments; ++i) {
+    auto const size = h_offsets[i + 1] - h_offsets[i];
+    if (size <= 0) { continue; }
+    if (size <= k) {
+      // Select the entire segment without CUB.
+      thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       indices.begin() + h_out_offsets[i],
+                       indices.begin() + h_out_offsets[i + 1],
+                       h_offsets[i]);
+      continue;
+    }
+    auto tmp_size = max_tmp_size;
+    CUDF_CUDA_TRY(run(tmp.data(), tmp_size, i));
+  }
+
+  auto child = std::make_unique<column>(std::move(indices), rmm::device_buffer{}, 0);
+
+  // Order each segment's selection by value like the sort-based path does. Which rows are
+  // selected among equal values at the k boundary, and their relative order, stay unspecified.
+  auto const nulls = topk_order == order::ASCENDING ? null_order::AFTER : null_order::BEFORE;
+  auto const keys  = cudf::detail::gather(cudf::table_view({col}),
+                                         child->view(),
+                                         out_of_bounds_policy::DONT_CHECK,
+                                         negative_index_policy::NOT_ALLOWED,
+                                         stream,
+                                         temp_mr);
+  auto sorted      = cudf::detail::stable_segmented_sort_by_key(cudf::table_view({child->view()}),
+                                                           keys->view(),
+                                                           offsets->view(),
+                                                                {topk_order},
+                                                                {nulls},
+                                                           stream,
+                                                           mr);
+
+  return make_lists_column(num_segments,
+                           std::move(offsets),
+                           std::move(sorted->release().front()),
+                           0,
+                           rmm::device_buffer{});
+}
+
+struct dispatch_segmented_topk_fn {
+  column_view col;
+  host_span<size_type const> h_offsets;
+  size_type k;
+  order topk_order;
+  cuda::stream_ref stream;
+  rmm::device_async_resource_ref mr;
+
+  template <typename T>
+    requires(cudf::is_fixed_width<T>() and !cudf::is_floating_point<T>() and !cudf::is_chrono<T>())
+  std::unique_ptr<column> operator()()
+  {
+    return cub_segmented_top_k_order<T>(col, h_offsets, k, topk_order, stream, mr);
+  }
+
+  template <typename T>
+    requires(cudf::is_chrono<T>())
+  std::unique_ptr<column> operator()()
+  {
+    using rep_type = typename T::rep;
+    return cub_segmented_top_k_order<rep_type>(col, h_offsets, k, topk_order, stream, mr);
+  }
+
+  template <typename T>
+    requires(not cudf::is_fixed_width<T>() or cudf::is_floating_point<T>())
+  std::unique_ptr<column> operator()()
+  {
+    CUDF_UNREACHABLE("unexpected type for segmented_top_k fast path");
+  }
+};
+}  // namespace
+
+std::unique_ptr<column> segmented_top_k_order(column_view const& col,
+                                              column_view const& segment_offsets,
+                                              size_type k,
+                                              order topk_order,
+                                              cuda::stream_ref stream,
+                                              rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(k >= 0, "k must be greater than or equal to 0", std::invalid_argument);
+
+  auto const size_data_type = data_type{type_to_id<size_type>()};
+  if (k == 0 || col.is_empty()) { return cudf::make_empty_lists_column(size_data_type); }
+
+  CUDF_EXPECTS(segment_offsets.size() > 0,
+               "segment_offsets must have at least one element",
+               std::invalid_argument);
+
+  CUDF_EXPECTS(segment_offsets.type() == size_data_type,
+               "segment_offsets must be of type INT32",
+               cudf::data_type_error);
+  CUDF_EXPECTS(segment_offsets.null_count() == 0,
+               "segment_offsets must not have nulls",
+               std::invalid_argument);
+
+  if (auto const num_segments = segment_offsets.size() - 1;
+      is_fast_path(col) && num_segments > 0 && num_segments <= cub_max_segments) {
+    auto const h_offsets = cudf::detail::make_host_vector(
+      device_span<size_type const>{segment_offsets.begin<size_type>(),
+                                   static_cast<std::size_t>(num_segments) + 1},
+      stream);
+    // Malformed offsets keep the sort-based path's failure behavior.
+    auto const valid_offsets = h_offsets.front() >= 0 && h_offsets.back() <= col.size() &&
+                               std::is_sorted(h_offsets.begin(), h_offsets.end());
+    auto const avg_segment_size = (h_offsets.back() - h_offsets.front()) / num_segments;
+    if (valid_offsets && avg_segment_size >= cub_min_avg_segment_size &&
+        k <= avg_segment_size / cub_max_k_fraction) {
+      return type_dispatcher<dispatch_storage_type>(
+        col.type(), dispatch_segmented_topk_fn{col, h_offsets, k, topk_order, stream, mr});
+    }
+  }
+
+  return sort_based_segmented_top_k_order(col, segment_offsets, k, topk_order, stream, mr);
 }
 
 std::unique_ptr<column> segmented_top_k(column_view const& col,

--- a/cpp/tests/sort/top_k_tests.cpp
+++ b/cpp/tests/sort/top_k_tests.cpp
@@ -11,10 +11,12 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <cuda/iterator>
 
@@ -470,4 +472,200 @@ TEST_F(TopK, TopKSegmentedEmptyMultiBlock)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   result = cudf::segmented_top_k_order(input, offsets, 2);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+}
+TEST_F(TopK, TopKSegmentedFewLargePartitions)
+{
+  using LCW  = cudf::test::lists_column_wrapper<int32_t>;
+  using LCWO = cudf::test::lists_column_wrapper<cudf::size_type>;
+
+  auto itr     = cuda::counting_iterator<int32_t>{0};
+  auto input   = cudf::test::fixed_width_column_wrapper<int32_t>(itr, itr + 60000);
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 20000, 40000, 60000});
+
+  LCW expected({LCW{19999, 19998, 19997}, LCW{39999, 39998, 39997}, LCW{59999, 59998, 59997}});
+  auto result = cudf::segmented_top_k(input, offsets, 3);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+
+  LCWO expected_order(
+    {LCWO{19999, 19998, 19997}, LCWO{39999, 39998, 39997}, LCWO{59999, 59998, 59997}});
+  result = cudf::segmented_top_k_order(input, offsets, 3);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+
+  LCW expected_asc({LCW{0, 1, 2}, LCW{20000, 20001, 20002}, LCW{40000, 40001, 40002}});
+  result = cudf::segmented_top_k(input, offsets, 3, cudf::order::ASCENDING);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_asc, result->view());
+}
+
+// Covers an empty segment and a segment smaller than k.
+TEST_F(TopK, TopKSegmentedFewLargePartitionsRagged)
+{
+  using LCW  = cudf::test::lists_column_wrapper<int32_t>;
+  using LCWO = cudf::test::lists_column_wrapper<cudf::size_type>;
+
+  auto itr     = cuda::counting_iterator<int32_t>{0};
+  auto input   = cudf::test::fixed_width_column_wrapper<int32_t>(itr, itr + 50002);
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 50000, 50000, 50002});
+
+  // Segment 1 is empty; segment 2 holds two rows, fewer than k=3.
+  LCW expected({LCW{49999, 49998, 49997}, LCW{}, LCW{50001, 50000}});
+  auto result = cudf::segmented_top_k(input, offsets, 3);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+
+  LCWO expected_order({LCWO{49999, 49998, 49997}, LCWO{}, LCWO{50001, 50000}});
+  result = cudf::segmented_top_k_order(input, offsets, 3);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+}
+
+// Leading and trailing rows are outside the segments.
+TEST_F(TopK, TopKSegmentedFewLargePartitionsUncovered)
+{
+  using LCW = cudf::test::lists_column_wrapper<int32_t>;
+
+  auto itr     = cuda::counting_iterator<int32_t>{0};
+  auto input   = cudf::test::fixed_width_column_wrapper<int32_t>(itr, itr + 80000);
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({10000, 40000, 70000});
+
+  // Rows 0-9999 and 70000-79999 lie outside every segment.
+  LCW expected({LCW{39999, 39998}, LCW{69999, 69998}});
+  auto result = cudf::segmented_top_k(input, offsets, 2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+// 64 segments use CUB; 65 use the fallback path.
+TEST_F(TopK, TopKSegmentedFewLargePartitionsSegmentCountBound)
+{
+  auto itr = cuda::counting_iterator<int32_t>{0};
+  for (int32_t num_segments : {64, 65}) {
+    auto const seg   = 20000;
+    auto const total = num_segments * seg;
+    auto input       = cudf::test::fixed_width_column_wrapper<int32_t>(itr, itr + total);
+    auto h_offsets   = std::vector<int32_t>(num_segments + 1);
+    for (int32_t i = 0; i <= num_segments; ++i) {
+      h_offsets[i] = i * seg;
+    }
+    auto offsets =
+      cudf::test::fixed_width_column_wrapper<int32_t>(h_offsets.begin(), h_offsets.end());
+
+    auto h_child       = std::vector<int32_t>();
+    auto h_exp_offsets = std::vector<int32_t>{0};
+    for (int32_t i = 0; i < num_segments; ++i) {
+      h_child.push_back((i + 1) * seg - 1);
+      h_child.push_back((i + 1) * seg - 2);
+      h_exp_offsets.push_back(h_exp_offsets.back() + 2);
+    }
+    auto expected = cudf::make_lists_column(
+      num_segments,
+      cudf::test::fixed_width_column_wrapper<int32_t>(h_exp_offsets.begin(), h_exp_offsets.end())
+        .release(),
+      cudf::test::fixed_width_column_wrapper<int32_t>(h_child.begin(), h_child.end()).release(),
+      0,
+      {});
+
+    auto result = cudf::segmented_top_k(input, offsets, 2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), result->view());
+  }
+}
+
+// Decimal keys reach the per-segment path through their storage type, including the
+// 128-bit one.
+template <typename T>
+struct TopKSegmentedDecimal : public cudf::test::BaseFixture {};
+
+TYPED_TEST_SUITE(TopKSegmentedDecimal, cudf::test::FixedPointTypes);
+
+TYPED_TEST(TopKSegmentedDecimal, FewLargePartitions)
+{
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+  using LCWO      = cudf::test::lists_column_wrapper<cudf::size_type>;
+
+  auto itr = cuda::counting_iterator<RepType>{0};
+  auto input =
+    cudf::test::fixed_point_column_wrapper<RepType>(itr, itr + 60000, numeric::scale_type{-2});
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 20000, 40000, 60000});
+
+  LCWO expected_order({LCWO{19999, 19998}, LCWO{39999, 39998}, LCWO{59999, 59998}});
+  auto result = cudf::segmented_top_k_order(input, offsets, 2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+
+  LCWO expected_asc({LCWO{0, 1}, LCWO{20000, 20001}, LCWO{40000, 40001}});
+  result = cudf::segmented_top_k_order(input, offsets, 2, cudf::order::ASCENDING);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_asc, result->view());
+}
+
+// Chrono keys reach the per-segment path through their representation type.
+template <typename T>
+struct TopKSegmentedChrono : public cudf::test::BaseFixture {};
+
+TYPED_TEST_SUITE(TopKSegmentedChrono, cudf::test::ChronoTypes);
+
+TYPED_TEST(TopKSegmentedChrono, FewLargePartitions)
+{
+  using T    = TypeParam;
+  using LCWO = cudf::test::lists_column_wrapper<cudf::size_type>;
+
+  auto itr     = cuda::counting_iterator<int32_t>{0};
+  auto input   = cudf::test::fixed_width_column_wrapper<T, int32_t>(itr, itr + 60000);
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 20000, 40000, 60000});
+
+  LCWO expected_order({LCWO{19999, 19998}, LCWO{39999, 39998}, LCWO{59999, 59998}});
+  auto result = cudf::segmented_top_k_order(input, offsets, 2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+}
+
+// Ties at the k boundary: the selected values are fully determined even though the
+// selected row indices among equal values are not.
+TEST_F(TopK, SegmentedFewLargePartitionsWithTies)
+{
+  // Each segment holds 200 copies of every value in [0, 100).
+  auto itr     = cuda::make_transform_iterator(cuda::counting_iterator<int32_t>{0},
+                                           [](int32_t i) { return i % 100; });
+  auto input   = cudf::test::fixed_width_column_wrapper<int32_t>(itr, itr + 60000);
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 20000, 40000, 60000});
+
+  auto sorted_values = [](cudf::column_view const& lists_col, cudf::order sort_order) {
+    auto lists = cudf::lists_column_view(lists_col);
+    return cudf::segmented_sort_by_key(cudf::table_view({lists.child()}),
+                                       cudf::table_view({lists.child()}),
+                                       lists.offsets(),
+                                       {sort_order});
+  };
+
+  // k = 300 takes all 200 copies of the extreme value and 100 of the next one.
+  auto desc_itr = cuda::make_transform_iterator(
+    cuda::counting_iterator<int32_t>{0}, [](int32_t i) { return (i % 300) < 200 ? 99 : 98; });
+  auto expected_desc = cudf::test::fixed_width_column_wrapper<int32_t>(desc_itr, desc_itr + 900);
+  auto result        = cudf::segmented_top_k(input, offsets, 300);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected_desc, sorted_values(result->view(), cudf::order::DESCENDING)->view().column(0));
+
+  auto asc_itr      = cuda::make_transform_iterator(cuda::counting_iterator<int32_t>{0},
+                                               [](int32_t i) { return (i % 300) < 200 ? 0 : 1; });
+  auto expected_asc = cudf::test::fixed_width_column_wrapper<int32_t>(asc_itr, asc_itr + 900);
+  result            = cudf::segmented_top_k(input, offsets, 300, cudf::order::ASCENDING);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected_asc, sorted_values(result->view(), cudf::order::ASCENDING)->view().column(0));
+
+  // The selected indices are unspecified among equal values, but must point at those values.
+  auto gathered_values = [&](cudf::column_view const& order_col) {
+    auto lists  = cudf::lists_column_view(order_col);
+    auto values = cudf::gather(cudf::table_view({input}), lists.child());
+    return cudf::make_lists_column(lists.size(),
+                                   std::make_unique<cudf::column>(lists.offsets()),
+                                   std::move(values->release().front()),
+                                   0,
+                                   rmm::device_buffer{});
+  };
+  auto order = cudf::segmented_top_k_order(input, offsets, 300);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected_desc,
+    sorted_values(gathered_values(order->view())->view(), cudf::order::DESCENDING)
+      ->view()
+      .column(0));
+  order = cudf::segmented_top_k_order(input, offsets, 300, cudf::order::ASCENDING);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected_asc,
+    sorted_values(gathered_values(order->view())->view(), cudf::order::ASCENDING)
+      ->view()
+      .column(0));
 }


### PR DESCRIPTION
## Description

Add a cub::DeviceTopK fast path for eligible inputs with at most 64 segments, an average
covered segment size of at least 16K rows, and k at most 1/8 of that average.

The fast path selects each segment independently, reuses temporary storage, and sorts only
the selected indices to preserve the existing per-segment ordering. Empty segments and
segments with at most k rows are handled without CUB.

Inputs with nulls, floating-point values, unsupported types, more than 64 segments,
an average covered segment size below 16K rows, or k greater than one eighth of that
average continue to use the existing sort-based implementation. Selection among equal
values at the k-th boundary remains unspecified.

This follows the pattern of the non-segmented `top_k` (#21582), which routes the same
eligible inputs to `cub::DeviceTopK` and falls back to the sort-based path for everything
else.

## Performance

GB10, 16.8M rows, k=100:

| Segments | Rows per segment | Before | After |
|---:|---:|---:|---:|
| 4 | 4.2M | 106.92 ms | 0.626 ms |
| 16 | 1.0M | 93.01 ms | 0.919 ms |
| 64 | 262K | 84.14 ms | 1.85 ms |

Peak temporary memory decreased from 192 MiB to under 1 MiB. FLOAT32 remains on the
fallback path and showed no change.

The guard bounds come from crossover measurements (INT32, 16 segments unless noted; the
sort-based path is k-independent):

* Average segment size: at 8K rows per segment the sort-based path wins (180 µs vs
  452 µs); at 16K the fast path wins 4x (465 µs vs 1.84 ms, also 3.4x at 64 segments).
  The segmented sort's small-segment kernels cut off between 8K and 16K.
* k: at k = avg/8 the fast path wins at least 3.4x at every measured point (16K-128K
  rows per segment, 16 and 64 segments); at k = avg/2 the margin shrinks to 1.2-1.7x,
  since the post-selection sort approaches the full sort this path avoids.
* Wider keys: with 8-byte keys (timestamp_s) the margins narrow but the fast path still
  wins at both bounds: 1.8x at 16K rows per segment and 1.5x at k = avg/8 (32K rows per
  segment). Below 16K it falls back, which errs toward the unchanged sort-based path.

A `segmented_top_k_few_large` benchmark is added (num_segments = {4, 16, 64}, segment =
{16K, 128K, 1M}, k = {100, 2048}) so the fast path's representative shapes and the guard
bounds stay measurable for future re-evaluation.


## Implementation note
h_out_offsets is currently copied with the synchronous make_device_uvector because it is stack-local, while the existing asynchronous H2D copy requires the source to remain alive until the stream reaches the copy. Once #23561, or an equivalent source-lifetime-safe API, is merged, this can switch to make_device_uvector_async, eliminating the extra stream synchronization and potentially improving  latency and overlap.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
