### PR TITLE
[cudf] Require explicit stream and MR for test `make_null_mask`

### DIFF
--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -294,11 +294,10 @@ std::pair<std::vector<bitmask_type>, cudf::size_type> make_null_mask_vector(Vali
  * element in `[begin,end)` that evaluated to `true`.
  */
 template <typename ValidityIterator>
-std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(
-  ValidityIterator begin,
-  ValidityIterator end,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref())
+std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(ValidityIterator begin,
+                                                              ValidityIterator end,
+                                                              rmm::cuda_stream_view stream,
+                                                              cudf::memory_resources mr)
 {
   auto [null_mask, null_count] = make_null_mask_vector(begin, end);
   rmm::device_buffer d_mask{null_mask.data(),

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -429,17 +429,19 @@ TEST_F(CopyBitmaskTest, NullPtr)
 
 TEST_F(CopyBitmaskTest, TestZeroOffset)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::vector<int> validity_bit(1000);
   for (auto& m : validity_bit) {
     m = this->generate();
   }
-  auto input_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end()));
+  auto input_mask = std::get<0>(
+    cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end(), stream, mr));
 
   int begin_bit         = 0;
   int end_bit           = 800;
   auto gold_splice_mask = std::get<0>(cudf::test::detail::make_null_mask(
-    validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit));
+    validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit, stream, mr));
 
   auto splice_mask = cudf::copy_bitmask(
     static_cast<cudf::bitmask_type const*>(input_mask.data()), begin_bit, end_bit);
@@ -452,17 +454,19 @@ TEST_F(CopyBitmaskTest, TestZeroOffset)
 
 TEST_F(CopyBitmaskTest, TestNonZeroOffset)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::vector<int> validity_bit(1000);
   for (auto& m : validity_bit) {
     m = this->generate();
   }
-  auto input_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end()));
+  auto input_mask = std::get<0>(
+    cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end(), stream, mr));
 
   int begin_bit         = 321;
   int end_bit           = 998;
   auto gold_splice_mask = std::get<0>(cudf::test::detail::make_null_mask(
-    validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit));
+    validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit, stream, mr));
 
   auto splice_mask = cudf::copy_bitmask(
     static_cast<cudf::bitmask_type const*>(input_mask.data()), begin_bit, end_bit);
@@ -475,6 +479,8 @@ TEST_F(CopyBitmaskTest, TestNonZeroOffset)
 
 TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::data_type t{cudf::type_id::INT32};
   cudf::size_type num_elements = 1001;
   std::vector<int> validity_bit(num_elements);
@@ -482,7 +488,7 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
     m = this->generate();
   }
   auto [gold_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end());
+    cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end(), stream, mr);
 
   rmm::device_buffer copy_mask{gold_mask, cudf::get_default_stream()};
   cudf::column original{t,
@@ -517,21 +523,23 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
 
 TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorDiscontiguous)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::data_type t{cudf::type_id::INT32};
   cudf::size_type num_elements = 1001;
   std::vector<int> validity_bit(num_elements);
   for (auto& m : validity_bit) {
     m = this->generate();
   }
-  auto gold_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end()));
+  auto gold_mask = std::get<0>(
+    cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end(), stream, mr));
   std::vector<cudf::size_type> split{0, 104, 128, 152, 311, 491, 583, 734, 760, num_elements};
 
   std::vector<cudf::column> cols;
   std::vector<cudf::column_view> views;
   for (unsigned i = 0; i < split.size() - 1; i++) {
     auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
-      validity_bit.begin() + split[i], validity_bit.begin() + split[i + 1]);
+      validity_bit.begin() + split[i], validity_bit.begin() + split[i + 1], stream, mr);
     cols.emplace_back(
       t,
       split[i + 1] - split[i],
@@ -550,6 +558,8 @@ struct MergeBitmaskTest : public cudf::test::BaseFixture {};
 
 TEST_F(MergeBitmaskTest, TestBitmaskAnd)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {0, 1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {1, 1, 0, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255});
@@ -569,8 +579,8 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   EXPECT_EQ(result3_null_count, gold_null_count);
 
   auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
-  auto odd =
-    std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows()));
+  auto odd         = std::get<0>(
+    cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows(), stream, mr));
 
   EXPECT_EQ(nullptr, result1_mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
@@ -581,6 +591,8 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
 
 TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {0, 1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {1, 1, 0, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255}, {1, 1, 1, 1, 1});
@@ -608,8 +620,8 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
     EXPECT_EQ(result_masks.size(), 1);
     EXPECT_EQ(result_null_count[0], 3);
     auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
-    auto const odd =
-      std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
+    auto const odd   = std::get<0>(
+      cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows, stream, mr));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(
       result_masks[0]->data(), odd.data(), cudf::num_bitmask_words(num_rows));
   }
@@ -623,8 +635,8 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
     EXPECT_EQ(result_masks.size(), 1);
     EXPECT_EQ(result_null_count[0], 3);
     auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
-    auto const odd =
-      std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
+    auto const odd   = std::get<0>(
+      cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows, stream, mr));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(
       result_masks[0]->data(), odd.data(), cudf::num_bitmask_words(num_rows));
   }
@@ -632,6 +644,8 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
 
 TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndMultipleSegments)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {0, 1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {1, 1, 0, 1, 0});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255}, {1, 1, 1, 1, 1});
@@ -664,8 +678,8 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndMultipleSegments)
     EXPECT_EQ(result_null_count[0], 3);
     EXPECT_EQ(result_null_count[1], 0);
     auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
-    auto const odd =
-      std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
+    auto const odd   = std::get<0>(
+      cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows, stream, mr));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(
       result_masks[0]->data(), odd.data(), cudf::num_bitmask_words(num_rows));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(result_masks[1]->data(),
@@ -676,6 +690,8 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndMultipleSegments)
 
 TEST_F(MergeBitmaskTest, TestBitmaskOr)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {1, 1, 0, 0, 1});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {0, 0, 1, 0, 1});
   cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255});
@@ -693,8 +709,8 @@ TEST_F(MergeBitmaskTest, TestBitmaskOr)
   EXPECT_EQ(result3_null_count, 0);
 
   auto all_but_index3 = cudf::test::iterators::null_at(3);
