### PR TITLE
Make is_supported_cast fail for variable-width inputs

### DIFF
--- a/cpp/include/cudf/unary.hpp
+++ b/cpp/include/cudf/unary.hpp
@@ -117,7 +117,7 @@ std::unique_ptr<cudf::column> is_valid(
  * @param mr Device memory resource used to allocate the returned column's device memory
  *
  * @returns Column of same size as `input` containing result of the cast operation
- * @throw cudf::logic_error if `out_type` is not a fixed-width type
+ * @throw cudf::logic_error if `input` or `out_type` is not a fixed-width type
  */
 std::unique_ptr<column> cast(
   column_view const& input,

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -118,8 +118,7 @@ struct fixed_point_unary_cast {
 template <typename From, typename To>
 constexpr inline auto is_supported_non_fixed_point_cast()
 {
-  return cudf::is_fixed_width<From>() &&
-         cudf::is_fixed_width<To>() &&
+  return cudf::is_fixed_width<From>() && cudf::is_fixed_width<To>() &&
          // Disallow fixed_point here (requires different specialization)
          !(cudf::is_fixed_point<From>() || cudf::is_fixed_point<To>()) &&
          // Disallow conversions between timestamps and numeric

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -118,7 +118,8 @@ struct fixed_point_unary_cast {
 template <typename From, typename To>
 constexpr inline auto is_supported_non_fixed_point_cast()
 {
-  return cudf::is_fixed_width<To>() &&
+  return cudf::is_fixed_width<From>() &&
+         cudf::is_fixed_width<To>() &&
          // Disallow fixed_point here (requires different specialization)
          !(cudf::is_fixed_point<From>() || cudf::is_fixed_point<To>()) &&
          // Disallow conversions between timestamps and numeric

--- a/cpp/tests/unary/cast_tests.cpp
+++ b/cpp/tests/unary/cast_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/unary/cast_tests.cpp
+++ b/cpp/tests/unary/cast_tests.cpp
@@ -201,10 +201,13 @@ inline auto make_data_type()
   return cudf::data_type{cudf::type_to_id<T>()};
 }
 
-TEST(IsSupportedCast, StringToInt32IsUnsupported)
+TEST(IsSupportedCast, UnsupportedTypes)
 {
-  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::STRING},
-                                       cudf::data_type{cudf::type_id::INT32}));
+  auto const to_int32 = cudf::data_type{cudf::type_id::INT32};
+  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::STRING}, to_int32));
+  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::LIST}, to_int32));
+  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::STRUCT}, to_int32));
+  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::DICTIONARY32}, to_int32));
 }
 
 struct CastTimestampsSimple : public cudf::test::BaseFixture {};

--- a/cpp/tests/unary/cast_tests.cpp
+++ b/cpp/tests/unary/cast_tests.cpp
@@ -201,6 +201,12 @@ inline auto make_data_type()
   return cudf::data_type{cudf::type_to_id<T>()};
 }
 
+TEST(IsSupportedCast, StringToInt32IsUnsupported)
+{
+  EXPECT_FALSE(cudf::is_supported_cast(cudf::data_type{cudf::type_id::STRING},
+                                       cudf::data_type{cudf::type_id::INT32}));
+}
+
 struct CastTimestampsSimple : public cudf::test::BaseFixture {};
 
 TEST_F(CastTimestampsSimple, IsIdempotent)


### PR DESCRIPTION
## Description
cudf is_supported_cast returns true for string inputs. But cudf cast operator does not support variable-width types.

This leads to an issue in velox (https://github.com/facebookincubator/velox/issues/18450) where the engine thinks it can
use cudf cast to convert varchars to ints, though that will ultimately need an exception. Velox will eventually need to use
a different strings API for this conversion, but at least changing is_supported_cast will allow it to no longer route conversions
through this path.


## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
