### PR TITLE
Update CODEOWNERS team names for rapidsai->NVIDIA migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,41 @@
 #cpp code owners
-cpp/                 @rapidsai/cudf-cpp-codeowners
-python/cudf/udf_cpp/ @rapidsai/cudf-cpp-codeowners
+cpp/                 @NVIDIA/cudf-cpp-codeowners
+python/cudf/udf_cpp/ @NVIDIA/cudf-cpp-codeowners
 
 #libcudf_streaming code owners (order matters, this supersedes cpp/ for files in this directory)
-cpp/libcudf_streaming/  @rapidsai/rapidsmpf-cpp-codeowners
+cpp/libcudf_streaming/  @NVIDIA/rapidsmpf-cpp-codeowners
 
 #python code owners
-python/            @rapidsai/cudf-python-codeowners
-notebooks/         @rapidsai/cudf-python-codeowners
-python/dask_cudf/  @rapidsai/cudf-dask-codeowners
-python/cudf_polars/ @rapidsai/cudf-polars-codeowners
-python/cudf_streaming/ @rapidsai/rapidsmpf-python-codeowners
+python/            @NVIDIA/cudf-python-codeowners
+notebooks/         @NVIDIA/cudf-python-codeowners
+python/dask_cudf/  @NVIDIA/cudf-dask-codeowners
+python/cudf_polars/ @NVIDIA/cudf-polars-codeowners
+python/cudf_streaming/ @NVIDIA/rapidsmpf-python-codeowners
 
 #cmake code owners
-CMakeLists.txt @rapidsai/cudf-cmake-codeowners
-**/cmake/      @rapidsai/cudf-cmake-codeowners
-*.cmake        @rapidsai/cudf-cmake-codeowners
-cpp/libcudf_streaming/CMakeLists.txt @rapidsai/rapidsmpf-cmake-codeowners
-cpp/libcudf_streaming/**/cmake/      @rapidsai/rapidsmpf-cmake-codeowners
-cpp/libcudf_streaming/*.cmake        @rapidsai/rapidsmpf-cmake-codeowners
+CMakeLists.txt @NVIDIA/cudf-cmake-codeowners
+**/cmake/      @NVIDIA/cudf-cmake-codeowners
+*.cmake        @NVIDIA/cudf-cmake-codeowners
+cpp/libcudf_streaming/CMakeLists.txt @NVIDIA/rapidsmpf-cmake-codeowners
+cpp/libcudf_streaming/**/cmake/      @NVIDIA/rapidsmpf-cmake-codeowners
+cpp/libcudf_streaming/*.cmake        @NVIDIA/rapidsmpf-cmake-codeowners
 
 #java code owners
-java/              @rapidsai/cudf-java-codeowners
+java/              @NVIDIA/cudf-java-codeowners
 
 #CI code owners
-/.github/                @rapidsai/ci-codeowners
-/ci/                     @rapidsai/ci-codeowners
-/.coderabbit.yaml        @rapidsai/ci-codeowners
-/.yamllint.yaml          @rapidsai/ci-codeowners
+/.github/                @NVIDIA/adi-ci-codeowners
+/ci/                     @NVIDIA/adi-ci-codeowners
+/.coderabbit.yaml        @NVIDIA/adi-ci-codeowners
+/.yamllint.yaml          @NVIDIA/adi-ci-codeowners
 
 #packaging code owners
-/.pre-commit-config.yaml @rapidsai/packaging-codeowners
-/.devcontainer/          @rapidsai/packaging-codeowners
-/conda/                  @rapidsai/packaging-codeowners
-dependencies.yaml        @rapidsai/packaging-codeowners
-/build.sh                @rapidsai/packaging-codeowners
-pyproject.toml           @rapidsai/packaging-codeowners
+/.pre-commit-config.yaml @NVIDIA/adi-packaging-codeowners
+/.devcontainer/          @NVIDIA/adi-packaging-codeowners
+/conda/                  @NVIDIA/adi-packaging-codeowners
+dependencies.yaml        @NVIDIA/adi-packaging-codeowners
+/build.sh                @NVIDIA/adi-packaging-codeowners
+pyproject.toml           @NVIDIA/adi-packaging-codeowners
 
 # Ops code owners
-/SECURITY.md             @rapidsai/ops-codeowners
+/SECURITY.md             @NVIDIA/adi-ops-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,7 +301,7 @@ repos:
           )
       - id: verify-alpha-spec
       - id: verify-codeowners
-        args: [--fix, --project-prefix=cudf]
+        args: [--fix, --org=NVIDIA, --project-prefix=cudf]
       - id: verify-hardcoded-version
         exclude: |
           (?x)


### PR DESCRIPTION
XREF: https://github.com/rapidsai/build-infra/issues/374

CODEOWNER teams must be in the same org as the repo. Let's update them now that we've migrated to the NVIDIA org.