-  auto null3          = std::get<0>(
-    cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows()));
+  auto null3          = std::get<0>(cudf::test::detail::make_null_mask(
+    all_but_index3, all_but_index3 + input2.num_rows(), stream, mr));
 
   EXPECT_EQ(nullptr, result1_mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(

--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -54,9 +54,11 @@ TEST_F(ValidIfTest, InvalidRange)
 
 TEST_F(ValidIfTest, OddsValid)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto iter         = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
+  auto expected     = cudf::test::detail::make_null_mask(iter, iter + 10000, stream, mr);
+  auto actual       = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        odds_valid{},
                                        cudf::get_default_stream(),
@@ -68,9 +70,11 @@ TEST_F(ValidIfTest, OddsValid)
 
 TEST_F(ValidIfTest, AllValid)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, all_valid{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto iter         = cudf::detail::make_counting_transform_iterator(0, all_valid{});
+  auto expected     = cudf::test::detail::make_null_mask(iter, iter + 10000, stream, mr);
+  auto actual       = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        all_valid{},
                                        cudf::get_default_stream(),
@@ -82,9 +86,11 @@ TEST_F(ValidIfTest, AllValid)
 
 TEST_F(ValidIfTest, AllNull)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, all_null{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto iter         = cudf::detail::make_counting_transform_iterator(0, all_null{});
+  auto expected     = cudf::test::detail::make_null_mask(iter, iter + 10000, stream, mr);
+  auto actual       = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        all_null{},
                                        cudf::get_default_stream(),

--- a/cpp/tests/column/factories_test.cpp
+++ b/cpp/tests/column/factories_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -689,10 +689,12 @@ TEST_F(ListsZeroLengthColumnTest, MixedTypes)
 
 TEST_F(ListsZeroLengthColumnTest, SuperimposeNulls)
 {
-  using FCW      = cudf::test::fixed_width_column_wrapper<int32_t>;
-  using StringCW = cudf::test::strings_column_wrapper;
-  using LCW      = cudf::test::lists_column_wrapper<int32_t>;
-  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using FCW         = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using StringCW    = cudf::test::strings_column_wrapper;
+  using LCW         = cudf::test::lists_column_wrapper<int32_t>;
+  using offset_t    = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
 
   auto const lists = [&] {
     auto child = this
@@ -702,8 +704,9 @@ TEST_F(ListsZeroLengthColumnTest, SuperimposeNulls)
                    .release();
     auto offsets = offset_t{0, 3, 3, 5}.release();
 
-    auto const valid_iter        = cudf::test::iterators::null_at(2);
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valid_iter, valid_iter + 3);
+    auto const valid_iter = cudf::test::iterators::null_at(2);
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(valid_iter, valid_iter + 3, stream, mr);
 
     auto tmp = cudf::make_lists_column(
       3, std::move(offsets), std::move(child), null_count, std::move(null_mask));

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -770,7 +770,9 @@ struct StructsColumnTest : public cudf::test::BaseFixture {};
 
 TEST_F(StructsColumnTest, ConcatenateStructs)
 {
-  auto count_iter = cuda::counting_iterator<int>{0};
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto count_iter   = cuda::counting_iterator<int>{0};
 
   // 1. String "names" column.
   std::vector<std::vector<std::string>> names(
@@ -813,7 +815,7 @@ TEST_F(StructsColumnTest, ConcatenateStructs)
   expected_children.push_back(cudf::concatenate(is_human_col_vec));
   std::vector<bool> struct_validity({true, false, true, true, true, false});
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
+    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end(), stream, mr);
   auto expected =
     make_structs_column(6, std::move(expected_children), null_count, std::move(null_mask));
 

--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -314,7 +314,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
 
 TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
   using strings = cudf::test::strings_column_wrapper;
@@ -334,8 +336,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   auto lhs_structs = structs{{lhs_ints, lhs_strings}}.release();
   auto lhs_offsets = offsets{0, 2, 4, 6, 10, 10}.release();
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5);
-  auto const lhs               = cudf::make_lists_column(
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5, stream, mr);
+  auto const lhs = cudf::make_lists_column(
     5, std::move(lhs_offsets), std::move(lhs_structs), null_count, std::move(null_mask));
 
   auto rhs_ints = ints{{0, 11, 22, 33, 44, 55, 66, 77, 88, 99}, null_at_6};
@@ -344,8 +347,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   auto rhs_structs = structs{{rhs_ints, rhs_strings}, null_at_8};
   auto rhs_offsets = offsets{0, 0, 4, 6, 8, 10};
 
-  std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(null_at_0, null_at_0 + 5);
-  auto const rhs                  = cudf::make_lists_column(
+  std::tie(null_mask, null_count) =
+    cudf::test::detail::make_null_mask(null_at_0, null_at_0 + 5, stream, mr);
+  auto const rhs = cudf::make_lists_column(
     5, rhs_offsets.release(), rhs_structs.release(), null_count, std::move(null_mask));
 
   auto selector_column = bools{1, 0, 1, 0, 1}.release();
@@ -359,8 +363,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   auto expected_structs = structs{{expected_ints, expected_strings}};
   auto expected_offsets = offsets{0, 2, 6, 8, 10, 10};
 
-  std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5);
-  auto const expected             = cudf::make_lists_column(
+  std::tie(null_mask, null_count) =
+    cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5, stream, mr);
+  auto const expected = cudf::make_lists_column(
     5, expected_offsets.release(), expected_structs.release(), null_count, std::move(null_mask));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result_column->view(), expected->view());

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -262,6 +262,8 @@ std::vector<std::unique_ptr<cudf::column>> generate_struct_of_list()
 
 std::vector<std::unique_ptr<cudf::column>> generate_list_of_struct()
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = cudf::get_current_device_resource_ref();
   // 1. String "names" column.
   std::vector<std::string> names{"Vimes",
                                  "Carrot",
@@ -326,8 +328,8 @@ std::vector<std::unique_ptr<cudf::column>> generate_list_of_struct()
   std::vector<bool> list_validity{true, true, true, true, true, false, true, false, true};
 
   cudf::test::fixed_width_column_wrapper<int> offsets{0, 1, 4, 5, 7, 7, 10, 13, 14, 16};
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_validity.begin(), list_validity.begin() + 9);
+  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+    list_validity.begin(), list_validity.begin() + 9, stream, mr);
   auto list = [&] {
     auto tmp = cudf::make_lists_column(
       9, offsets.release(), struct_column.release(), null_count, std::move(null_mask));

--- a/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
+++ b/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -336,6 +336,8 @@ TEST_F(PurgeNonEmptyNullsTest, ListOfStrings)
 // List<string>.
 TEST_F(PurgeNonEmptyNullsTest, UnsanitizedListOfUnsanitizedStrings)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto strings =
     cudf::test::strings_column_wrapper{
       {"1", "22", "3", "44", "5", "66", "7", "8888", "9", "1010"},  //<--- "8888" will be
@@ -359,8 +361,9 @@ TEST_F(PurgeNonEmptyNullsTest, UnsanitizedListOfUnsanitizedStrings)
   );
 
   // Construct a list column from the strings column.
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(no_nulls(), no_nulls() + 4);
-  auto const lists             = cudf::make_lists_column(4,
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(no_nulls(), no_nulls() + 4, stream, mr);
+  auto const lists = cudf::make_lists_column(4,
                                              offsets_col_t{0, 4, 5, 7, 10}.release(),
                                              std::move(strings),
                                              null_count,
@@ -409,6 +412,8 @@ TEST_F(PurgeNonEmptyNullsTest, UnsanitizedListOfUnsanitizedStrings)
 // Struct<List<T>>.
 TEST_F(PurgeNonEmptyNullsTest, StructOfList)
 {
+  auto const stream        = cudf::test::get_default_stream();
+  auto mr                  = this->mr();
   auto const structs_input = [] {
     auto child = LCW<T>{{{{1, 2, 3, 4}, null_at(2)},
                          {5},
@@ -420,7 +425,8 @@ TEST_F(PurgeNonEmptyNullsTest, StructOfList)
   }();
   auto [null_mask, null_count] = [&] {
     auto const valid_iter = null_at(2);
-    return cudf::test::detail::make_null_mask(valid_iter, valid_iter + structs_input->size());
+    return cudf::test::detail::make_null_mask(
+      valid_iter, valid_iter + structs_input->size(), stream, mr);
   }();
 
   // Manually set the null mask for the columns, leaving the null at list index 2 unsanitized.

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -150,14 +150,16 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfNullableFixedWidth)
 
 TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto src_child = cudf::test::fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8},
                                                                       {1, 1, 1, 0, 1, 1, 1}};
 
   auto src_list_validity = cudf::test::iterators::null_at(2);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(src_list_validity, src_list_validity + 3);
+    cudf::test::detail::make_null_mask(src_list_validity, src_list_validity + 3, stream, mr);
   // One null list row, and one row with nulls.
   auto src_list_column = cudf::make_lists_column(
     3,
@@ -180,7 +182,7 @@ TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
 
   auto expected_validity = cudf::test::iterators::null_at(5);
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 7);
+    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 7, stream, mr);
   auto expected_lists_column = cudf::make_lists_column(
     7,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
@@ -325,13 +327,16 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 
 TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto src_strings_column =
     cudf::test::strings_column_wrapper{{"all", "the", "leaves", "", "brown", "", "dreaming"},
                                        {true, true, true, false, true, false, true}};
 
-  auto src_validity            = cudf::test::iterators::null_at(1);
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(src_validity, src_validity + 3);
-  auto src_list_column         = cudf::make_lists_column(
+  auto src_validity = cudf::test::iterators::null_at(1);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(src_validity, src_validity + 3, stream, mr);
+  auto src_list_column = cudf::make_lists_column(
     3,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
     src_strings_column.release(),
@@ -369,7 +374,7 @@ TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
 
   auto expected_validity = cudf::test::iterators::null_at(4);
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 6);
+    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 6, stream, mr);
   auto expected_lists = cudf::make_lists_column(
     6,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
@@ -838,6 +843,8 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 
 TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 {
+  auto const stream     = cudf::test::get_default_stream();
+  auto mr               = this->mr();
   using T               = TypeParam;
   using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
   using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
@@ -866,7 +873,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   auto source_list_null_mask_begin = cudf::test::iterators::null_at(2);
 
   auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
-    source_list_null_mask_begin, source_list_null_mask_begin + 3);
+    source_list_null_mask_begin, source_list_null_mask_begin + 3, stream, mr);
   auto source_lists = cudf::make_lists_column(3,
                                               offsets_column{0, 4, 7, 7}.release(),
                                               source_structs.release(),
@@ -933,7 +940,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   auto expected_lists_null_mask_begin = cudf::test::iterators::null_at(4);
 
   std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
-    expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6);
+    expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6, stream, mr);
   auto expected_lists = cudf::make_lists_column(6,
                                                 offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
                                                 expected_structs.release(),

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -955,6 +955,8 @@ void split_structs(bool include_validity, SplitFunc Split, CompareFunc Compare, 
 template <typename SplitFunc, typename CompareFunc>
 void split_structs_no_children(SplitFunc Split, CompareFunc Compare, bool split = true)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = cudf::get_current_device_resource_ref();
   // no nulls
   {
     auto struct_column = cudf::make_structs_column(4, {}, 0, rmm::device_buffer{});
@@ -978,14 +980,14 @@ void split_structs_no_children(SplitFunc Split, CompareFunc Compare, bool split 
   // all nulls
   {
     std::vector<bool> struct_validity{false, false, false, false};
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      struct_validity.begin(), struct_validity.end(), stream, mr);
     auto struct_column = cudf::make_structs_column(4, {}, null_count, std::move(null_mask));
 
     if (split) {
       std::vector<bool> expected_validity{false, false};
-      std::tie(null_mask, null_count) =
-        cudf::test::detail::make_null_mask(expected_validity.begin(), expected_validity.end());
+      std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
+        expected_validity.begin(), expected_validity.end(), stream, mr);
       auto expected = cudf::make_structs_column(2, {}, null_count, std::move(null_mask));
 
       // split
@@ -1026,14 +1028,14 @@ void split_structs_no_children(SplitFunc Split, CompareFunc Compare, bool split 
   // all nulls, empty output column
   {
     std::vector<bool> struct_validity{false, false, false, false};
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      struct_validity.begin(), struct_validity.end(), stream, mr);
     auto struct_column = cudf::make_structs_column(4, {}, null_count, std::move(null_mask));
 
     if (split) {
       std::vector<bool> expected_validity0{false, false, false, false};
-      std::tie(null_mask, null_count) =
-        cudf::test::detail::make_null_mask(expected_validity0.begin(), expected_validity0.end());
+      std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
+        expected_validity0.begin(), expected_validity0.end(), stream, mr);
       auto expected0 = cudf::make_structs_column(4, {}, null_count, std::move(null_mask));
 
       auto expected1 = cudf::make_structs_column(0, {}, 0, rmm::device_buffer{});
@@ -1126,6 +1128,9 @@ void split_nested_struct_of_list(SplitFunc Split, CompareFunc Compare, bool spli
 template <typename SplitFunc, typename CompareFunc>
 void split_nested_list_of_structs(SplitFunc Split, CompareFunc Compare, bool split = true)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = cudf::get_current_device_resource_ref();
+
   // List<Struct<List<>>
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
@@ -1259,7 +1264,7 @@ void split_nested_list_of_structs(SplitFunc Split, CompareFunc Compare, bool spl
                                                                 outer_offsets.end());
   std::vector<bool> outer_validity{true, true, true, false, true, true, false};
   auto [outer_null_mask, outer_null_count] =
-    cudf::test::detail::make_null_mask(outer_validity.begin(), outer_validity.end());
+    cudf::test::detail::make_null_mask(outer_validity.begin(), outer_validity.end(), stream, mr);
   auto outer_list = [&] {
     auto tmp = make_lists_column(static_cast<cudf::size_type>(outer_validity.size()),
                                  outer_offsets_col.release(),
@@ -1675,6 +1680,8 @@ TEST_F(ContiguousSplitUntypedTest, ProgressiveSizesChunked)
 
 TEST_F(ContiguousSplitUntypedTest, ValidityRepartition)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // it is tricky to actually get the internal repartitioning/load-balancing code to add new splits
   // inside a validity buffer.  Under almost all situations, the fraction of bytes that validity
   // represents is so small compared to the bytes for all other data, that those buffers end up not
@@ -1686,7 +1693,8 @@ TEST_F(ContiguousSplitUntypedTest, ValidityRepartition)
   });
   cudf::size_type const num_rows = 2000000;
   auto col                       = cudf::sequence(num_rows, cudf::numeric_scalar<int8_t>{0});
-  auto [null_mask, null_count]   = cudf::test::detail::make_null_mask(rvalids, rvalids + num_rows);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(rvalids, rvalids + num_rows, stream, mr);
   col->set_null_mask(std::move(null_mask), null_count);
 
   cudf::table_view t({*col});
@@ -1701,13 +1709,16 @@ TEST_F(ContiguousSplitUntypedTest, ValidityRepartition)
 
 TEST_F(ContiguousSplitUntypedTest, ValidityRepartitionChunked)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   srand(0);
   auto rvalids                   = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     return static_cast<float>(rand()) / static_cast<float>(RAND_MAX) < 0.5f ? 0 : 1;
   });
   cudf::size_type const num_rows = 2000000;
   auto col                       = cudf::sequence(num_rows, cudf::numeric_scalar<int8_t>{0});
-  auto [null_mask, null_count]   = cudf::test::detail::make_null_mask(rvalids, rvalids + num_rows);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(rvalids, rvalids + num_rows, stream, mr);
   col->set_null_mask(std::move(null_mask), null_count);
 
   cudf::table_view t({*col});

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -319,11 +319,13 @@ TYPED_TEST(typed_groupby_rank_scan_test, nestedStructs)
 
 TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto constexpr num_rows = 12;
 
-  auto get_struct_column = [] {
+  auto get_struct_column = [&] {
     auto nums_member =
       cudf::test::fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
     auto strings_member = cudf::test::strings_column_wrapper{
@@ -332,7 +334,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
     // Reset null-mask, a posteriori. Nulls will not be pushed down to children.
     auto const null_iter = nulls_at({1, 2, 11});
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_iter, null_iter + num_rows);
+      cudf::test::detail::make_null_mask(null_iter, null_iter + num_rows, stream, mr);
     struct_column->set_null_mask(std::move(null_mask), null_count);
     return struct_column;
   };

--- a/cpp/tests/groupby/sum_overflow_tests.cpp
+++ b/cpp/tests/groupby/sum_overflow_tests.cpp
@@ -189,8 +189,10 @@ TYPED_TEST(groupby_sum_overflow_test, ZeroValidKeys)
 
 TYPED_TEST(groupby_sum_overflow_test, ZeroValidValues)
 {
-  using K = int32_t;
-  using V = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using K           = int32_t;
+  using V           = TypeParam;
 
   cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
   cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, cudf::test::iterators::all_nulls());
@@ -206,7 +208,7 @@ TYPED_TEST(groupby_sum_overflow_test, ZeroValidValues)
   children.push_back(overflow_col.release());
   std::vector<int> validity{0};  // null struct
   auto [validity_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
   auto expect_vals =
     cudf::create_structs_hierarchy(1, std::move(children), null_count, std::move(validity_mask));
 
@@ -221,8 +223,10 @@ TYPED_TEST(groupby_sum_overflow_test, ZeroValidValues)
 
 TYPED_TEST(groupby_sum_overflow_test, NullKeysAndValues)
 {
-  using K = int32_t;
-  using V = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using K           = int32_t;
+  using V           = TypeParam;
 
   cudf::test::fixed_width_column_wrapper<K> keys(
     {1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
@@ -244,7 +248,7 @@ TYPED_TEST(groupby_sum_overflow_test, NullKeysAndValues)
   children.push_back(overflow_col.release());
   std::vector<int> validity{1, 1, 1, 0};
   auto [validity_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
   auto expect_vals =
     cudf::create_structs_hierarchy(4, std::move(children), null_count, std::move(validity_mask));
 

--- a/cpp/tests/hashing/murmurhash3_x86_32_test.cpp
+++ b/cpp/tests/hashing/murmurhash3_x86_32_test.cpp
@@ -192,26 +192,28 @@ TEST_F(MurmurHashTest, NullableList)
 
 TEST_F(MurmurHashTest, ListOfStruct)
 {
-  auto col1 = cudf::test::fixed_width_column_wrapper<int32_t>{
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto col1         = cudf::test::fixed_width_column_wrapper<int32_t>{
     {-1, -1, 0, 2, 2, 2, 1, 2, 0, 2, 0, 2, 0, 2, 0, 0, 1, 2},
     {true,
-     true,
-     true,
-     true,
-     true,
-     false,
-     true,
-     true,
-     true,
-     true,
-     true,
-     true,
-     true,
-     true,
-     true,
-     true,
-     false,
-     false}};
+             true,
+             true,
+             true,
+             true,
+             false,
+             true,
+             true,
+             true,
+             true,
+             true,
+             true,
+             true,
+             true,
+             true,
+             true,
+             false,
+             false}};
   auto col2 = cudf::test::strings_column_wrapper{
     {"x", "x", "a", "a", "b", "b", "a", "b", "a", "b", "a", "c", "a", "c", "a", "c", "b", "b"},
     {true,
@@ -273,7 +275,7 @@ TEST_F(MurmurHashTest, ListOfStruct)
                                          true,
                                          true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::make_lists_column(
     17, offsets.release(), struct_col.release(), null_count, std::move(null_mask));
 
@@ -323,6 +325,8 @@ TEST_F(MurmurHashTest, ListOfStruct)
 
 TEST_F(MurmurHashTest, ListOfEmptyStruct)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // []
   // []
   // Null
@@ -340,7 +344,7 @@ TEST_F(MurmurHashTest, ListOfEmptyStruct)
   auto struct_validity = std::vector<bool>{
     false, false, false, false, false, false, false, false, true, true, true, true, true, true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
+    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end(), stream, mr);
   auto struct_col = cudf::make_structs_column(14, {}, null_count, std::move(null_mask));
 
   auto offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>{
@@ -348,7 +352,7 @@ TEST_F(MurmurHashTest, ListOfEmptyStruct)
   auto list_nullmask = std::vector<bool>{
     true, true, false, false, true, true, true, true, true, true, true, true, true};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::make_lists_column(
     13, offsets.release(), std::move(struct_col), null_count, std::move(null_mask));
 
@@ -372,6 +376,8 @@ TEST_F(MurmurHashTest, ListOfEmptyStruct)
 
 TEST_F(MurmurHashTest, EmptyDeepList)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // List<List<int>>, where all lists are empty
   // []
   // []
@@ -384,7 +390,7 @@ TEST_F(MurmurHashTest, EmptyDeepList)
   auto offsets       = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 0, 0, 0};
   auto list_nullmask = std::vector<bool>{true, true, false, false};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::make_lists_column(
     4, offsets.release(), list1.release(), null_count, std::move(null_mask));
 

--- a/cpp/tests/io/experimental/hybrid_scan_common.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_common.cpp
@@ -91,6 +91,8 @@ std::unique_ptr<cudf::column> make_list_str_column(std::mt19937& gen,
                                                    bool is_str_nullable,
                                                    bool is_list_nullable)
 {
+  auto stream                    = cudf::get_default_stream();
+  auto mr                        = cudf::get_current_device_resource_ref();
   auto constexpr num_rows        = num_ordered_rows;
   auto constexpr string_per_row  = 3;
   auto constexpr num_string_rows = num_rows * string_per_row;
@@ -116,7 +118,7 @@ std::unique_ptr<cudf::column> make_list_str_column(std::mt19937& gen,
     cudf::detail::make_counting_transform_iterator(0, [&](int index) { return index % 100; });
   auto [null_mask, null_count] = [&]() {
     if (is_list_nullable) {
-      return cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+      return cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
     } else {
       return std::make_pair(rmm::device_buffer{}, 0);
     }

--- a/cpp/tests/io/experimental/hybrid_scan_common.hpp
+++ b/cpp/tests/io/experimental/hybrid_scan_common.hpp
@@ -16,6 +16,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>

--- a/cpp/tests/io/experimental/hybrid_scan_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_test.cpp
@@ -443,6 +443,8 @@ TEST_F(HybridScanTest, MaterializeListsOfStrings)
 
 TEST_F(HybridScanTest, ConsecutivePrunedPageOffsets)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::mt19937 gen(0x5ca1e);
   auto constexpr num_rows = num_ordered_rows;
 
@@ -472,9 +474,7 @@ TEST_F(HybridScanTest, ConsecutivePrunedPageOffsets)
     cudf::io::write_parquet(write_options);
   }
 
-  auto const stream = cudf::get_default_stream();
-  auto const mr     = cudf::get_current_device_resource_ref();
-  auto aligned_mr   = rmm::mr::aligned_resource_adaptor(mr, bloom_filter_alignment);
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(mr, bloom_filter_alignment);
 
   // Helper to validate monotonic string and list offsets
   auto const expect_monotonic_offsets = [](auto& self, cudf::column_view const& column) -> void {
@@ -600,6 +600,8 @@ TEST_F(HybridScanTest, MaterializeStructs)
 
 TEST_F(HybridScanTest, MaterializeListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::mt19937 gen(0xcaLL);
 
   auto constexpr num_concat = 2;
@@ -634,7 +636,7 @@ TEST_F(HybridScanTest, MaterializeListsOfStructs)
   auto col1_offsets_col  = cudf::test::fixed_width_column_wrapper<int32_t>(
     col1_offsets_iter, col1_offsets_iter + num_rows + 1);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
   auto col1 = cudf::make_lists_column(
     num_rows, col1_offsets_col.release(), std::move(struct1), null_count, std::move(null_mask));
 
@@ -663,7 +665,7 @@ TEST_F(HybridScanTest, MaterializeListsOfStructs)
   auto col2_offsets_col  = cudf::test::fixed_width_column_wrapper<int32_t>(
     col2_offsets_iter, col2_offsets_iter + num_rows + 1);
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
   auto col2 = cudf::make_lists_column(
     num_rows, col2_offsets_col.release(), std::move(struct2), null_count, std::move(null_mask));
 
@@ -672,6 +674,8 @@ TEST_F(HybridScanTest, MaterializeListsOfStructs)
 
 TEST_F(HybridScanTest, MaterializeMixedPayloadColumns)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::mt19937 gen(0xcaffe);
 
   auto constexpr num_rows = num_ordered_rows;
@@ -707,7 +711,7 @@ TEST_F(HybridScanTest, MaterializeMixedPayloadColumns)
   auto offsets_col =
     cudf::test::fixed_width_column_wrapper<int32_t>(offsets_iter, offsets_iter + num_rows + 1);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+    cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
   auto col2 = cudf::make_lists_column(
     num_rows, offsets_col.release(), bools_col.release(), null_count, std::move(null_mask));
   // list<list<bool(nullable)>(nullable)>(nullable)
@@ -725,7 +729,7 @@ TEST_F(HybridScanTest, MaterializeMixedPayloadColumns)
                                                                     offset_iter + num_rows + 1);
     auto [null_mask, null_count] = [&]() {
       if (is_nullable) {
-        return cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+        return cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
       } else {
         return std::make_pair(rmm::device_buffer{}, 0);
       }
@@ -773,8 +777,8 @@ TEST_F(HybridScanTest, MaterializeMixedPayloadColumns)
     0, [](cudf::size_type idx) { return idx * string_per_row; });
   cudf::test::fixed_width_column_wrapper<cudf::size_type> list_offsets(
     offset_iter, offset_iter + (num_rows * lists_per_list) + 1);
-  std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_valids, list_valids + (num_rows * lists_per_list));
+  std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
+    list_valids, list_valids + (num_rows * lists_per_list), stream, mr);
 
   auto list_col = cudf::make_lists_column(num_rows * lists_per_list,
                                           list_offsets.release(),
@@ -789,7 +793,7 @@ TEST_F(HybridScanTest, MaterializeMixedPayloadColumns)
   auto list_list_valids =
     cudf::detail::make_counting_transform_iterator(0, [&](int index) { return index % 80; });
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_list_valids, list_list_valids + num_rows);
+    cudf::test::detail::make_null_mask(list_list_valids, list_list_valids + num_rows, stream, mr);
 
   auto col9 = cudf::make_lists_column(
     num_rows, list_list_offsets.release(), std::move(list_col), null_count, std::move(null_mask));

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -1681,6 +1681,9 @@ TEST_P(JsonReaderParamTest, JsonDtypeSchema)
 
 TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+
   std::string json_string = R"( [{"a":[123, {"0": 123}], "b":1.0}, {"b":1.1}, {"b":2.1}])";
 
   std::map<std::string, cudf::io::schema_element> dtype_schema{
@@ -1736,7 +1739,7 @@ TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
   auto leaf_child     = float_wrapper{{0.0, 123.0}, {false, true}};
   auto const validity = {1, 0, 0};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
   auto expected = cudf::make_lists_column(
     3,
     int_wrapper{{0, 2, 2, 2}}.release(),
@@ -3113,6 +3116,9 @@ TEST_F(JsonReaderTest, LastRecordInvalid)
 // Test case for dtype pruning with column order
 TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+
   std::string json_stringl = R"(
     {"a": 1, "b": {"0": "abc", "1": [-1.]}, "c": true}
     {"a": 1, "b": {"0": "abc"          }, "c": false}
@@ -3419,7 +3425,7 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
     auto const expected0 = [&] {
       auto const valids = std::vector<bool>{1, 0};
       auto [null_mask, null_count] =
-        cudf::test::detail::make_null_mask(valids.begin(), valids.end());
+        cudf::test::detail::make_null_mask(valids.begin(), valids.end(), stream, mr);
       return cudf::make_lists_column(2,
                                      size_type_wrapper{0, 1, 1}.release(),
                                      int64_wrapper{1}.release(),
@@ -3434,7 +3440,7 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
       };
       auto const valids = std::vector<bool>{0, 0};
       auto [null_mask, null_count] =
-        cudf::test::detail::make_null_mask(valids.begin(), valids.end());
+        cudf::test::detail::make_null_mask(valids.begin(), valids.end(), stream, mr);
       return cudf::make_lists_column(2,
                                      size_type_wrapper{0, 0, 0}.release(),
                                      get_structs().release(),
@@ -3449,6 +3455,9 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
 
 TEST_F(JsonReaderTest, NullifyMixedList)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+
   using namespace cudf::test::iterators;
   // test list
   std::string json_stringl = R"(
@@ -3501,7 +3510,7 @@ TEST_F(JsonReaderTest, NullifyMixedList)
   };
   std::vector<bool> const list_nulls{1, 1, 0, 0, 0, 1, 0};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nulls.cbegin(), list_nulls.cend());
+    cudf::test::detail::make_null_mask(list_nulls.cbegin(), list_nulls.cend(), stream, mr);
   auto const expected = cudf::make_lists_column(
     7,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 1, 1, 1, 1, 3, 3}.release(),

--- a/cpp/tests/io/json/json_type_cast_test.cpp
+++ b/cpp/tests/io/json/json_type_cast_test.cpp
@@ -46,8 +46,8 @@ auto default_json_options()
 
 TEST_F(JSONTypeCastTest, String)
 {
-  auto const stream = cudf::get_default_stream();
-  auto mr           = cudf::get_current_device_resource_ref();
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto const type   = cudf::data_type{cudf::type_id::STRING};
 
   auto in_valids = null_at(4);
@@ -58,8 +58,8 @@ TEST_F(JSONTypeCastTest, String)
   rmm::device_uvector<cudf::size_type> svs_length = string_offset_to_length(column, stream);
 
   auto null_mask_it = no_nulls();
-  auto null_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size()));
+  auto null_mask    = std::get<0>(
+    cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size(), stream, mr));
 
   auto str_col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
@@ -82,8 +82,8 @@ TEST_F(JSONTypeCastTest, String)
 
 TEST_F(JSONTypeCastTest, Int)
 {
-  auto const stream = cudf::get_default_stream();
-  auto mr           = cudf::get_current_device_resource_ref();
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto const type   = cudf::data_type{cudf::type_id::INT64};
 
   cudf::test::strings_column_wrapper data({"1", "null", "3", "true", "5", "false"});
@@ -91,8 +91,8 @@ TEST_F(JSONTypeCastTest, Int)
   rmm::device_uvector<cudf::size_type> svs_length = string_offset_to_length(column, stream);
 
   auto null_mask_it = no_nulls();
-  auto null_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size()));
+  auto null_mask    = std::get<0>(
+    cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size(), stream, mr));
 
   auto col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
@@ -113,8 +113,8 @@ TEST_F(JSONTypeCastTest, Int)
 
 TEST_F(JSONTypeCastTest, StringEscapes)
 {
-  auto const stream = cudf::get_default_stream();
-  auto mr           = cudf::get_current_device_resource_ref();
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto const type   = cudf::data_type{cudf::type_id::STRING};
 
   cudf::test::strings_column_wrapper data({
@@ -132,8 +132,8 @@ TEST_F(JSONTypeCastTest, StringEscapes)
   rmm::device_uvector<cudf::size_type> svs_length = string_offset_to_length(column, stream);
 
   auto null_mask_it = no_nulls();
-  auto null_mask =
-    std::get<0>(cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size()));
+  auto null_mask    = std::get<0>(
+    cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size(), stream, mr));
 
   auto col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
@@ -155,8 +155,8 @@ TEST_F(JSONTypeCastTest, StringEscapes)
 
 TEST_F(JSONTypeCastTest, ErrorNulls)
 {
-  auto const stream = cudf::get_default_stream();
-  auto mr           = cudf::get_current_device_resource_ref();
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   auto const type   = cudf::data_type{cudf::type_id::STRING};
 
   // error in decoding
@@ -202,8 +202,8 @@ TEST_F(JSONTypeCastTest, ErrorNulls)
     rmm::device_uvector<cudf::size_type> svs_length = string_offset_to_length(column, stream);
 
     auto null_mask_it = no_nulls();
-    auto null_mask =
-      std::get<0>(cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size()));
+    auto null_mask    = std::get<0>(
+      cudf::test::detail::make_null_mask(null_mask_it, null_mask_it + column.size(), stream, mr));
 
     auto str_col = cudf::io::json::detail::parse_data(
       column.chars_begin(stream),

--- a/cpp/tests/io/orc_chunked_reader_test.cu
+++ b/cpp/tests/io/orc_chunked_reader_test.cu
@@ -58,20 +58,22 @@ auto write_file(std::vector<std::unique_ptr<cudf::column>>& input_columns,
                 std::size_t stripe_size_bytes    = cudf::io::default_stripe_size_bytes,
                 cudf::size_type stripe_size_rows = cudf::io::default_stripe_size_rows)
 {
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
   if (nullable) {
     // Generate deterministic bitmask instead of random bitmask for easy computation of data size.
     auto const valid_iter = cudf::detail::make_counting_transform_iterator(
       0, [](cudf::size_type i) { return i % 4 != 3; });
     cudf::size_type offset{0};
     for (auto& col : input_columns) {
-      auto const [null_mask, null_count] =
-        cudf::test::detail::make_null_mask(valid_iter + offset, valid_iter + col->size() + offset);
+      auto const [null_mask, null_count] = cudf::test::detail::make_null_mask(
+        valid_iter + offset, valid_iter + col->size() + offset, stream, mr);
       col = cudf::structs::detail::superimpose_and_sanitize_nulls(
         static_cast<cudf::bitmask_type const*>(null_mask.data()),
         null_count,
         std::move(col),
-        cudf::get_default_stream(),
-        cudf::get_current_device_resource_ref());
+        stream,
+        mr);
 
       // Shift nulls of the next column by one position, to avoid having all nulls
       // in the same table rows.
@@ -210,10 +212,12 @@ TEST_F(OrcChunkedReaderTest, TestChunkedReadNoData)
 
 TEST_F(OrcChunkedReaderTest, NestedEmptyStructColumnSelection)
 {
+  auto const stream   = cudf::test::get_default_stream();
+  auto mr             = this->mr();
   auto const validity = std::vector<bool>{true, false};
   auto const num_rows = static_cast<cudf::size_type>(validity.size());
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   struct_children.emplace_back(cudf::make_structs_column(num_rows, {}, 0, {}));
@@ -231,10 +235,12 @@ TEST_F(OrcChunkedReaderTest, NestedEmptyStructColumnSelection)
 
 TEST_F(OrcChunkedReaderTest, NullableEmptyStructChildColumnSelection)
 {
+  auto const stream   = cudf::test::get_default_stream();
+  auto mr             = this->mr();
   auto const validity = std::vector<bool>{true, false};
   auto const num_rows = static_cast<cudf::size_type>(validity.size());
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   struct_children.emplace_back(

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -1529,6 +1529,8 @@ TEST_F(OrcWriterTest, StripeSizeInvalid)
 
 TEST_F(OrcWriterTest, TestMap)
 {
+  auto const stream         = cudf::test::get_default_stream();
+  auto mr                   = this->mr();
   auto const num_rows       = 1200000;
   auto const lists_per_row  = 4;
   auto const num_child_rows = (num_rows * lists_per_row) / 2;  // half due to validity
@@ -1550,9 +1552,10 @@ TEST_F(OrcWriterTest, TestMap)
   }
   int32_col offsets(row_offsets.begin(), row_offsets.end());
 
-  auto num_list_rows           = static_cast<cudf::column_view>(offsets).size() - 1;
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_list_rows);
-  auto list_col                = cudf::make_lists_column(
+  auto num_list_rows = static_cast<cudf::column_view>(offsets).size() - 1;
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(valids, valids + num_list_rows, stream, mr);
+  auto list_col = cudf::make_lists_column(
     num_list_rows, offsets.release(), std::move(s_col), null_count, std::move(null_mask));
 
   table_view expected({*list_col});
@@ -1612,10 +1615,12 @@ TEST_F(OrcReaderTest, NestedColumnSelection)
 
 TEST_F(OrcReaderTest, NestedEmptyStructColumnSelection)
 {
+  auto const stream   = cudf::test::get_default_stream();
+  auto mr             = this->mr();
   auto const validity = std::vector<bool>{true, false};
   auto const num_rows = static_cast<cudf::size_type>(validity.size());
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   struct_children.emplace_back(cudf::make_structs_column(num_rows, {}, 0, {}));
@@ -1633,10 +1638,12 @@ TEST_F(OrcReaderTest, NestedEmptyStructColumnSelection)
 
 TEST_F(OrcReaderTest, NullableEmptyStructChildColumnSelection)
 {
+  auto const stream   = cudf::test::get_default_stream();
+  auto mr             = this->mr();
   auto const validity = std::vector<bool>{true, false};
   auto const num_rows = static_cast<cudf::size_type>(validity.size());
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(validity.begin(), validity.end());
+    cudf::test::detail::make_null_mask(validity.begin(), validity.end(), stream, mr);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   struct_children.emplace_back(

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -58,6 +58,8 @@ auto write_file(std::vector<std::unique_ptr<cudf::column>>& input_columns,
                 std::size_t max_page_size_bytes = cudf::io::default_max_page_size_bytes,
                 std::size_t max_page_size_rows  = cudf::io::default_max_page_size_rows)
 {
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
   if (nullable) {
     // Generate deterministic bitmask instead of random bitmask for easy computation of data size.
     auto const valid_iter = cudf::detail::make_counting_transform_iterator(
@@ -65,14 +67,14 @@ auto write_file(std::vector<std::unique_ptr<cudf::column>>& input_columns,
 
     cudf::size_type offset{0};
     for (auto& col : input_columns) {
-      auto const [null_mask, null_count] =
-        cudf::test::detail::make_null_mask(valid_iter + offset, valid_iter + col->size() + offset);
+      auto const [null_mask, null_count] = cudf::test::detail::make_null_mask(
+        valid_iter + offset, valid_iter + col->size() + offset, stream, mr);
       col = cudf::structs::detail::superimpose_and_sanitize_nulls(
         static_cast<cudf::bitmask_type const*>(null_mask.data()),
         null_count,
         std::move(col),
-        cudf::get_default_stream(),
-        cudf::get_current_device_resource_ref());
+        stream,
+        mr);
 
       // Shift nulls of the next column by one position, to avoid having all nulls
       // in the same table rows.
@@ -2296,6 +2298,8 @@ TEST_F(ParquetChunkedReaderTest, TestNumRowsPerSourceEmptyTable)
 
 TEST_F(ParquetReaderTest, BooleanList)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   std::mt19937 gen(0xcaffe);
 
   // Parquet file
@@ -2322,7 +2326,7 @@ TEST_F(ParquetReaderTest, BooleanList)
     auto offsets_col  = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
       offsets_iter, offsets_iter + num_rows + 1);
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows);
+      cudf::test::detail::make_null_mask(list_valids, list_valids + num_rows, stream, mr);
     auto _col1 = cudf::make_lists_column(
       num_rows, offsets_col.release(), bools_col.release(), null_count, std::move(null_mask));
     auto col1 = cudf::purge_nonempty_nulls(*_col1);

--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -120,6 +120,8 @@ template <typename T>
 std::unique_ptr<cudf::column> make_parquet_list_list_col(
   int skip_rows, int num_rows, int lists_per_row, int list_size, bool include_validity)
 {
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
   auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // root list
@@ -184,8 +186,9 @@ std::unique_ptr<cudf::column> make_parquet_list_list_col(
   auto child             = cudf::make_lists_column(
     child_offsets_size, child_offsets.release(), child_data.release(), 0, rmm::device_buffer{});
 
-  int offsets_size             = static_cast<cudf::column_view>(offsets).size() - 1;
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + offsets_size);
+  int offsets_size = static_cast<cudf::column_view>(offsets).size() - 1;
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(valids, valids + offsets_size, stream, mr);
   return include_validity
            ? cudf::make_lists_column(
                offsets_size, offsets.release(), std::move(child), null_count, std::move(null_mask))
@@ -549,6 +552,8 @@ std::unique_ptr<cudf::column> make_parquet_list_col(std::mt19937& engine,
                                                     int max_vals_per_row,
                                                     bool include_validity)
 {
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
   std::vector<cudf::size_type> row_sizes(num_rows);
 
   auto const min_values_per_row = include_validity ? 0 : 1;
@@ -567,7 +572,8 @@ std::unique_ptr<cudf::column> make_parquet_list_col(std::mt19937& engine,
     auto valids = random_validity(engine);
     auto values_col =
       cudf::test::fixed_width_column_wrapper<T>(values.begin(), values.end(), valids);
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
 
     auto col = cudf::make_lists_column(
       num_rows, offsets_col.release(), values_col.release(), null_count, std::move(null_mask));
@@ -625,6 +631,8 @@ std::unique_ptr<cudf::column> make_parquet_string_list_col(std::mt19937& engine,
                                                            int max_string_len,
                                                            bool include_validity)
 {
+  auto stream          = cudf::get_default_stream();
+  auto mr              = cudf::get_current_device_resource_ref();
   auto const range_min = include_validity ? 0 : 1;
 
   std::uniform_int_distribution<cudf::size_type> dist{range_min, max_vals_per_row};
@@ -645,7 +653,8 @@ std::unique_ptr<cudf::column> make_parquet_string_list_col(std::mt19937& engine,
   if (include_validity) {
     auto valids     = random_validity(engine);
     auto values_col = cudf::test::strings_column_wrapper(values.begin(), values.end(), valids);
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
 
     auto col = cudf::make_lists_column(
       num_rows, offsets_col.release(), values_col.release(), null_count, std::move(null_mask));

--- a/cpp/tests/io/parquet_misc_test.cpp
+++ b/cpp/tests/io/parquet_misc_test.cpp
@@ -72,7 +72,9 @@ TYPED_TEST(ParquetWriterDeltaTest, SupportedDeltaTestTypesSliced)
 
 TYPED_TEST(ParquetWriterDeltaTest, SupportedDeltaListSliced)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   constexpr int num_slice = 4'000;
   constexpr int num_rows  = 32 * 1024;
@@ -91,7 +93,8 @@ TYPED_TEST(ParquetWriterDeltaTest, SupportedDeltaListSliced)
                                                                      c1_offset_iter + num_rows + 1);
   cudf::test::fixed_width_column_wrapper<T> c1_vals(
     values, values + (num_rows * vals_per_row), valids);
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
 
   auto _c1 = cudf::make_lists_column(
     num_rows, c1_offsets.release(), c1_vals.release(), null_count, std::move(null_mask));

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -190,6 +190,8 @@ TEST_F(ParquetReaderTest, UserBoundsWithNulls)
 
 TEST_F(ParquetReaderTest, UserBoundsWithNullsMixedTypes)
 {
+  auto const stream      = cudf::test::get_default_stream();
+  auto mr                = this->mr();
   constexpr int num_rows = 32 * 1024;
 
   std::mt19937 gen(6542);
@@ -209,7 +211,8 @@ TEST_F(ParquetReaderTest, UserBoundsWithNullsMixedTypes)
                                                                      c1_offset_iter + num_rows + 1);
   cudf::test::fixed_width_column_wrapper<float> c1_floats(
     values, values + (num_rows * floats_per_row), valids);
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
 
   auto _c1 = cudf::make_lists_column(
     num_rows, c1_offsets.release(), c1_floats.release(), null_count, std::move(null_mask));
@@ -236,8 +239,9 @@ TEST_F(ParquetReaderTest, UserBoundsWithNullsMixedTypes)
     cudf::detail::make_counting_transform_iterator(0, [&](int index) { return index % 200; });
   std::vector<bool> c3_valids(num_rows);
   std::copy(_c3_valids, _c3_valids + num_rows, c3_valids.begin());
-  std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(valids, valids + num_rows);
-  auto _c3_list                   = cudf::make_lists_column(
+  std::tie(null_mask, null_count) =
+    cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
+  auto _c3_list = cudf::make_lists_column(
     num_rows, offsets.release(), string_col.release(), null_count, std::move(null_mask));
   auto c3_list = cudf::purge_nonempty_nulls(*_c3_list);
   cudf::test::fixed_width_column_wrapper<int> c3_ints(values, values + num_rows, valids);
@@ -4017,6 +4021,8 @@ void filter_typed_test()
 template <typename T>
 void filter_unary_operation_typed_test()
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = cudf::get_current_device_resource_ref();
   std::mt19937 gen(0xd00dL);
   auto [src, filepath, null_count] = [&]() {
     auto constexpr num_rows            = num_ordered_rows;
@@ -4027,7 +4033,8 @@ void filter_unary_operation_typed_test()
     auto valids = cudf::detail::make_counting_transform_iterator(0, [&](int index) {
       return (index >= 2 * row_group_size_rows and index < 3 * row_group_size_rows) ? false : true;
     });
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
     _col0->set_null_mask(std::move(null_mask), null_count);
     auto col0                = cudf::purge_nonempty_nulls(_col0->view());
     auto col1                = testdata::descending<T>();

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -2178,6 +2178,8 @@ TEST_F(ParquetWriterTest, DeltaBinaryStartsWithNulls)
 std::pair<std::unique_ptr<cudf::table>, cudf::io::table_input_metadata>
 make_byte_stream_split_table(bool as_struct)
 {
+  auto stream             = cudf::get_default_stream();
+  auto mr                 = cudf::get_current_device_resource_ref();
   constexpr auto num_rows = 100;
   std::mt19937 engine{31337};
   auto col0_data = random_values<int32_t>(num_rows);
@@ -2206,8 +2208,9 @@ make_byte_stream_split_table(bool as_struct)
 
     // make as a nested struct
     if (as_struct) {
-      auto valids                  = cudf::test::iterators::valids_at_multiples_of(2);
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
+      auto valids = cudf::test::iterators::valids_at_multiples_of(2);
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(valids, valids + num_rows, stream, mr);
 
       std::vector<std::unique_ptr<cudf::column>> table_cols;
       table_cols.push_back(

--- a/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -525,6 +525,8 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsNoNull)
 
 TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsWithNull)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using structs_col = cudf::test::structs_column_wrapper;
   using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
   using strings_col = cudf::test::strings_column_wrapper;
@@ -533,15 +535,16 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsWithNull)
   // [ [{1, 11, "1"}, {null, null, null}], [{3, 13, "3"}], NULL ]
   // [ [{4, 14, "4"}, {5, 15, "5"}, {null, null, null}] ]
   // [ [{7, 17, "7"}, {null, null, null}], [{9, 19, "9"}, {10, 110, "10"}] ]
-  auto const input = [] {
-    auto child = [] {
-      auto child1                  = int32s_col{1, null, 3, 4, 5, null, 7, null, 9, 10};
-      auto child2                  = int32s_col{11, null, 13, 14, 15, null, 17, null, 19, 110};
-      auto child3                  = strings_col{"1", "", "3", "4", "5", "", "7", "", "9", "10"};
-      auto structs                 = structs_col{{child1, child2, child3}, nulls_at({1, 5, 7})};
-      auto offsets                 = int32s_col{0, 2, 3, 3, 6, 8, 10};
-      auto const null_it           = null_at(2);  // null list
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 6);
+  auto const input = [&] {
+    auto child = [&] {
+      auto child1        = int32s_col{1, null, 3, 4, 5, null, 7, null, 9, 10};
+      auto child2        = int32s_col{11, null, 13, 14, 15, null, 17, null, 19, 110};
+      auto child3        = strings_col{"1", "", "3", "4", "5", "", "7", "", "9", "10"};
+      auto structs       = structs_col{{child1, child2, child3}, nulls_at({1, 5, 7})};
+      auto offsets       = int32s_col{0, 2, 3, 3, 6, 8, 10};
+      auto const null_it = null_at(2);  // null list
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 6, stream, mr);
       return cudf::make_lists_column(
         6, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -593,14 +596,15 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsWithNull)
     // NULL
     // [{4, 14, "4"}, {5, 15, "5"}, {null, null, null}]
     // [{7, 17, "7"}, {null, null, null}, {9, 19, "9"}, {10, 110, "10"}]
-    auto const expected = [] {
-      auto child1                  = int32s_col{4, 5, null, 7, null, 9, 10};
-      auto child2                  = int32s_col{14, 15, null, 17, null, 19, 110};
-      auto child3                  = strings_col{"4", "5", "", "7", "", "9", "10"};
-      auto structs                 = structs_col{{child1, child2, child3}, nulls_at({2, 4})};
-      auto offsets                 = int32s_col{0, 0, 3, 7};
-      auto const null_it           = null_at(0);  // null row
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 3);
+    auto const expected = [&] {
+      auto child1        = int32s_col{4, 5, null, 7, null, 9, 10};
+      auto child2        = int32s_col{14, 15, null, 17, null, 19, 110};
+      auto child3        = strings_col{"4", "5", "", "7", "", "9", "10"};
+      auto structs       = structs_col{{child1, child2, child3}, nulls_at({2, 4})};
+      auto offsets       = int32s_col{0, 0, 3, 7};
+      auto const null_it = null_at(0);  // null row
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 3, stream, mr);
       return cudf::make_lists_column(
         3, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -615,14 +619,15 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsWithNull)
     // Output:
     // NULL
     // [{4, 14, "4"}, {5, 15, "5"}, {null, null, null}]
-    auto const expected = [] {
-      auto child1                  = int32s_col{4, 5, null};
-      auto child2                  = int32s_col{14, 15, null};
-      auto child3                  = strings_col{"4", "5", ""};
-      auto structs                 = structs_col{{child1, child2, child3}, null_at(2)};
-      auto offsets                 = int32s_col{0, 0, 3};
-      auto const null_it           = null_at(0);  // null row
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 2);
+    auto const expected = [&] {
+      auto child1        = int32s_col{4, 5, null};
+      auto child2        = int32s_col{14, 15, null};
+      auto child3        = strings_col{"4", "5", ""};
+      auto structs       = structs_col{{child1, child2, child3}, null_at(2)};
+      auto offsets       = int32s_col{0, 0, 3};
+      auto const null_it = null_at(0);  // null row
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 2, stream, mr);
       return cudf::make_lists_column(
         2, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -683,6 +688,8 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsHavingListsNoNull)
 
 TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsHavingListsWithNulls)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using structs_col = cudf::test::structs_column_wrapper;
   using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
   using lists_col   = cudf::test::lists_column_wrapper<int32_t>;
@@ -691,17 +698,18 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsHavingListsWithNulls)
   // [ [{1, 11, [1, 1]}, {2, 12, [2]}], [{3, 13, [3, 3]}] ]
   // [ [{4, 14, null}, {5, 15, [5, 5, 5]}, {6, 16, [6, 6]}], NULL ]
   // [ [{7, 17, [7]}, {8, 18, [8]}], [{9, 19, [9, 9]}, {10, 110, [10, 10, 10, 10]}] ]
-  auto const input = [] {
-    auto child = [] {
+  auto const input = [&] {
+    auto child = [&] {
       auto child1 = int32s_col{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
       auto child2 = int32s_col{11, 12, 13, 14, 15, 16, 17, 18, 19, 110};
       auto child3 =
         lists_col{{{1, 1}, {2}, {3, 3}, {}, {5, 5, 5}, {6, 6}, {7}, {8}, {9, 9}, {10, 10, 10, 10}},
                   null_at(3)};
-      auto structs                 = structs_col{{child1, child2, child3}};
-      auto offsets                 = int32s_col{0, 2, 3, 6, 6, 8, 10};
-      auto const null_it           = null_at(3);  // null list
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 6);
+      auto structs       = structs_col{{child1, child2, child3}};
+      auto offsets       = int32s_col{0, 2, 3, 6, 6, 8, 10};
+      auto const null_it = null_at(3);  // null list
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 6, stream, mr);
       return cudf::make_lists_column(
         6, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -755,15 +763,16 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsHavingListsWithNulls)
     // [{1, 11, [1, 1]}, {2, 12, [2]}, {3, 13, [3, 3]}]
     // NULL
     // [{7, 17, [7]}, {8, 18, [8]}, {9, 19, [9, 9]}, {10, 110, [10, 10, 10, 10]}]
-    auto const expected = [] {
+    auto const expected = [&] {
       auto child1 = int32s_col{1, 2, 3, 7, 8, 9, 10};
       auto child2 = int32s_col{11, 12, 13, 17, 18, 19, 110};
       auto child3 =
         lists_col{{{1, 1}, {2}, {3, 3}, {7}, {8}, {9, 9}, {10, 10, 10, 10}}, no_nulls()};
-      auto structs                 = structs_col{{child1, child2, child3}};
-      auto offsets                 = int32s_col{0, 3, 3, 7};
-      auto const null_it           = null_at(1);  // null row
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 3);
+      auto structs       = structs_col{{child1, child2, child3}};
+      auto offsets       = int32s_col{0, 3, 3, 7};
+      auto const null_it = null_at(1);  // null row
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 3, stream, mr);
       return cudf::make_lists_column(
         3, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -778,14 +787,15 @@ TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsHavingListsWithNulls)
     // Output:
     // NULL
     // [{7, 17, [7]}, {8, 18, [8]}, {9, 19, [9, 9]}, {10, 110, [10, 10, 10, 10]}]
-    auto const expected = [] {
-      auto child1                  = int32s_col{7, 8, 9, 10};
-      auto child2                  = int32s_col{17, 18, 19, 110};
-      auto child3                  = lists_col{{{7}, {8}, {9, 9}, {10, 10, 10, 10}}, no_nulls()};
-      auto structs                 = structs_col{{child1, child2, child3}};
-      auto offsets                 = int32s_col{0, 0, 4};
-      auto const null_it           = null_at(0);  // null row
-      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 2);
+    auto const expected = [&] {
+      auto child1        = int32s_col{7, 8, 9, 10};
+      auto child2        = int32s_col{17, 18, 19, 110};
+      auto child3        = lists_col{{{7}, {8}, {9, 9}, {10, 10, 10, 10}}, no_nulls()};
+      auto structs       = structs_col{{child1, child2, child3}};
+      auto offsets       = int32s_col{0, 0, 4};
+      auto const null_it = null_at(0);  // null row
+      auto [null_mask, null_count] =
+        cudf::test::detail::make_null_mask(null_it, null_it + 2, stream, mr);
       return cudf::make_lists_column(
         2, offsets.release(), structs.release(), null_count, std::move(null_mask));
     }();
@@ -834,6 +844,8 @@ TEST_F(ConcatenateListElementsTest, EmptyInnerListColumnChildSizeZero)
 // Subcase C: child.size()==0 with a null outer row — verifies null mask is preserved.
 TEST_F(ConcatenateListElementsTest, EmptyInnerListColumnWithNullRow)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // list<list<int32>> with 2 outer rows: row 0 is null, row 1 is a valid empty list.
   // child.size() == 0; the null mask must be copied to the output.
   auto offsets        = cudf::test::fixed_width_column_wrapper<int32_t>{0, 0, 0};
@@ -841,19 +853,21 @@ TEST_F(ConcatenateListElementsTest, EmptyInnerListColumnWithNullRow)
   auto inner_elements = cudf::test::fixed_width_column_wrapper<int32_t>{};
   auto inner_col =
     cudf::make_lists_column(0, inner_offsets.release(), inner_elements.release(), 0, {});
-  auto const null_it           = cudf::test::iterators::null_at(0);
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 2);
-  auto const col               = cudf::make_lists_column(
+  auto const null_it = cudf::test::iterators::null_at(0);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 2, stream, mr);
+  auto const col = cudf::make_lists_column(
     2, offsets.release(), std::move(inner_col), null_count, std::move(null_mask));
 
   auto const results = cudf::lists::concatenate_list_elements(*col);
 
   // Expected: list<int32> with 2 rows — null row 0, empty row 1.
   // concatenate_list_elements reduces list<list<int32>> → list<int32>.
-  auto exp_offsets                     = cudf::test::fixed_width_column_wrapper<int32_t>{0, 0, 0};
-  auto exp_elements                    = cudf::test::fixed_width_column_wrapper<int32_t>{};
-  auto [exp_null_mask, exp_null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 2);
-  auto const expected                  = cudf::make_lists_column(
+  auto exp_offsets  = cudf::test::fixed_width_column_wrapper<int32_t>{0, 0, 0};
+  auto exp_elements = cudf::test::fixed_width_column_wrapper<int32_t>{};
+  auto [exp_null_mask, exp_null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 2, stream, mr);
+  auto const expected = cudf::make_lists_column(
     2, exp_offsets.release(), exp_elements.release(), exp_null_count, std::move(exp_null_mask));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results, verbosity);

--- a/cpp/tests/lists/combine/concatenate_rows_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_rows_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -740,6 +740,8 @@ TEST_F(ListConcatenateRowsNestedTypesTest, Struct)
 
 TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // list<struct<int, string>>
 
   // col 0
@@ -754,7 +756,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
   auto const l0_size = static_cast<cudf::column_view>(l0_offsets).size() - 1;
   std::vector<bool> l0_validity{false, true, true, false, true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(l0_validity.begin(), l0_validity.end());
+    cudf::test::detail::make_null_mask(l0_validity.begin(), l0_validity.end(), stream, mr);
   auto l0 = cudf::make_lists_column(
     l0_size, l0_offsets.release(), s0.release(), null_count, std::move(null_mask));
   l0 = cudf::purge_nonempty_nulls(l0->view());
@@ -785,7 +787,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
   auto const l1_size = static_cast<cudf::column_view>(l1_offsets).size() - 1;
   std::vector<bool> l1_validity{false, true, true, true, true};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(l1_validity.begin(), l1_validity.end());
+    cudf::test::detail::make_null_mask(l1_validity.begin(), l1_validity.end(), stream, mr);
   auto l1 = cudf::make_lists_column(
     l1_size, l1_offsets.release(), s1.release(), null_count, std::move(null_mask));
 
@@ -810,7 +812,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
     auto const le_size = static_cast<cudf::column_view>(le_offsets).size() - 1;
     std::vector<bool> le_validity{false, true, true, true, true};
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end());
+      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end(), stream, mr);
     auto expected = cudf::make_lists_column(
       le_size, le_offsets.release(), se.release(), null_count, std::move(null_mask));
 
@@ -838,7 +840,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
     auto const le_size = static_cast<cudf::column_view>(le_offsets).size() - 1;
     std::vector<bool> le_validity{false, true, true, false, true};
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end());
+      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end(), stream, mr);
     auto expected = cudf::make_lists_column(
       le_size, le_offsets.release(), se.release(), null_count, std::move(null_mask));
 
@@ -848,6 +850,8 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNulls)
 
 TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNullsSliced)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // list<struct<int, string>>
 
   // col 0
@@ -862,7 +866,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNullsSliced)
   auto const l0_size = static_cast<cudf::column_view>(l0_offsets).size() - 1;
   std::vector<bool> l0_validity{false, true, false, false, true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(l0_validity.begin(), l0_validity.end());
+    cudf::test::detail::make_null_mask(l0_validity.begin(), l0_validity.end(), stream, mr);
   auto l0_unsliced = cudf::make_lists_column(
     l0_size, l0_offsets.release(), s0.release(), null_count, std::move(null_mask));
   l0_unsliced = cudf::purge_nonempty_nulls(l0_unsliced->view());
@@ -894,7 +898,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNullsSliced)
   auto const l1_size = static_cast<cudf::column_view>(l1_offsets).size() - 1;
   std::vector<bool> l1_validity{false, true, false, true, true};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(l1_validity.begin(), l1_validity.end());
+    cudf::test::detail::make_null_mask(l1_validity.begin(), l1_validity.end(), stream, mr);
   auto l1_unsliced = cudf::make_lists_column(
     l1_size, l1_offsets.release(), s1.release(), null_count, std::move(null_mask));
   l1_unsliced = cudf::purge_nonempty_nulls(l1_unsliced->view());
@@ -919,7 +923,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNullsSliced)
     auto const le_size = static_cast<cudf::column_view>(le_offsets).size() - 1;
     std::vector<bool> le_validity{false, true, true};
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end());
+      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end(), stream, mr);
     auto expected = cudf::make_lists_column(
       le_size, le_offsets.release(), se.release(), null_count, std::move(null_mask));
 
@@ -944,7 +948,7 @@ TEST_F(ListConcatenateRowsNestedTypesTest, StructWithNullsSliced)
     auto const le_size = static_cast<cudf::column_view>(le_offsets).size() - 1;
     std::vector<bool> le_validity{false, false, true};
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end());
+      cudf::test::detail::make_null_mask(le_validity.begin(), le_validity.end(), stream, mr);
     auto expected = cudf::make_lists_column(
       le_size, le_offsets.release(), se.release(), null_count, std::move(null_mask));
 

--- a/cpp/tests/lists/contains_tests.cpp
+++ b/cpp/tests/lists/contains_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -319,14 +319,16 @@ TYPED_TEST(TypedContainsTest, ScalarKeyNonNullListsWithNullValues)
 
 TYPED_TEST(TypedContainsTest, ScalarKeysWithNullsInLists)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto numerals = cudf::test::fixed_width_column_wrapper<T>{
     {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
 
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(8,
                                               indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
                                               numerals.release(),
@@ -363,13 +365,15 @@ TYPED_TEST(TypedContainsTest, ScalarKeysWithNullsInLists)
 
 TEST_F(ContainsTest, BoolScalarWithNullsInLists)
 {
-  using T = bool;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = bool;
 
   auto numerals = cudf::test::fixed_width_column_wrapper<T>{
     {X, 1, 1, X, 1, 1, X, 1, 1, X, X, 1, 1, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(
     8,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
@@ -407,14 +411,16 @@ TEST_F(ContainsTest, BoolScalarWithNullsInLists)
 
 TEST_F(ContainsTest, StringScalarWithNullsInLists)
 {
-  using T = std::string;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = std::string;
 
   auto strings = cudf::test::strings_column_wrapper{
     {"X", "1", "2", "X", "4", "5", "X", "7", "8", "X", "X", "1", "2", "X", "1"},
     nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(8,
                                               indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
                                               strings.release(),
@@ -645,14 +651,16 @@ TYPED_TEST(TypedVectorContainsTest, VectorNonNullListsWithNullValues)
 
 TYPED_TEST(TypedVectorContainsTest, VectorWithNullsInLists)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto numerals = cudf::test::fixed_width_column_wrapper<T>{
     {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(8,
                                               indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
                                               numerals.release(),
@@ -684,14 +692,16 @@ TYPED_TEST(TypedVectorContainsTest, VectorWithNullsInLists)
 
 TYPED_TEST(TypedVectorContainsTest, ListContainsVectorWithNullsInListsAndInSearchKeys)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto numerals = cudf::test::fixed_width_column_wrapper<T>{
     {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(8,
                                               indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
                                               numerals.release(),
@@ -724,14 +734,16 @@ TYPED_TEST(TypedVectorContainsTest, ListContainsVectorWithNullsInListsAndInSearc
 
 TEST_F(ContainsTest, BoolKeyVectorWithNullsInListsAndInSearchKeys)
 {
-  using T = bool;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = bool;
 
   auto numerals = cudf::test::fixed_width_column_wrapper<T>{
     {X, 0, 1, X, 1, 1, X, 1, 1, X, X, 0, 1, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(8,
                                               indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
                                               numerals.release(),
@@ -764,12 +776,14 @@ TEST_F(ContainsTest, BoolKeyVectorWithNullsInListsAndInSearchKeys)
 
 TEST_F(ContainsTest, StringKeyVectorWithNullsInListsAndInSearchKeys)
 {
-  auto strings = cudf::test::strings_column_wrapper{
-    {"X", "1", "2", "X", "4", "5", "X", "7", "8", "X", "X", "1", "2", "X", "1"},
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto strings      = cudf::test::strings_column_wrapper{
+         {"X", "1", "2", "X", "4", "5", "X", "7", "8", "X", "X", "1", "2", "X", "1"},
     nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8);
+    cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8, stream, mr);
   auto search_space = cudf::make_lists_column(
     8,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
@@ -1170,9 +1184,11 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyNoNullLists)
 
 TYPED_TEST(TypedStructContainsTest, ScalarKeyWithNullLists)
 {
-  using tdata_col = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using tdata_col   = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
 
-  auto const lists = [] {
+  auto const lists = [&] {
     auto offsets = indices_col{0, 4, 7, 10, 10, 15, 18, 21, 24, 24, 28, 28};
     // clang-format off
     auto data1    = tdata_col{0, 1, 2, 1,
@@ -1197,7 +1213,7 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyWithNullLists)
     auto child               = cudf::test::structs_column_wrapper{{data1, data2}};
     auto const validity_iter = nulls_at({3, 10});
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11);
+      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11, stream, mr);
     return cudf::make_lists_column(
       11, offsets.release(), child.release(), null_count, std::move(null_mask));
   }();
@@ -1482,9 +1498,11 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsNoNulls)
 
 TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsHavingNulls)
 {
-  using tdata_col = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using tdata_col   = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
 
-  auto const lists_original = [] {
+  auto const lists_original = [&] {
     auto offsets = indices_col{0, 4, 7, 10, 10, 15, 18, 21, 24, 24, 28, 28};
     // clang-format off
     auto data1    = tdata_col{0, X, 2, 1,
@@ -1509,7 +1527,7 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsHavingNulls)
     auto child = cudf::test::structs_column_wrapper{{data1, data2}, nulls_at({1, 10, 15, 24})};
     auto const validity_iter = nulls_at({3, 10});
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11);
+      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11, stream, mr);
     return cudf::make_lists_column(
       11, offsets.release(), child.release(), null_count, std::move(null_mask));
   }();

--- a/cpp/tests/lists/explode_tests.cpp
+++ b/cpp/tests/lists/explode_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -350,6 +350,8 @@ TEST_F(ExplodeTest, NestedStructs)
 
 TEST_F(ExplodeTest, ListOfStructsWithEmpties)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   //  a           b
   //  [{1}}]      "a"
   //  [{null}]    "b"
@@ -381,7 +383,7 @@ TEST_F(ExplodeTest, ListOfStructsWithEmpties)
   s2_cols.push_back(i2.release());
   std::vector<bool> r2_valids{false};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(r2_valids.begin(), r2_valids.end());
+    cudf::test::detail::make_null_mask(r2_valids.begin(), r2_valids.end(), stream, mr);
   auto s2 = cudf::make_structs_column(1, std::move(s2_cols), null_count, std::move(null_mask));
   cudf::test::fixed_width_column_wrapper<int32_t> off2{0, 1};
   auto row2 = cudf::make_lists_column(1, off2.release(), std::move(s2), 0, rmm::device_buffer{});
@@ -402,7 +404,7 @@ TEST_F(ExplodeTest, ListOfStructsWithEmpties)
   cudf::test::fixed_width_column_wrapper<int32_t> off4{0, 0};
   std::vector<bool> r4_valids{false};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(r4_valids.begin(), r4_valids.end());
+    cudf::test::detail::make_null_mask(r4_valids.begin(), r4_valids.end(), stream, mr);
   auto row4 =
     cudf::make_lists_column(1, off4.release(), std::move(s4), null_count, std::move(null_mask));
 
@@ -988,6 +990,8 @@ TEST_F(ExplodeOuterTest, NestedStructs)
 
 TEST_F(ExplodeOuterTest, ListOfStructsWithEmpties)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   //  a           b
   //  [{1}}]      "a"
   //  [{null}]    "b"
@@ -1019,7 +1023,7 @@ TEST_F(ExplodeOuterTest, ListOfStructsWithEmpties)
   s2_cols.push_back(i2.release());
   std::vector<bool> r2_valids{false};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(r2_valids.begin(), r2_valids.end());
+    cudf::test::detail::make_null_mask(r2_valids.begin(), r2_valids.end(), stream, mr);
   auto s2 = cudf::make_structs_column(1, std::move(s2_cols), null_count, std::move(null_mask));
   cudf::test::fixed_width_column_wrapper<int32_t> off2{0, 1};
   auto row2 = cudf::make_lists_column(1, off2.release(), std::move(s2), 0, rmm::device_buffer{});
@@ -1040,7 +1044,7 @@ TEST_F(ExplodeOuterTest, ListOfStructsWithEmpties)
   cudf::test::fixed_width_column_wrapper<int32_t> off4{0, 0};
   std::vector<bool> r4_valids{false};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(r4_valids.begin(), r4_valids.end());
+    cudf::test::detail::make_null_mask(r4_valids.begin(), r4_valids.end(), stream, mr);
   auto row4 =
     cudf::make_lists_column(1, off4.release(), std::move(s4), null_count, std::move(null_mask));
 

--- a/cpp/tests/lists/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/lists/stream_compaction/apply_boolean_mask_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -131,16 +131,19 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, NullListRowsInTheInputColumn)
 
 TYPED_TEST(ApplyBooleanMaskTypedTest, StructInput)
 {
-  using T    = TypeParam;
-  using fwcw = fwcw<T>;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
+  using fwcw        = fwcw<T>;
 
   auto constexpr num_input_rows = 7;
-  auto const input              = [] {
-    auto child_num               = fwcw{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    auto child_str               = strings{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
-    auto const null_mask_begin   = null_at(5);
-    auto const null_mask_end     = null_mask_begin + num_input_rows;
-    auto [null_mask, null_count] = detail::make_null_mask(null_mask_begin, null_mask_end);
+  auto const input              = [&] {
+    auto child_num             = fwcw{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto child_str             = strings{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+    auto const null_mask_begin = null_at(5);
+    auto const null_mask_end   = null_mask_begin + num_input_rows;
+    auto [null_mask, null_count] =
+      detail::make_null_mask(null_mask_begin, null_mask_end, stream, mr);
     return cudf::make_lists_column(num_input_rows,
                                    offsets{0, 2, 3, 6, 6, 8, 8, 10}.release(),
                                    structs_column_wrapper{{child_num, child_str}}.release(),
@@ -153,12 +156,13 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, StructInput)
     // Input:                     {[0, 1], [2], [3, 4, 5], [], [6, 7], [], [8, 9]}
     auto const filter   = filter_t{{1, 1}, {0}, {0, 1, 0}, {}, {1, 0}, {}, {0, 1}};
     auto const result   = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
-    auto const expected = [] {
-      auto child_num               = fwcw{0, 1, 4, 6, 9};
-      auto child_str               = strings{"0", "1", "4", "6", "9"};
-      auto const null_mask_begin   = null_at(5);
-      auto const null_mask_end     = null_mask_begin + num_input_rows;
-      auto [null_mask, null_count] = detail::make_null_mask(null_mask_begin, null_mask_end);
+    auto const expected = [&] {
+      auto child_num             = fwcw{0, 1, 4, 6, 9};
+      auto child_str             = strings{"0", "1", "4", "6", "9"};
+      auto const null_mask_begin = null_at(5);
+      auto const null_mask_end   = null_mask_begin + num_input_rows;
+      auto [null_mask, null_count] =
+        detail::make_null_mask(null_mask_begin, null_mask_end, stream, mr);
       return cudf::make_lists_column(num_input_rows,
                                      offsets{0, 2, 2, 3, 3, 4, 4, 5}.release(),
                                      structs_column_wrapper{{child_num, child_str}}.release(),
@@ -175,12 +179,13 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, StructInput)
     auto const filter = filter_t{{0}, {0, 1, 0}, {}, {1, 0}, {}, {0, 1}};
     auto const result =
       apply_boolean_mask(lists_column_view{sliced_input}, lists_column_view{filter});
-    auto const expected = [] {
-      auto child_num               = fwcw{4, 6, 9};
-      auto child_str               = strings{"4", "6", "9"};
-      auto const null_mask_begin   = null_at(4);
-      auto const null_mask_end     = null_mask_begin + num_input_rows;
-      auto [null_mask, null_count] = detail::make_null_mask(null_mask_begin, null_mask_end);
+    auto const expected = [&] {
+      auto child_num             = fwcw{4, 6, 9};
+      auto child_str             = strings{"4", "6", "9"};
+      auto const null_mask_begin = null_at(4);
+      auto const null_mask_end   = null_mask_begin + num_input_rows;
+      auto [null_mask, null_count] =
+        detail::make_null_mask(null_mask_begin, null_mask_end, stream, mr);
       return cudf::make_lists_column(num_input_rows - 1,
                                      offsets{0, 0, 1, 1, 2, 2, 3}.release(),
                                      structs_column_wrapper{{child_num, child_str}}.release(),

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -290,8 +290,10 @@ void grouped_test(cudf::data_type input_type, std::vector<std::pair<int, int>> p
 
 std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(cudf::column_view const& col)
 {
-  auto itr = cudf::test::iterators::valids_at_multiples_of(2);
-  return cudf::test::detail::make_null_mask(itr, itr + col.size());
+  auto stream = cudf::get_default_stream();
+  auto mr     = cudf::get_current_device_resource_ref();
+  auto itr    = cudf::test::iterators::valids_at_multiples_of(2);
+  return cudf::test::detail::make_null_mask(itr, itr + col.size(), stream, mr);
 }
 
 void simple_with_nulls_test(cudf::data_type input_type, std::vector<std::pair<int, int>> params)
@@ -409,7 +411,9 @@ struct PercentileApproxTest : public cudf::test::BaseFixture {};
 
 TEST_F(PercentileApproxTest, EmptyInput)
 {
-  auto empty_ = cudf::tdigest::detail::make_empty_tdigests_column(
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto empty_       = cudf::tdigest::detail::make_empty_tdigests_column(
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
   cudf::test::fixed_width_column_wrapper<double> percentiles{0.0, 0.25, 0.3};
 
@@ -424,7 +428,8 @@ TEST_F(PercentileApproxTest, EmptyInput)
 
   cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 0, 0, 0};
   std::vector<bool> nulls{false, false, false};
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(nulls.begin(), nulls.end());
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(nulls.begin(), nulls.end(), stream, mr);
 
   auto expected = cudf::make_lists_column(3,
                                           offsets.release(),
@@ -437,7 +442,9 @@ TEST_F(PercentileApproxTest, EmptyInput)
 
 TEST_F(PercentileApproxTest, EmptyPercentiles)
 {
-  auto const delta = 1000;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto const delta  = 1000;
 
   cudf::test::fixed_width_column_wrapper<double> values{0, 1, 2, 3, 4, 5};
   cudf::test::fixed_width_column_wrapper<int> keys{0, 0, 0, 1, 1, 1};
@@ -456,7 +463,8 @@ TEST_F(PercentileApproxTest, EmptyPercentiles)
 
   cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 0, 0};
   std::vector<bool> nulls{false, false};
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(nulls.begin(), nulls.end());
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(nulls.begin(), nulls.end(), stream, mr);
 
   auto expected = cudf::make_lists_column(2,
                                           offsets.release(),

--- a/cpp/tests/reductions/list_rank_test.cpp
+++ b/cpp/tests/reductions/list_rank_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -80,6 +80,8 @@ TEST_F(ListRankScanTest, DeepList)
 
 TEST_F(ListRankScanTest, ListOfStruct)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of struct of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -180,7 +182,7 @@ TEST_F(ListRankScanTest, ListOfStruct)
                                          true,
                                          true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                        17,
                                        nullptr,
@@ -215,6 +217,8 @@ TEST_F(ListRankScanTest, ListOfStruct)
 
 TEST_F(ListRankScanTest, ListOfEmptyStruct)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // []
   // []
   // Null
@@ -232,7 +236,7 @@ TEST_F(ListRankScanTest, ListOfEmptyStruct)
   auto struct_validity = std::vector<bool>{
     false, false, false, false, false, false, false, false, true, true, true, true, true, true};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
+    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end(), stream, mr);
   auto struct_col = cudf::make_structs_column(14, {}, null_count, std::move(null_mask));
 
   auto offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>{
@@ -240,7 +244,7 @@ TEST_F(ListRankScanTest, ListOfEmptyStruct)
   auto list_nullmask = std::vector<bool>{
     true, true, false, false, true, true, true, true, true, true, true, true, true};
   std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::make_lists_column(
     13, offsets.release(), std::move(struct_col), null_count, std::move(null_mask));
 
@@ -256,6 +260,8 @@ TEST_F(ListRankScanTest, ListOfEmptyStruct)
 
 TEST_F(ListRankScanTest, EmptyDeepList)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // List<List<int>>, where all lists are empty
   // []
   // []
@@ -268,7 +274,7 @@ TEST_F(ListRankScanTest, EmptyDeepList)
   auto offsets       = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 0, 0, 0};
   auto list_nullmask = std::vector<bool>{true, true, false, false};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
+    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end(), stream, mr);
   auto list_column = cudf::make_lists_column(
     4, offsets.release(), list1.release(), null_count, std::move(null_mask));
 

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -198,7 +198,9 @@ TYPED_TEST(TypedRankScanTest, NestedStructs)
 
 TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
 {
-  auto struct_col = make_mixed_structs_column<TypeParam>().release();
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  auto struct_col   = make_mixed_structs_column<TypeParam>().release();
 
   // First, verify that if the structs column has only nulls, all output rows are ranked 1.
   {
@@ -221,7 +223,7 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
   {
     auto const null_iter = cudf::test::iterators::nulls_at({1, 2});
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_iter, null_iter + struct_col->size());
+      cudf::test::detail::make_null_mask(null_iter, null_iter + struct_col->size(), stream, mr);
     struct_col->set_null_mask(std::move(null_mask), null_count);
     auto const expected_dense   = rank_result_col{1, 2, 2, 3, 4, 5, 6, 6, 7, 8, 8, 9};
     auto const expected_rank    = rank_result_col{1, 2, 2, 4, 5, 6, 7, 7, 9, 10, 10, 12};

--- a/cpp/tests/reshape/byte_cast_tests.cpp
+++ b/cpp/tests/reshape/byte_cast_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,6 +37,8 @@ TEST_F(ByteCastTest, int16ValuesWithSplit)
 
 TEST_F(ByteCastTest, int16ValuesWithNulls)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using limits      = std::numeric_limits<int16_t>;
   auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
@@ -45,8 +47,9 @@ TEST_F(ByteCastTest, int16ValuesWithNulls)
     {false, true, false, true, false});
 
   auto int16_data = cudf::test::fixed_width_column_wrapper<uint8_t>{0x00, 0x64, 0x80, 0x00};
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5);
-  auto int16_expected          = cudf::make_lists_column(
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5, stream, mr);
+  auto int16_expected = cudf::make_lists_column(
     5,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 2, 2, 4, 4}.release(),
     int16_data.release(),
@@ -82,6 +85,8 @@ TEST_F(ByteCastTest, int32Values)
 
 TEST_F(ByteCastTest, int32ValuesWithNulls)
 {
+  auto const stream  = cudf::test::get_default_stream();
+  auto mr            = this->mr();
   using limits       = std::numeric_limits<int32_t>;
   auto even_validity = cudf::test::iterators::valids_at_multiples_of(2);
 
@@ -91,7 +96,7 @@ TEST_F(ByteCastTest, int32ValuesWithNulls)
   auto int32_data = cudf::test::fixed_width_column_wrapper<uint8_t>{
     0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x9c, 0x7f, 0xff, 0xff, 0xff};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(even_validity, even_validity + 5);
+    cudf::test::detail::make_null_mask(even_validity, even_validity + 5, stream, mr);
 
   auto int32_expected = cudf::make_lists_column(
     5,
@@ -136,6 +141,8 @@ TEST_F(ByteCastTest, int64ValuesWithSplit)
 
 TEST_F(ByteCastTest, int64ValuesWithNulls)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using limits      = std::numeric_limits<int64_t>;
   auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
@@ -145,8 +152,9 @@ TEST_F(ByteCastTest, int64ValuesWithNulls)
 
   auto int64_data = cudf::test::fixed_width_column_wrapper<uint8_t>{
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5);
-  auto int64_expected          = cudf::make_lists_column(
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5, stream, mr);
+  auto int64_expected = cudf::make_lists_column(
     5,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 8, 8, 16, 16}.release(),
     int64_data.release(),
@@ -196,6 +204,8 @@ TEST_F(ByteCastTest, fp32ValuesWithSplit)
 
 TEST_F(ByteCastTest, fp32ValuesWithNulls)
 {
+  auto const stream  = cudf::test::get_default_stream();
+  auto mr            = this->mr();
   using limits       = std::numeric_limits<float>;
   auto even_validity = cudf::test::iterators::valids_at_multiples_of(2);
 
@@ -206,7 +216,7 @@ TEST_F(ByteCastTest, fp32ValuesWithNulls)
   auto fp32_data = cudf::test::fixed_width_column_wrapper<uint8_t>{
     0x00, 0x00, 0x00, 0x00, 0xc2, 0xc8, 0x00, 0x00, 0x7f, 0x7f, 0xff, 0xff};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(even_validity, even_validity + 5);
+    cudf::test::detail::make_null_mask(even_validity, even_validity + 5, stream, mr);
   auto fp32_expected = cudf::make_lists_column(
     5,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 4, 8, 8, 12}.release(),
@@ -267,6 +277,8 @@ TEST_F(ByteCastTest, fp64ValuesWithSplit)
 
 TEST_F(ByteCastTest, fp64ValuesWithNulls)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using limits      = std::numeric_limits<double>;
   auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
@@ -276,8 +288,9 @@ TEST_F(ByteCastTest, fp64ValuesWithNulls)
 
   auto fp64_data = cudf::test::fixed_width_column_wrapper<uint8_t>{
     0x40, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5);
-  auto fp64_expected           = cudf::make_lists_column(
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(odd_validity, odd_validity + 5, stream, mr);
+  auto fp64_expected = cudf::make_lists_column(
     5,
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 8, 8, 16, 16}.release(),
     fp64_data.release(),
@@ -323,7 +336,9 @@ TEST_F(ByteCastTest, StringValuesNoNulls)
 
 TEST_F(ByteCastTest, StringValuesWithNulls)
 {
-  auto const strings_col = [] {
+  auto const stream      = cudf::test::get_default_stream();
+  auto mr                = this->mr();
+  auto const strings_col = [&] {
     auto output =
       cudf::test::strings_column_wrapper(
         {"", "The quick", " brown fox...", "!\"#$%&\'()*+,-./", "0123456789:;<=>?@", "[\\]^_`{|}~"})
@@ -333,7 +348,7 @@ TEST_F(ByteCastTest, StringValuesWithNulls)
     // This is intentional.
     auto const null_iter = cudf::test::iterators::nulls_at({2, 4});
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_iter, null_iter + output->size());
+      cudf::test::detail::make_null_mask(null_iter, null_iter + output->size(), stream, mr);
     output->set_null_mask(std::move(null_mask), null_count);
     return output;
   }();

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -223,6 +223,8 @@ TYPED_TEST(TypedCollectListTest, RollingWindowHonoursMinPeriods)
 
 TYPED_TEST(TypedCollectListTest, RollingWindowWithNullInputsHonoursMinPeriods)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Test that when the number of observations is fewer than min_periods,
   // the result is null.
   // Input column has null inputs.
@@ -257,8 +259,8 @@ TYPED_TEST(TypedCollectListTest, RollingWindowWithNullInputsHonoursMinPeriods)
       cudf::size_type{0},
       [expected_num_rows](auto i) { return i != 0 && i != (expected_num_rows - 1); });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -292,8 +294,8 @@ TYPED_TEST(TypedCollectListTest, RollingWindowWithNullInputsHonoursMinPeriods)
       cudf::size_type{0},
       [expected_num_rows](auto i) { return i != 0 && i != (expected_num_rows - 1); });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -330,8 +332,8 @@ TYPED_TEST(TypedCollectListTest, RollingWindowWithNullInputsHonoursMinPeriods)
     auto null_mask_iter    = cudf::detail::make_counting_transform_iterator(
       cudf::size_type{0}, [](auto i) { return i > 0 && i < 4; });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -365,8 +367,8 @@ TYPED_TEST(TypedCollectListTest, RollingWindowWithNullInputsHonoursMinPeriods)
     auto null_mask_iter    = cudf::detail::make_counting_transform_iterator(
       cudf::size_type{0}, [](auto i) { return i > 0 && i < 4; });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -443,6 +445,8 @@ TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsOnStrings)
 
 TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsWithDecimal)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Test that when the number of observations is fewer than min_periods,
   // the result is null.
   auto const input_iter   = cuda::counting_iterator<int32_t>{0};
@@ -473,8 +477,8 @@ TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsWithDecimal)
       cudf::size_type{0},
       [expected_num_rows](auto i) { return i != 0 && i != (expected_num_rows - 1); });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -518,8 +522,8 @@ TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsWithDecimal)
     auto null_mask_iter    = cudf::detail::make_counting_transform_iterator(
       cudf::size_type{0}, [](auto i) { return i > 0 && i < 4; });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -1206,6 +1210,8 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithNullsAndMinPer
 
 TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowOnStructsWithMinPeriods)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Test that min_periods is honoured.
   // i.e. output row is null when min_periods exceeds number of observations.
   using T = TypeParam;
@@ -1252,9 +1258,9 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowOnStructsWithMinPe
   auto expected_offsets_column =
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 8, 13, 18, 23, 23, 23, 23, 23}
       .release();
-  auto expected_validity_iter = cudf::test::iterators::nulls_at({5, 6, 7, 8});
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(expected_validity_iter, expected_validity_iter + 9);
+  auto expected_validity_iter  = cudf::test::iterators::nulls_at({5, 6, 7, 8});
+  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+    expected_validity_iter, expected_validity_iter + 9, stream, mr);
   auto expected_result = cudf::make_lists_column(9,
                                                  std::move(expected_offsets_column),
                                                  std::move(expected_structs_column),
@@ -1568,6 +1574,8 @@ TEST_F(CollectSetTest, RollingWindowHonoursMinPeriodsOnStrings)
 
 TEST_F(CollectSetTest, RollingWindowHonoursMinPeriodsWithDecimal)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Test that when the number of observations is fewer than min_periods,
   // the result is null.
 
@@ -1598,8 +1606,8 @@ TEST_F(CollectSetTest, RollingWindowHonoursMinPeriodsWithDecimal)
       cudf::size_type{0},
       [expected_num_rows](auto i) { return i != 0 && i != (expected_num_rows - 1); });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),
@@ -1643,8 +1651,8 @@ TEST_F(CollectSetTest, RollingWindowHonoursMinPeriodsWithDecimal)
     auto null_mask_iter    = cudf::detail::make_counting_transform_iterator(
       cudf::size_type{0}, [](auto i) { return i > 0 && i < 4; });
 
-    auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(null_mask_iter, null_mask_iter + expected_num_rows);
+    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+      null_mask_iter, null_mask_iter + expected_num_rows, stream, mr);
 
     auto expected_result = cudf::make_lists_column(expected_num_rows,
                                                    std::move(expected_offsets),

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -271,6 +271,8 @@ TYPED_TEST(Sort, WithNestedStructColumn)
 
 TYPED_TEST(Sort, WithNullableStructColumn)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Test for a struct column that has nulls on struct layer but not pushed down on the child
   using T    = int;
   using fwcw = cudf::test::fixed_width_column_wrapper<T>;
@@ -279,8 +281,9 @@ TYPED_TEST(Sort, WithNullableStructColumn)
   auto make_struct = [&](std::vector<std::unique_ptr<cudf::column>> child_cols,
                          std::vector<bool> nulls) {
     cudf::test::structs_column_wrapper struct_col(std::move(child_cols));
-    auto struct_                 = struct_col.release();
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(nulls.begin(), nulls.end());
+    auto struct_ = struct_col.release();
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(nulls.begin(), nulls.end(), stream, mr);
     struct_->set_null_mask(std::move(null_mask), null_count);
     return struct_;
   };

--- a/cpp/tests/stream_compaction/distinct_tests.cpp
+++ b/cpp/tests/stream_compaction/distinct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -819,6 +819,8 @@ TEST_F(DistinctKeepFirstLastNone, ListsWithNullsUnequal)
 
 TEST_F(DistinctKeepAny, ListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -868,7 +870,8 @@ TEST_F(DistinctKeepAny, ListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -905,6 +908,8 @@ TEST_F(DistinctKeepAny, ListsOfStructs)
 
 TEST_F(DistinctKeepFirstLastNone, ListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -954,7 +959,8 @@ TEST_F(DistinctKeepFirstLastNone, ListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -1001,6 +1007,8 @@ TEST_F(DistinctKeepFirstLastNone, ListsOfStructs)
 
 TEST_F(DistinctKeepAny, SlicedListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of struct of two elements
   // 0.   []                  ==                <- Don't care
   // 1.   []                  !=                <- Don't care
@@ -1050,7 +1058,8 @@ TEST_F(DistinctKeepAny, SlicedListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -1088,6 +1097,8 @@ TEST_F(DistinctKeepAny, SlicedListsOfStructs)
 
 TEST_F(DistinctKeepAny, ListsOfEmptyStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // 0.  []             ==
   // 1.  []             !=
   // 2.  Null           ==
@@ -1104,7 +1115,7 @@ TEST_F(DistinctKeepAny, ListsOfEmptyStructs)
 
   auto const structs_null_it = nulls_at({0, 1, 2, 3, 4, 5, 6, 7});
   auto [structs_null_mask, structs_null_count] =
-    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14);
+    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14, stream, mr);
   auto const structs =
     cudf::column_view(cudf::data_type(cudf::type_id::STRUCT),
                       14,
@@ -1115,7 +1126,7 @@ TEST_F(DistinctKeepAny, ListsOfEmptyStructs)
   auto const offsets       = int32s_col{0, 0, 0, 0, 0, 2, 4, 6, 7, 8, 9, 10, 12, 14};
   auto const lists_null_it = nulls_at({2, 3});
   auto [lists_null_mask, lists_null_count] =
-    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13);
+    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13, stream, mr);
   auto const keys =
     cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                       13,

--- a/cpp/tests/stream_compaction/stable_distinct_tests.cpp
+++ b/cpp/tests/stream_compaction/stable_distinct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -758,6 +758,8 @@ TEST_F(StableDistinctKeepFirstLastNone, ListsWithNullsUnequal)
 
 TEST_F(StableDistinctKeepAny, ListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -807,7 +809,8 @@ TEST_F(StableDistinctKeepAny, ListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -842,6 +845,8 @@ TEST_F(StableDistinctKeepAny, ListsOfStructs)
 
 TEST_F(StableDistinctKeepFirstLastNone, ListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -891,7 +896,8 @@ TEST_F(StableDistinctKeepFirstLastNone, ListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -935,6 +941,8 @@ TEST_F(StableDistinctKeepFirstLastNone, ListsOfStructs)
 
 TEST_F(StableDistinctKeepAny, SlicedListsOfStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of struct of two elements
   // 0.   []                  ==                <- Don't care
   // 1.   []                  !=                <- Don't care
@@ -984,7 +992,8 @@ TEST_F(StableDistinctKeepAny, SlicedListsOfStructs)
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
 
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -1020,6 +1029,8 @@ TEST_F(StableDistinctKeepAny, SlicedListsOfStructs)
 
 TEST_F(StableDistinctKeepAny, ListsOfEmptyStructs)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Column(s) used to test KEEP_ANY needs to have same rows in contiguous
   // groups for equivalent keys because KEEP_ANY is nondeterministic.
 
@@ -1039,7 +1050,7 @@ TEST_F(StableDistinctKeepAny, ListsOfEmptyStructs)
 
   auto const structs_null_it = nulls_at({0, 1, 2, 3, 4, 5, 6, 7});
   auto [structs_null_mask, structs_null_count] =
-    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14);
+    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14, stream, mr);
   auto const structs =
     cudf::column_view(cudf::data_type(cudf::type_id::STRUCT),
                       14,
@@ -1050,7 +1061,7 @@ TEST_F(StableDistinctKeepAny, ListsOfEmptyStructs)
   auto const offsets       = int32s_col{0, 0, 0, 0, 0, 2, 4, 6, 7, 8, 9, 10, 12, 14};
   auto const lists_null_it = nulls_at({2, 3});
   auto [lists_null_mask, lists_null_count] =
-    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13);
+    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13, stream, mr);
   auto const keys =
     cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                       13,

--- a/cpp/tests/stream_compaction/unique_tests.cpp
+++ b/cpp/tests/stream_compaction/unique_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -414,6 +414,8 @@ TEST_F(Unique, NullableListsKeepFirstLastNone)
 
 TEST_F(Unique, ListsOfStructsKeepAny)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -462,7 +464,8 @@ TEST_F(Unique, ListsOfStructsKeepAny)
 
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -497,6 +500,8 @@ TEST_F(Unique, ListsOfStructsKeepAny)
 
 TEST_F(Unique, ListsOfStructsKeepFirstLastNone)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // Constructing a list of structs of two elements
   // 0.   []                  ==
   // 1.   []                  !=
@@ -545,7 +550,8 @@ TEST_F(Unique, ListsOfStructsKeepFirstLastNone)
 
   auto const offsets = int32s_col{0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
   auto const null_it = nulls_at({2, 3});
-  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 17);
+  auto [null_mask, null_count] =
+    cudf::test::detail::make_null_mask(null_it, null_it + 17, stream, mr);
 
   auto const keys = cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                                       17,
@@ -589,6 +595,8 @@ TEST_F(Unique, ListsOfStructsKeepFirstLastNone)
 
 TEST_F(Unique, ListsOfEmptyStructsKeepAny)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // 0.  []             ==
   // 1.  []             !=
   // 2.  Null           ==
@@ -605,7 +613,7 @@ TEST_F(Unique, ListsOfEmptyStructsKeepAny)
 
   auto const structs_null_it = nulls_at({0, 1, 2, 3, 4, 5, 6, 7});
   auto [structs_null_mask, structs_null_count] =
-    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14);
+    cudf::test::detail::make_null_mask(structs_null_it, structs_null_it + 14, stream, mr);
   auto const structs =
     cudf::column_view(cudf::data_type(cudf::type_id::STRUCT),
                       14,
@@ -616,7 +624,7 @@ TEST_F(Unique, ListsOfEmptyStructsKeepAny)
   auto const offsets       = int32s_col{0, 0, 0, 0, 0, 2, 4, 6, 7, 8, 9, 10, 12, 14};
   auto const lists_null_it = nulls_at({2, 3});
   auto [lists_null_mask, lists_null_count] =
-    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13);
+    cudf::test::detail::make_null_mask(lists_null_it, lists_null_it + 13, stream, mr);
   auto const keys =
     cudf::column_view(cudf::data_type(cudf::type_id::LIST),
                       13,

--- a/cpp/tests/structs/structs_column_tests.cpp
+++ b/cpp/tests/structs/structs_column_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -410,6 +410,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestListsOfStructs)
 
 TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using namespace cudf::test;
 
   auto list_col =
@@ -422,8 +424,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
   auto struct_of_lists_col = structs_column_wrapper{{list_col}}.release();
 
   auto list_of_struct_of_list_validity = cudf::test::iterators::nulls_at_multiples_of(3);
-  auto [null_mask, null_count] =
-    detail::make_null_mask(list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5);
+  auto [null_mask, null_count]         = detail::make_null_mask(
+    list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5, stream, mr);
   auto list_of_struct_of_list =
     cudf::make_lists_column(5,
                             fixed_width_column_wrapper<size_type>{0, 2, 4, 6, 8, 10}.release(),
@@ -442,8 +444,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::lists_column_view(*list_of_struct_of_list).child(),
                                  *expected_level2_struct);
 
-  std::tie(null_mask, null_count) =
-    detail::make_null_mask(list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5);
+  std::tie(null_mask, null_count) = detail::make_null_mask(
+    list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5, stream, mr);
   auto expected_level3_list =
     cudf::make_lists_column(5,
                             fixed_width_column_wrapper<size_type>{0, 0, 2, 4, 4, 6}.release(),
@@ -457,6 +459,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
 
 TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   using namespace cudf::test;
 
   auto ints_col = fixed_width_column_wrapper<TypeParam, int32_t>{
@@ -468,8 +472,9 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
     }
       .release();
 
-  auto list_validity           = cudf::test::iterators::nulls_at_multiples_of(3);
-  auto [null_mask, null_count] = detail::make_null_mask(list_validity, list_validity + 5);
+  auto list_validity = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto [null_mask, null_count] =
+    detail::make_null_mask(list_validity, list_validity + 5, stream, mr);
 
   auto lists_col =
     cudf::make_lists_column(5,
@@ -491,7 +496,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
   auto expected_structs_col =
     structs_column_wrapper{{expected_ints_col}, {1, 1, 1, 1, 1, 1, 0, 0, 0, 0}}.release();
 
-  std::tie(null_mask, null_count) = detail::make_null_mask(list_validity, list_validity + 5);
+  std::tie(null_mask, null_count) =
+    detail::make_null_mask(list_validity, list_validity + 5, stream, mr);
 
   auto expected_lists_col =
     cudf::make_lists_column(5,
@@ -596,6 +602,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, CopyColumnFromView)
 
 TEST_F(StructColumnWrapperTest, TestStructsColumnWithEmptyChild)
 {
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
   // structs_column_views should not superimpose their null mask onto any EMPTY children,
   // because EMPTY columns cannot have a null mask. This test ensures that
   // we can construct a structs column with a parent null mask and an EMPTY
@@ -607,7 +615,7 @@ TEST_F(StructColumnWrapperTest, TestStructsColumnWithEmptyChild)
   cols.push_back(std::move(empty_col));
   auto mask_vec = std::vector<bool>{true, false, false};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(mask_vec.begin(), mask_vec.end());
+    cudf::test::detail::make_null_mask(mask_vec.begin(), mask_vec.end(), stream, mr);
   EXPECT_NO_THROW(auto structs_col = cudf::make_structs_column(
                     num_rows, std::move(cols), null_count, std::move(null_mask)));
 }

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -228,6 +228,8 @@ TYPED_TEST(RowBitCountTyped, Lists)
 
 TYPED_TEST(RowBitCountTyped, ListsWithNulls)
 {
+  auto const stream                   = cudf::test::get_default_stream();
+  auto mr                             = this->mr();
   using T                             = TypeParam;
   using LCW                           = cudf::test::lists_column_wrapper<T, int>;
   constexpr cudf::size_type type_size = sizeof(cudf::device_storage_type_t<T>) * CHAR_BIT;
@@ -242,8 +244,8 @@ TYPED_TEST(RowBitCountTyped, ListsWithNulls)
                                                    {1, 1, 1, 0, 1, 1, 0, 1, 0}};
   cudf::test::fixed_width_column_wrapper<cudf::size_type> inner_offsets{0, 2, 5, 6, 9, 9};
   std::vector<bool> inner_list_validity{1, 1, 1, 1, 0};
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(inner_list_validity.begin(), inner_list_validity.end());
+  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
+    inner_list_validity.begin(), inner_list_validity.end(), stream, mr);
   auto inner_list = cudf::make_lists_column(
     5, inner_offsets.release(), values.release(), null_count, std::move(null_mask));
   cudf::test::fixed_width_column_wrapper<cudf::size_type> outer_offsets{0, 2, 2, 3, 5};

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -395,7 +395,8 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
     cudf::test::fixed_width_column_wrapper<int> c0_data(
       {1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7, 7}, stream, mr);
 
-    auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids.begin(), valids.end());
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(valids.begin(), valids.end(), stream, mr);
 
     auto c0 = [&] {
       auto tmp = make_lists_column(
@@ -411,7 +412,7 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
         c1_offsets.release(),
         c1_data.release(),
         null_count,
-        std::get<0>(cudf::test::detail::make_null_mask(valids.begin(), valids.end())));
+        std::get<0>(cudf::test::detail::make_null_mask(valids.begin(), valids.end(), stream, mr)));
       return cudf::purge_nonempty_nulls(tmp->view());
     }();
 
@@ -439,7 +440,7 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
     std::vector<bool> c0_l2_valids = {1, 1, 1, 0, 0, 1, 1};
 
     auto [null_mask, null_count] =
-      cudf::test::detail::make_null_mask(c0_l2_valids.begin(), c0_l2_valids.end());
+      cudf::test::detail::make_null_mask(c0_l2_valids.begin(), c0_l2_valids.end(), stream, mr);
     auto c0_l2 = [&] {
       auto tmp = make_lists_column(
         7, c0_l2_offsets.release(), c0_l2_data.release(), null_count, std::move(null_mask));
@@ -447,7 +448,7 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
     }();
 
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(level1_valids.begin(), level1_valids.end());
+      cudf::test::detail::make_null_mask(level1_valids.begin(), level1_valids.end(), stream, mr);
     auto c0 = [&] {
       auto tmp = make_lists_column(
         7, c0_l1_offsets.release(), std::move(c0_l2), null_count, std::move(null_mask));
@@ -464,7 +465,7 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
     std::vector<bool> c1_l2_valids = {1, 0, 0, 1, 1};
 
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(c1_l2_valids.begin(), c1_l2_valids.end());
+      cudf::test::detail::make_null_mask(c1_l2_valids.begin(), c1_l2_valids.end(), stream, mr);
     auto c1_l2 = [&] {
       auto tmp = make_lists_column(
         5, c1_l2_offsets.release(), c1_l2_data.release(), null_count, std::move(null_mask));
@@ -472,7 +473,7 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructureBeforeConstruction)
     }();
 
     std::tie(null_mask, null_count) =
-      cudf::test::detail::make_null_mask(level1_valids.begin(), level1_valids.end());
+      cudf::test::detail::make_null_mask(level1_valids.begin(), level1_valids.end(), stream, mr);
     auto c1 = [&] {
       auto tmp = make_lists_column(
         7, c1_l1_offsets.release(), std::move(c1_l2), null_count, std::move(null_mask));

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -1361,7 +1361,9 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructs)
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructsWithValidity)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto num_struct_rows = 8;
   auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{
@@ -1376,7 +1378,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructsWithValidity)
   auto list_null_mask = {1, 1, 0};
   auto num_lists      = lists_column_offsets->size() - 1;
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end());
+    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end(), stream, mr);
   auto lists_column = [&] {
     auto tmp = cudf::make_lists_column(num_lists,
                                        std::move(lists_column_offsets),
@@ -1437,7 +1439,9 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructs)
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructsWithValidity)
 {
-  using T = TypeParam;
+  auto const stream = cudf::test::get_default_stream();
+  auto mr           = this->mr();
+  using T           = TypeParam;
 
   auto num_struct_rows = 8;
   auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{
@@ -1452,7 +1456,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructsWithValidity)
   auto num_lists      = lists_column_offsets->size() - 1;
   auto list_null_mask = {1, 1, 0};
   auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end());
+    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end(), stream, mr);
   auto lists_column = [&] {
     auto tmp = cudf::make_lists_column(num_lists,
                                        std::move(lists_column_offsets),
@@ -1468,7 +1472,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructsWithValidity)
   auto list_of_lists_null_mask = {1, 0};
 
   std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
-    list_of_lists_null_mask.begin(), list_of_lists_null_mask.end());
+    list_of_lists_null_mask.begin(), list_of_lists_null_mask.end(), stream, mr);
   auto lists_of_lists_of_structs_column = [&] {
     auto tmp = cudf::make_lists_column(num_lists_of_lists,
                                        std::move(lists_of_lists_column_offsets),


### PR DESCRIPTION
## Description

This is a low-priority change, and would likely be automatically addressed when #20780 completes. 

Depends on #23581

A part of https://github.com/NVIDIA/cudf/issues/20780. 

`cudf::test::detail::make_null_mask` still defaulted to the test stream and current device resource, which hid unintentional resource use. This removes those defaults and updates callers to pass stream and memory resources explicitly.

- Drop default `stream`/`mr` parameters from `detail::make_null_mask`
- Pass fixture-scoped `stream`/`mr` at direct test call sites, including nested lambdas that now capture them
- Keep shared IO/test helpers signature-stable for now by binding local `cudf::get_default_stream()` / `cudf::get_current_device_resource_ref()` inside the helpers until those modules are migrated

NOTE:
In many instances, the default stream and current MR are now defined in test fixture scopes. Ideally when each module is ported to `memory_resources`, corresponding test cases and utils should follow suite. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
