### PR TITLE
Use cuda::stream_ref for core libcudf APIs

### DIFF
--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,9 +10,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <type_traits>
@@ -52,7 +53,7 @@ class column {
    * @param mr Device memory resource to use for all device memory allocations
    */
   column(column const& other,
-         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         cuda::stream_ref stream           = cudf::get_default_stream(),
          rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -130,7 +131,7 @@ class column {
    * @param mr Device memory resource to use for all device memory allocations
    */
   explicit column(column_view view,
-                  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                  cuda::stream_ref stream           = cudf::get_default_stream(),
                   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -181,7 +182,7 @@ class column {
    */
   void set_null_mask(rmm::device_buffer const& new_null_mask,
                      size_type new_null_count,
-                     rmm::cuda_stream_view stream = cudf::get_default_stream());
+                     cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Updates the count of null elements.

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -15,11 +15,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <functional>
@@ -506,7 +506,7 @@ class alignas(16) column_device_view : public column_device_view_core {
    */
   static std::unique_ptr<column_device_view, std::function<void(column_device_view*)>> create(
     column_view source_view,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -657,7 +657,7 @@ class alignas(16) mutable_column_device_view : public mutable_column_device_view
   static std::unique_ptr<mutable_column_device_view,
                          std::function<void(mutable_column_device_view*)>>
   create(mutable_column_view source_view,
-         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         cuda::stream_ref stream           = cudf::get_default_stream(),
          rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -14,6 +14,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 
 /**
  * @file
@@ -68,7 +69,7 @@ std::unique_ptr<column> make_numeric_column(
   data_type type,
   size_type size,
   mask_state state                  = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -94,7 +95,7 @@ std::unique_ptr<column> make_numeric_column(
   size_type size,
   B&& null_mask,
   size_type null_count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
@@ -126,7 +127,7 @@ std::unique_ptr<column> make_fixed_point_column(
   data_type type,
   size_type size,
   mask_state state                  = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -151,7 +152,7 @@ std::unique_ptr<column> make_fixed_point_column(
   size_type size,
   B&& null_mask,
   size_type null_count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_EXPECTS(is_fixed_point(type), "Invalid, non-fixed_point type.");
@@ -184,7 +185,7 @@ std::unique_ptr<column> make_timestamp_column(
   data_type type,
   size_type size,
   mask_state state                  = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -210,7 +211,7 @@ std::unique_ptr<column> make_timestamp_column(
   size_type size,
   B&& null_mask,
   size_type null_count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
@@ -243,7 +244,7 @@ std::unique_ptr<column> make_duration_column(
   data_type type,
   size_type size,
   mask_state state                  = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -269,7 +270,7 @@ std::unique_ptr<column> make_duration_column(
   size_type size,
   B&& null_mask,
   size_type null_count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
@@ -302,7 +303,7 @@ std::unique_ptr<column> make_fixed_width_column(
   data_type type,
   size_type size,
   mask_state state                  = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -328,7 +329,7 @@ std::unique_ptr<column> make_fixed_width_column(
   size_type size,
   B&& null_mask,
   size_type null_count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_EXPECTS(is_fixed_width(type), "Invalid, non-fixed-width type.");
@@ -593,7 +594,7 @@ std::unique_ptr<cudf::column> create_structs_hierarchy(
 std::unique_ptr<column> make_column_from_scalar(
   scalar const& s,
   size_type size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -613,7 +614,7 @@ std::unique_ptr<column> make_column_from_scalar(
 std::unique_ptr<column> make_dictionary_from_scalar(
   scalar const& s,
   size_type size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/column/column_stream.hpp
+++ b/cpp/include/cudf/column/column_stream.hpp
@@ -6,7 +6,7 @@
 
 #include <cudf/column/column.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -40,7 +40,7 @@ namespace CUDF_EXPORT cudf {
  * @param stream Stream used for future asynchronous deallocation of the buffers
  * @return Column with equivalent contents and rebinding applied
  */
-[[nodiscard]] std::unique_ptr<column> rebind_stream(column&& col, rmm::cuda_stream_view stream);
+[[nodiscard]] std::unique_ptr<column> rebind_stream(column&& col, cuda::stream_ref stream);
 
 /** @} */  // end of group
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -170,10 +170,9 @@ class column_view_base {
    * @param[in] stream CUDA stream used for device memory operations and kernel launches
    * @return The count of null elements in the given range
    */
-  [[nodiscard]] size_type null_count(
-    size_type begin,
-    size_type end,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] size_type null_count(size_type begin,
+                                     size_type end,
+                                     cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Indicates if the column contains null elements,
@@ -199,7 +198,7 @@ class column_view_base {
    */
   [[nodiscard]] bool has_nulls(size_type begin,
                                size_type end,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream()) const
+                               cuda::stream_ref stream = cudf::get_default_stream()) const
   {
     return null_count(begin, end, stream) > 0;
   }

--- a/cpp/include/cudf/concatenate.hpp
+++ b/cpp/include/cudf/concatenate.hpp
@@ -11,6 +11,8 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <cuda/stream_ref>
+
 #include <memory>
 #include <span>
 
@@ -39,7 +41,7 @@ namespace CUDF_EXPORT cudf {
  */
 rmm::device_buffer concatenate_masks(
   std::span<column_view const> views,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -56,7 +58,7 @@ rmm::device_buffer concatenate_masks(
  */
 std::unique_ptr<column> concatenate(
   std::span<column_view const> columns_to_concat,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -85,7 +87,7 @@ std::unique_ptr<column> concatenate(
  */
 std::unique_ptr<table> concatenate(
   std::span<table_view const> tables_to_concat,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/contiguous_split.hpp
+++ b/cpp/include/cudf/contiguous_split.hpp
@@ -70,7 +70,7 @@ namespace CUDF_EXPORT cudf {
 std::vector<packed_table> contiguous_split(
   cudf::table_view const& input,
   std::vector<size_type> const& splits,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 namespace detail {
@@ -155,7 +155,7 @@ class chunked_pack {
   explicit chunked_pack(
     cudf::table_view const& input,
     std::size_t user_buffer_size,
-    rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+    cuda::stream_ref stream                = cudf::get_default_stream(),
     rmm::device_async_resource_ref temp_mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -222,7 +222,7 @@ class chunked_pack {
   [[nodiscard]] static std::unique_ptr<chunked_pack> create(
     cudf::table_view const& input,
     std::size_t user_buffer_size,
-    rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+    cuda::stream_ref stream                = cudf::get_default_stream(),
     rmm::device_async_resource_ref temp_mr = cudf::get_current_device_resource_ref());
 
  private:
@@ -244,7 +244,7 @@ class chunked_pack {
  *         and device memory respectively
  */
 packed_columns pack(cudf::table_view const& input,
-                    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                    cuda::stream_ref stream           = cudf::get_default_stream(),
                     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -261,7 +261,7 @@ packed_columns pack(cudf::table_view const& input,
  */
 std::size_t packed_size(
   cudf::table_view const& input,
-  rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+  cuda::stream_ref stream                = cudf::get_default_stream(),
   rmm::device_async_resource_ref temp_mr = cudf::get_current_device_resource_ref());
 
 /**

--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -82,7 +82,7 @@ std::unique_ptr<table> gather(
   table_view const& source_table,
   column_view const& gather_map,
   out_of_bounds_policy bounds_policy = out_of_bounds_policy::DONT_CHECK,
-  rmm::cuda_stream_view stream       = cudf::get_default_stream(),
+  cuda::stream_ref stream            = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr  = cudf::get_current_device_resource_ref());
 
 /**
@@ -120,7 +120,7 @@ std::unique_ptr<table> gather(
   column_view const& gather_map,
   out_of_bounds_policy bounds_policy,
   negative_index_policy neg_indices,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -140,7 +140,7 @@ std::unique_ptr<table> gather(
  */
 std::unique_ptr<table> reverse(
   table_view const& source_table,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -160,7 +160,7 @@ std::unique_ptr<table> reverse(
  */
 std::unique_ptr<column> reverse(
   column_view const& source_column,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -209,7 +209,7 @@ std::unique_ptr<table> scatter(
   table_view const& source,
   column_view const& scatter_map,
   table_view const& target,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -252,7 +252,7 @@ std::unique_ptr<table> scatter(
   std::vector<std::reference_wrapper<scalar const>> const& source,
   column_view const& indices,
   table_view const& target,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -300,7 +300,7 @@ std::unique_ptr<column> empty_like(scalar const& input);
 std::unique_ptr<column> allocate_like(
   column_view const& input,
   mask_allocation_policy mask_alloc = mask_allocation_policy::RETAIN,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -323,7 +323,7 @@ std::unique_ptr<column> allocate_like(
   column_view const& input,
   size_type size,
   mask_allocation_policy mask_alloc = mask_allocation_policy::RETAIN,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -375,7 +375,7 @@ void copy_range_in_place(column_view const& source,
                          size_type source_begin,
                          size_type source_end,
                          size_type target_begin,
-                         rmm::cuda_stream_view stream = cudf::get_default_stream());
+                         cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Copies a range of elements out-of-place from one column to another.
@@ -415,7 +415,7 @@ std::unique_ptr<column> copy_range(
   size_type source_begin,
   size_type source_end,
   size_type target_begin,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -459,7 +459,7 @@ std::unique_ptr<column> shift(
   column_view const& input,
   size_type offset,
   scalar const& fill_value,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -495,14 +495,14 @@ std::unique_ptr<column> shift(
  */
 std::vector<column_view> slice(column_view const& input,
                                std::span<size_type const> indices,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               cuda::stream_ref stream = cudf::get_default_stream());
 /**
  * @ingroup copy_slice
- * @copydoc cudf::slice(column_view const&, std::span<size_type const>, rmm::cuda_stream_view)
+ * @copydoc cudf::slice(column_view const&, std::span<size_type const>, cuda::stream_ref)
  */
 std::vector<column_view> slice(column_view const& input,
                                std::initializer_list<size_type> indices,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Slices a `table_view` into a set of `table_view`s according to a set of indices.
@@ -539,14 +539,14 @@ std::vector<column_view> slice(column_view const& input,
  */
 std::vector<table_view> slice(table_view const& input,
                               std::span<size_type const> indices,
-                              rmm::cuda_stream_view stream = cudf::get_default_stream());
+                              cuda::stream_ref stream = cudf::get_default_stream());
 /**
  * @ingroup copy_slice
- * @copydoc cudf::slice(table_view const&, std::span<size_type const>, rmm::cuda_stream_view stream)
+ * @copydoc cudf::slice(table_view const&, std::span<size_type const>, cuda::stream_ref stream)
  */
 std::vector<table_view> slice(table_view const& input,
                               std::initializer_list<size_type> indices,
-                              rmm::cuda_stream_view stream = cudf::get_default_stream());
+                              cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Splits a `column_view` into a set of `column_view`s according to a set of indices
@@ -583,14 +583,14 @@ std::vector<table_view> slice(table_view const& input,
  */
 std::vector<column_view> split(column_view const& input,
                                std::span<size_type const> splits,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               cuda::stream_ref stream = cudf::get_default_stream());
 /**
  * @ingroup copy_split
- * @copydoc cudf::split(column_view const&, std::span<size_type const>, rmm::cuda_stream_view)
+ * @copydoc cudf::split(column_view const&, std::span<size_type const>, cuda::stream_ref)
  */
 std::vector<column_view> split(column_view const& input,
                                std::initializer_list<size_type> splits,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Splits a `table_view` into a set of `table_view`s according to a set of indices
@@ -629,14 +629,14 @@ std::vector<column_view> split(column_view const& input,
  */
 std::vector<table_view> split(table_view const& input,
                               std::span<size_type const> splits,
-                              rmm::cuda_stream_view stream = cudf::get_default_stream());
+                              cuda::stream_ref stream = cudf::get_default_stream());
 /**
  * @ingroup copy_split
- * @copydoc cudf::split(table_view const&, std::span<size_type const>, rmm::cuda_stream_view)
+ * @copydoc cudf::split(table_view const&, std::span<size_type const>, cuda::stream_ref)
  */
 std::vector<table_view> split(table_view const& input,
                               std::initializer_list<size_type> splits,
-                              rmm::cuda_stream_view stream = cudf::get_default_stream());
+                              cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief   Returns a new column, where each element is selected from either @p lhs or
@@ -662,7 +662,7 @@ std::unique_ptr<column> copy_if_else(
   column_view const& lhs,
   column_view const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -688,7 +688,7 @@ std::unique_ptr<column> copy_if_else(
   scalar const& lhs,
   column_view const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -714,7 +714,7 @@ std::unique_ptr<column> copy_if_else(
   column_view const& lhs,
   scalar const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -738,7 +738,7 @@ std::unique_ptr<column> copy_if_else(
   scalar const& lhs,
   scalar const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -782,7 +782,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   table_view const& input,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -821,7 +821,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   std::vector<std::reference_wrapper<scalar const>> const& input,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -841,7 +841,7 @@ std::unique_ptr<table> boolean_mask_scatter(
 std::unique_ptr<scalar> get_element(
   column_view const& input,
   size_type index,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -885,7 +885,7 @@ std::unique_ptr<table> sample(
   size_type const n,
   sample_with_replacement replacement = sample_with_replacement::FALSE,
   int64_t const seed                  = 0,
-  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  cuda::stream_ref stream             = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr   = cudf::get_current_device_resource_ref());
 
 /**
@@ -906,7 +906,7 @@ std::unique_ptr<table> sample(
  * @return false If neither the column or its descendants have non-empty null rows
  */
 bool has_nonempty_nulls(column_view const& input,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream());
+                        cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Approximates if a column or its descendants *may* have non-empty null elements
@@ -1002,7 +1002,7 @@ bool may_have_nonempty_nulls(column_view const& input);
  */
 std::unique_ptr<column> purge_nonempty_nulls(
   column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */

--- a/cpp/include/cudf/detail/concatenate.hpp
+++ b/cpp/include/cudf/detail/concatenate.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <span>
 #include <vector>
@@ -21,18 +21,18 @@ namespace cudf {
 namespace detail {
 /**
  * @copydoc cudf::concatenate(std::span<column_view
- * const>,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * const>,cuda::stream_ref,rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> concatenate(std::span<column_view const> columns_to_concat,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::concatenate(std::span<table_view
- * const>,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * const>,cuda::stream_ref,rmm::device_async_resource_ref)
  */
 std::unique_ptr<table> concatenate(std::span<table_view const> tables_to_concat,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/concatenate_masks.hpp
+++ b/cpp/include/cudf/detail/concatenate_masks.hpp
@@ -9,8 +9,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+
+#include <cuda/stream_ref>
 
 #include <span>
 
@@ -33,7 +34,7 @@ size_type concatenate_masks(device_span<column_device_view const> d_views,
                             device_span<size_t const> d_offsets,
                             bitmask_type* dest_mask,
                             size_type output_size,
-                            rmm::cuda_stream_view stream);
+                            cuda::stream_ref stream);
 
 /**
  * @brief Concatenates `views[i]`'s bitmask from the bits
@@ -47,7 +48,7 @@ size_type concatenate_masks(device_span<column_device_view const> d_views,
  */
 size_type concatenate_masks(host_span<column_view const> views,
                             bitmask_type* dest_mask,
-                            rmm::cuda_stream_view stream);
+                            cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::concatenate_masks(std::span<column_view const>, rmm::device_async_resource_ref)
@@ -55,7 +56,7 @@ size_type concatenate_masks(host_span<column_view const> views,
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 rmm::device_buffer concatenate_masks(std::span<column_view const> views,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/contiguous_split.hpp
+++ b/cpp/include/cudf/detail/contiguous_split.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <optional>
@@ -23,14 +23,14 @@ namespace detail {
  **/
 std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            std::vector<size_type> const& splits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::pack
  **/
 packed_columns pack(cudf::table_view const& input,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr);
 
 // opaque implementation of `metadata_builder` since it needs to use

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -13,7 +13,7 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <initializer_list>
 #include <span>
@@ -39,10 +39,7 @@ namespace detail {
  * @return ColumnView View of the elements `[begin,end)` from `input`.
  */
 template <typename ColumnView>
-ColumnView slice(ColumnView const& input,
-                 size_type begin,
-                 size_type end,
-                 rmm::cuda_stream_view stream);
+ColumnView slice(ColumnView const& input, size_type begin, size_type end, cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::slice(column_view const&, std::span<size_type const>)
@@ -51,7 +48,7 @@ ColumnView slice(ColumnView const& input,
  */
 std::vector<column_view> slice(column_view const& input,
                                std::span<size_type const> indices,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 /**
  * @copydoc cudf::slice(column_view const&, std::initializer_list<size_type>)
  *
@@ -59,7 +56,7 @@ std::vector<column_view> slice(column_view const& input,
  */
 std::vector<column_view> slice(column_view const& input,
                                std::initializer_list<size_type> indices,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::slice(table_view const&, std::span<size_type const>)
@@ -68,7 +65,7 @@ std::vector<column_view> slice(column_view const& input,
  */
 std::vector<table_view> slice(table_view const& input,
                               std::span<size_type const> indices,
-                              rmm::cuda_stream_view stream);
+                              cuda::stream_ref stream);
 /**
  * @copydoc cudf::slice(table_view const&, std::initializer_list<size_type>)
  *
@@ -76,7 +73,7 @@ std::vector<table_view> slice(table_view const& input,
  */
 std::vector<table_view> slice(table_view const& input,
                               std::initializer_list<size_type> indices,
-                              rmm::cuda_stream_view stream);
+                              cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::split(column_view const&, std::span<size_type const>)
@@ -85,7 +82,7 @@ std::vector<table_view> slice(table_view const& input,
  */
 std::vector<column_view> split(column_view const& input,
                                std::span<size_type const> splits,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 /**
  * @copydoc cudf::split(column_view const&, std::initializer_list<size_type>)
  *
@@ -93,7 +90,7 @@ std::vector<column_view> split(column_view const& input,
  */
 std::vector<column_view> split(column_view const& input,
                                std::initializer_list<size_type> splits,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::split(table_view const&, std::span<size_type const>)
@@ -102,7 +99,7 @@ std::vector<column_view> split(column_view const& input,
  */
 std::vector<table_view> split(table_view const& input,
                               std::span<size_type const> splits,
-                              rmm::cuda_stream_view stream);
+                              cuda::stream_ref stream);
 /**
  * @copydoc cudf::split(table_view const&, std::initializer_list<size_type>)
  *
@@ -110,7 +107,7 @@ std::vector<table_view> split(table_view const& input,
  */
 std::vector<table_view> split(table_view const& input,
                               std::initializer_list<size_type> splits,
-                              rmm::cuda_stream_view stream);
+                              cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::shift(column_view const&,size_type,scalar const&,
@@ -121,7 +118,7 @@ std::vector<table_view> split(table_view const& input,
 std::unique_ptr<column> shift(column_view const& input,
                               size_type offset,
                               scalar const& fill_value,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 /**
@@ -161,7 +158,7 @@ std::unique_ptr<column> segmented_shift(column_view const& segmented_values,
                                         device_span<size_type const> segment_offsets,
                                         size_type offset,
                                         scalar const& fill_value,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -173,7 +170,7 @@ std::unique_ptr<column> segmented_shift(column_view const& segmented_values,
 std::unique_ptr<column> allocate_like(column_view const& input,
                                       size_type size,
                                       mask_allocation_policy mask_alloc,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -185,7 +182,7 @@ std::unique_ptr<column> allocate_like(column_view const& input,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -197,7 +194,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -209,7 +206,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -221,7 +218,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -233,7 +230,7 @@ std::unique_ptr<table> sample(table_view const& input,
                               size_type const n,
                               sample_with_replacement replacement,
                               int64_t const seed,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 /**
@@ -243,7 +240,7 @@ std::unique_ptr<table> sample(table_view const& input,
  */
 std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -251,14 +248,14 @@ std::unique_ptr<scalar> get_element(column_view const& input,
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-bool has_nonempty_nulls(column_view const& input, rmm::cuda_stream_view stream);
+bool has_nonempty_nulls(column_view const& input, cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::may_have_nonempty_nulls
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-bool may_have_nonempty_nulls(column_view const& input, rmm::cuda_stream_view stream);
+bool may_have_nonempty_nulls(column_view const& input, cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::purge_nonempty_nulls
@@ -266,7 +263,7 @@ bool may_have_nonempty_nulls(column_view const& input, rmm::cuda_stream_view str
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> purge_nonempty_nulls(column_view const& input,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -18,9 +18,8 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cub/cub.cuh>
+#include <cuda/stream_ref>
 #include <cuda_runtime.h>
 
 #include <memory>
@@ -122,7 +121,7 @@ void copy_range(SourceValueIterator source_value_begin,
                 mutable_column_view& target,
                 size_type target_begin,
                 size_type target_end,
-                rmm::cuda_stream_view stream)
+                cuda::stream_ref stream)
 {
   CUDF_EXPECTS((target_begin <= target_end) && (target_begin >= 0) &&
                  (target_begin < target.size()) && (target_end <= target.size()),
@@ -146,7 +145,7 @@ void copy_range(SourceValueIterator source_value_begin,
 
     auto kernel =
       copy_range_kernel<block_size, SourceValueIterator, SourceValidityIterator, T, true>;
-    kernel<<<grid.num_blocks, block_size, 0, stream.value()>>>(
+    kernel<<<grid.num_blocks, block_size, 0, stream.get()>>>(
       source_value_begin,
       source_validity_begin,
       *mutable_column_device_view::create(target, stream),
@@ -158,7 +157,7 @@ void copy_range(SourceValueIterator source_value_begin,
   } else {
     auto kernel =
       copy_range_kernel<block_size, SourceValueIterator, SourceValidityIterator, T, false>;
-    kernel<<<grid.num_blocks, block_size, 0, stream.value()>>>(
+    kernel<<<grid.num_blocks, block_size, 0, stream.get()>>>(
       source_value_begin,
       source_validity_begin,
       *mutable_column_device_view::create(target, stream),
@@ -167,7 +166,7 @@ void copy_range(SourceValueIterator source_value_begin,
       nullptr);
   }
 
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 /**
@@ -179,7 +178,7 @@ void copy_range_in_place(column_view const& source,
                          size_type source_begin,
                          size_type source_end,
                          size_type target_begin,
-                         rmm::cuda_stream_view stream);
+                         cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::copy_range
@@ -191,7 +190,7 @@ std::unique_ptr<column> copy_range(column_view const& source,
                                    size_type source_begin,
                                    size_type source_end,
                                    size_type target_begin,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::detail

--- a/cpp/include/cudf/detail/fill.hpp
+++ b/cpp/include/cudf/detail/fill.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -24,7 +24,7 @@ void fill_in_place(mutable_column_view& destination,
                    size_type begin,
                    size_type end,
                    scalar const& value,
-                   rmm::cuda_stream_view stream);
+                   cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::fill
@@ -33,7 +33,7 @@ std::unique_ptr<column> fill(column_view const& input,
                              size_type begin,
                              size_type end,
                              scalar const& value,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/gather.hpp
+++ b/cpp/include/cudf/detail/gather.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -22,19 +22,19 @@ namespace detail {
 
 /**
  * @copydoc cudf::gather(table_view const&,column_view const&,table_view
- * const&,cudf::out_of_bounds_policy,cudf::negative_index_policy,rmm::cuda_stream_view,
+ * const&,cudf::out_of_bounds_policy,cudf::negative_index_policy,cuda::stream_ref,
  * rmm::device_async_resource_ref)
  */
 std::unique_ptr<table> gather(table_view const& source_table,
                               column_view const& gather_map,
                               out_of_bounds_policy bounds_policy,
                               negative_index_policy neg_indices,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::detail::gather(table_view const&,column_view const&,table_view
- * const&,cudf::out_of_bounds_policy,cudf::negative_index_policy,rmm::cuda_stream_view,
+ * const&,cudf::out_of_bounds_policy,cudf::negative_index_policy,cuda::stream_ref,
  * rmm::device_async_resource_ref)
  *
  * @throws cudf::logic_error if `gather_map` span size is larger than max of `size_type`.
@@ -43,7 +43,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                               device_span<size_type const> const gather_map,
                               out_of_bounds_policy bounds_policy,
                               negative_index_policy neg_indices,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/repeat.hpp
+++ b/cpp/include/cudf/detail/repeat.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -18,21 +18,21 @@ namespace detail {
 
 /**
  * @copydoc cudf::repeat(table_view const&, column_view const&, bool,
- * rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<table> repeat(table_view const& input_table,
                               column_view const& count,
                               bool check_count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::repeat(table_view const&, size_type,
- * rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<table> repeat(table_view const& input_table,
                               size_type count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -23,10 +23,10 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scatter.h>
@@ -58,7 +58,7 @@ template <typename MapIterator>
 auto scatter_to_gather(MapIterator scatter_map_begin,
                        MapIterator scatter_map_end,
                        size_type gather_rows,
-                       rmm::cuda_stream_view stream)
+                       cuda::stream_ref stream)
 {
   using MapValueType = cuda::std::iter_value_t<MapIterator>;
 
@@ -101,7 +101,7 @@ template <typename MapIterator>
 auto scatter_to_gather_complement(MapIterator scatter_map_begin,
                                   MapIterator scatter_map_end,
                                   size_type gather_rows,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   auto gather_map = rmm::device_uvector<size_type>(gather_rows, stream);
   thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -137,7 +137,7 @@ struct column_scatterer_impl<Element, std::enable_if_t<cudf::is_fixed_width<Elem
                                      MapIterator scatter_map_begin,
                                      MapIterator scatter_map_end,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     auto result      = std::make_unique<column>(target, stream, mr);
@@ -162,7 +162,7 @@ struct column_scatterer_impl<string_view> {
                                      MapIterator scatter_map_begin,
                                      MapIterator scatter_map_end,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     auto d_column    = column_device_view::create(source, stream);
@@ -179,7 +179,7 @@ struct column_scatterer_impl<list_view> {
                                      MapIterator scatter_map_begin,
                                      MapIterator scatter_map_end,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     return cudf::lists::detail::scatter(
@@ -194,7 +194,7 @@ struct column_scatterer_impl<dictionary32> {
                                      MapIterator scatter_map_begin,
                                      MapIterator scatter_map_end,
                                      column_view const& target_in,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     if (target_in.is_empty())  // empty begets empty
@@ -240,7 +240,7 @@ struct column_scatterer {
                                      MapIterator scatter_map_begin,
                                      MapIterator scatter_map_end,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     column_scatterer_impl<Element> scatterer{};
@@ -255,7 +255,7 @@ struct column_scatterer_impl<struct_view> {
                                      MapItRoot scatter_map_begin,
                                      MapItRoot scatter_map_end,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(source.num_children() == target.num_children(),
@@ -368,7 +368,7 @@ std::unique_ptr<table> scatter(table_view const& source,
                                MapIterator scatter_map_begin,
                                MapIterator scatter_map_end,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/include/cudf/detail/scatter.hpp
+++ b/cpp/include/cudf/detail/scatter.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -53,19 +53,19 @@ namespace detail {
 std::unique_ptr<table> scatter(table_view const& source,
                                column_view const& scatter_map,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::detail::scatter(table_view const&,column_view const&,table_view
- * const&,bool,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * const&,bool,cuda::stream_ref,rmm::device_async_resource_ref)
  *
  * @throws cudf::logic_error if `scatter_map` span size is larger than max of `size_type`.
  */
 std::unique_ptr<table> scatter(table_view const& source,
                                device_span<size_type const> const scatter_map,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
@@ -100,7 +100,7 @@ std::unique_ptr<table> scatter(table_view const& source,
 std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>> const& source,
                                column_view const& indices,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
@@ -114,7 +114,7 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>>
 std::unique_ptr<table> boolean_mask_scatter(table_view const& source,
                                             table_view const& target,
                                             column_view const& boolean_mask,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 /**
@@ -130,7 +130,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   std::vector<std::reference_wrapper<scalar const>> const& source,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/search.hpp
+++ b/cpp/include/cudf/detail/search.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,8 +11,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -26,7 +27,7 @@ std::unique_ptr<column> lower_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -38,7 +39,7 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -46,7 +47,7 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_stream_view stream);
+bool contains(column_view const& haystack, scalar const& needle, cuda::stream_ref stream);
 
 /**
  * @copydoc cudf::contains(column_view const&, column_view const&, rmm::device_async_resource_ref)
@@ -55,7 +56,7 @@ bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_strea
  */
 std::unique_ptr<column> contains(column_view const& haystack,
                                  column_view const& needles,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -88,7 +89,7 @@ rmm::device_uvector<bool> contains(table_view const& haystack,
                                    table_view const& needles,
                                    null_equality compare_nulls,
                                    nan_equality compare_nans,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,27 +10,27 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 /**
- * @copydoc cudf::sequence(size_type, scalar const&, scalar const&,rmm::cuda_stream_view
+ * @copydoc cudf::sequence(size_type, scalar const&, scalar const&,cuda::stream_ref
  * stream,rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  scalar const& step,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
- * @copydoc cudf::sequence(size_type, scalar const&, rmm::cuda_stream_view,
+ * @copydoc cudf::sequence(size_type, scalar const&, cuda::stream_ref,
  * rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -42,7 +42,7 @@ std::unique_ptr<column> sequence(size_type size,
 std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          scalar const& init,
                                                          size_type months,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/detail/concatenate.hpp
+++ b/cpp/include/cudf/dictionary/detail/concatenate.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary::detail {
@@ -27,7 +27,7 @@ namespace dictionary::detail {
  * @return New column with concatenated results.
  */
 std::unique_ptr<column> concatenate(host_span<column_view const> columns,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 }  // namespace dictionary::detail

--- a/cpp/include/cudf/dictionary/detail/encode.hpp
+++ b/cpp/include/cudf/dictionary/detail/encode.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary::detail {
@@ -42,7 +42,7 @@ namespace dictionary::detail {
  */
 std::unique_ptr<column> encode(column_view const& column,
                                data_type indices_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
@@ -61,7 +61,7 @@ std::unique_ptr<column> encode(column_view const& column,
  * @return New column with type matching the dictionary_column's keys.
  */
 std::unique_ptr<column> decode(dictionary_column_view const& dictionary_column,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**

--- a/cpp/include/cudf/dictionary/detail/merge.hpp
+++ b/cpp/include/cudf/dictionary/detail/merge.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary::detail {
@@ -32,7 +32,7 @@ namespace dictionary::detail {
 std::unique_ptr<column> merge(dictionary_column_view const& lcol,
                               dictionary_column_view const& rcol,
                               cudf::detail::index_vector const& row_order,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 }  // namespace dictionary::detail

--- a/cpp/include/cudf/dictionary/detail/replace.hpp
+++ b/cpp/include/cudf/dictionary/detail/replace.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary::detail {
@@ -30,7 +30,7 @@ namespace dictionary::detail {
  */
 std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
                                       dictionary_column_view const& replacement,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -47,7 +47,7 @@ std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
  */
 std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
                                       scalar const& replacement,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 }  // namespace dictionary::detail

--- a/cpp/include/cudf/dictionary/detail/search.hpp
+++ b/cpp/include/cudf/dictionary/detail/search.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary {
@@ -23,7 +23,7 @@ namespace detail {
  */
 std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   scalar const& key,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/detail/update_keys.hpp
+++ b/cpp/include/cudf/dictionary/detail/update_keys.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <span>
 
@@ -25,7 +25,7 @@ namespace dictionary::detail {
  */
 std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column,
                                  column_view const& new_keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -36,7 +36,7 @@ std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column
  */
 std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_column,
                                     column_view const& keys_to_remove,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -46,7 +46,7 @@ std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_col
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr);
 
 /**
@@ -57,7 +57,7 @@ std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& diction
  */
 std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column,
                                  column_view const& keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -68,7 +68,7 @@ std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column
  */
 std::vector<std::unique_ptr<column>> match_dictionaries(
   std::span<dictionary_column_view const> input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -91,7 +91,7 @@ std::vector<std::unique_ptr<column>> match_dictionaries(
  * @return New dictionary columns and updated cudf::table_views.
  */
 std::pair<std::vector<std::unique_ptr<column>>, std::vector<table_view>> match_dictionaries(
-  std::vector<table_view> tables, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  std::vector<table_view> tables, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
 }  // namespace dictionary::detail
 }  // namespace cudf

--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 /**
  * @file
@@ -55,7 +55,7 @@ namespace CUDF_EXPORT cudf {
 std::unique_ptr<column> make_dictionary_column(
   column_view const& keys_column,
   column_view const& indices_column,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -103,7 +103,7 @@ std::unique_ptr<column> make_dictionary_column(std::unique_ptr<column> keys_colu
 std::unique_ptr<column> make_dictionary_column(
   std::unique_ptr<column> keys_column,
   std::unique_ptr<column> indices_column,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/dictionary/encode.hpp
+++ b/cpp/include/cudf/dictionary/encode.hpp
@@ -53,7 +53,7 @@ namespace dictionary {
 std::unique_ptr<column> encode(
   column_view const& column,
   data_type indices_type            = data_type{type_id::INT32},
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -73,7 +73,7 @@ std::unique_ptr<column> encode(
  */
 std::unique_ptr<column> decode(
   dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/dictionary/search.hpp
+++ b/cpp/include/cudf/dictionary/search.hpp
@@ -36,7 +36,7 @@ namespace dictionary {
 std::unique_ptr<scalar> get_index(
   dictionary_column_view const& dictionary,
   scalar const& key,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/dictionary/update_keys.hpp
+++ b/cpp/include/cudf/dictionary/update_keys.hpp
@@ -52,7 +52,7 @@ namespace dictionary {
 std::unique_ptr<column> add_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& new_keys,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -84,7 +84,7 @@ std::unique_ptr<column> add_keys(
 std::unique_ptr<column> remove_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& keys_to_remove,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -106,7 +106,7 @@ std::unique_ptr<column> remove_keys(
  */
 std::unique_ptr<column> remove_unused_keys(
   dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -143,7 +143,7 @@ std::unique_ptr<column> remove_unused_keys(
 std::unique_ptr<column> set_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& keys,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -159,7 +159,7 @@ std::unique_ptr<column> set_keys(
  */
 std::vector<std::unique_ptr<column>> match_dictionaries(
   std::span<dictionary_column_view const> input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -53,7 +53,7 @@ void fill_in_place(mutable_column_view& destination,
                    size_type begin,
                    size_type end,
                    scalar const& value,
-                   rmm::cuda_stream_view stream = cudf::get_default_stream());
+                   cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Fills a range of elements in a column out-of-place with a scalar
@@ -83,7 +83,7 @@ std::unique_ptr<column> fill(
   size_type begin,
   size_type end,
   scalar const& value,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -117,7 +117,7 @@ std::unique_ptr<column> fill(
 std::unique_ptr<table> repeat(
   table_view const& input_table,
   column_view const& count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -142,7 +142,7 @@ std::unique_ptr<table> repeat(
 std::unique_ptr<table> repeat(
   table_view const& input_table,
   size_type count,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -174,7 +174,7 @@ std::unique_ptr<column> sequence(
   size_type size,
   scalar const& init,
   scalar const& step,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -202,7 +202,7 @@ std::unique_ptr<column> sequence(
 std::unique_ptr<column> sequence(
   size_type size,
   scalar const& init,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -233,7 +233,7 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(
   size_type size,
   scalar const& init,
   size_type months,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/partitioning.hpp
+++ b/cpp/include/cudf/partitioning.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <vector>
@@ -72,7 +72,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> partition(
   table_view const& t,
   column_view const& partition_map,
   size_type num_partitions,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -106,7 +106,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function             = hash_id::HASH_MURMUR3,
   uint32_t seed                     = DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -141,7 +141,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function             = hash_id::HASH_MURMUR3,
   uint32_t seed                     = DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -287,7 +287,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> round_robi
   table_view const& input,
   cudf::size_type num_partitions,
   cudf::size_type start_partition   = 0,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -12,9 +12,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
+
+#include <cuda/stream_ref>
 
 #include <span>
 #include <string_view>
@@ -58,7 +59,7 @@ class scalar {
    * @param is_valid true: set the value to valid. false: set it to null.
    * @param stream CUDA stream used for device memory operations.
    */
-  void set_valid_async(bool is_valid, rmm::cuda_stream_view stream = cudf::get_default_stream());
+  void set_valid_async(bool is_valid, cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Indicates whether the scalar contains a valid value.
@@ -70,7 +71,7 @@ class scalar {
    * @return true Value is valid
    * @return false Value is invalid/null
    */
-  [[nodiscard]] bool is_valid(rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] bool is_valid(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Returns a raw pointer to the validity bool in device memory.
@@ -104,7 +105,7 @@ class scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   scalar(scalar const& other,
-         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         cuda::stream_ref stream           = cudf::get_default_stream(),
          rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -120,7 +121,7 @@ class scalar {
    */
   scalar(data_type type,
          bool is_valid                     = false,
-         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         cuda::stream_ref stream           = cudf::get_default_stream(),
          rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 };
 
@@ -157,7 +158,7 @@ class fixed_width_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   fixed_width_scalar(fixed_width_scalar const& other,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -166,7 +167,7 @@ class fixed_width_scalar : public scalar {
    * @param value New value of scalar.
    * @param stream CUDA stream used for device memory operations.
    */
-  void set_value(T value, rmm::cuda_stream_view stream = cudf::get_default_stream());
+  void set_value(T value, cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Get the value of the scalar.
@@ -174,7 +175,7 @@ class fixed_width_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return Value of the scalar
    */
-  [[nodiscard]] T value(rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] T value(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Returns a raw pointer to the value in device memory.
@@ -201,7 +202,7 @@ class fixed_width_scalar : public scalar {
    */
   fixed_width_scalar(T value,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -214,7 +215,7 @@ class fixed_width_scalar : public scalar {
    */
   fixed_width_scalar(rmm::device_scalar<T>&& data,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 };
 
@@ -250,7 +251,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   numeric_scalar(numeric_scalar const& other,
-                 rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                 cuda::stream_ref stream           = cudf::get_default_stream(),
                  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -263,7 +264,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    */
   numeric_scalar(T value,
                  bool is_valid                     = true,
-                 rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                 cuda::stream_ref stream           = cudf::get_default_stream(),
                  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -276,7 +277,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    */
   numeric_scalar(rmm::device_scalar<T>&& data,
                  bool is_valid                     = true,
-                 rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                 cuda::stream_ref stream           = cudf::get_default_stream(),
                  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 };
 
@@ -313,7 +314,7 @@ class fixed_point_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   fixed_point_scalar(fixed_point_scalar const& other,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -328,7 +329,7 @@ class fixed_point_scalar : public scalar {
   fixed_point_scalar(rep_type value,
                      numeric::scale_type scale,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -341,7 +342,7 @@ class fixed_point_scalar : public scalar {
    */
   fixed_point_scalar(rep_type value,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -354,7 +355,7 @@ class fixed_point_scalar : public scalar {
    */
   fixed_point_scalar(T value,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -369,7 +370,7 @@ class fixed_point_scalar : public scalar {
   fixed_point_scalar(rmm::device_scalar<rep_type>&& data,
                      numeric::scale_type scale,
                      bool is_valid                     = true,
-                     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                     cuda::stream_ref stream           = cudf::get_default_stream(),
                      rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -378,7 +379,7 @@ class fixed_point_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The value of the scalar
    */
-  [[nodiscard]] rep_type value(rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] rep_type value(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Get the decimal32, decimal64 or decimal128.
@@ -386,8 +387,7 @@ class fixed_point_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The decimal32, decimal64 or decimal128 value
    */
-  [[nodiscard]] T fixed_point_value(
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] T fixed_point_value(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Returns a raw pointer to the value in device memory.
@@ -433,7 +433,7 @@ class string_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   string_scalar(string_scalar const& other,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -448,7 +448,7 @@ class string_scalar : public scalar {
    */
   string_scalar(std::string_view string,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -463,7 +463,7 @@ class string_scalar : public scalar {
    */
   string_scalar(value_type const& source,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -478,7 +478,7 @@ class string_scalar : public scalar {
    */
   string_scalar(rmm::device_scalar<value_type>& data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -494,7 +494,7 @@ class string_scalar : public scalar {
    */
   string_scalar(rmm::device_buffer&& data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -503,8 +503,7 @@ class string_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The value of the scalar in a host std::string
    */
-  [[nodiscard]] std::string to_string(
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] std::string to_string(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Get the value of the scalar as a string_view.
@@ -512,7 +511,7 @@ class string_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The value of the scalar as a string_view
    */
-  [[nodiscard]] value_type value(rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] value_type value(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Returns the size of the string in bytes.
@@ -561,7 +560,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   chrono_scalar(chrono_scalar const& other,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -574,7 +573,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    */
   chrono_scalar(T value,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -587,7 +586,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    */
   chrono_scalar(rmm::device_scalar<T>&& data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 };
 
@@ -620,7 +619,7 @@ class timestamp_scalar : public chrono_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   timestamp_scalar(timestamp_scalar const& other,
-                   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                   cuda::stream_ref stream           = cudf::get_default_stream(),
                    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -636,7 +635,7 @@ class timestamp_scalar : public chrono_scalar<T> {
   template <typename Duration2>
   timestamp_scalar(Duration2 const& value,
                    bool is_valid,
-                   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                   cuda::stream_ref stream           = cudf::get_default_stream(),
                    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -644,7 +643,7 @@ class timestamp_scalar : public chrono_scalar<T> {
    * @param stream CUDA stream used for device memory operations.
    * @return The duration in number of ticks since the UNIX epoch
    */
-  rep_type ticks_since_epoch(rmm::cuda_stream_view stream);
+  rep_type ticks_since_epoch(cuda::stream_ref stream);
 };
 
 /**
@@ -676,7 +675,7 @@ class duration_scalar : public chrono_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   duration_scalar(duration_scalar const& other,
-                  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                  cuda::stream_ref stream           = cudf::get_default_stream(),
                   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -689,7 +688,7 @@ class duration_scalar : public chrono_scalar<T> {
    */
   duration_scalar(rep_type value,
                   bool is_valid,
-                  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                  cuda::stream_ref stream           = cudf::get_default_stream(),
                   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -697,7 +696,7 @@ class duration_scalar : public chrono_scalar<T> {
    * @param stream CUDA stream used for device memory operations.
    * @return The duration in number of ticks
    */
-  rep_type count(rmm::cuda_stream_view stream);
+  rep_type count(cuda::stream_ref stream);
 };
 
 /**
@@ -725,7 +724,7 @@ class list_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   list_scalar(list_scalar const& other,
-              rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+              cuda::stream_ref stream           = cudf::get_default_stream(),
               rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -740,7 +739,7 @@ class list_scalar : public scalar {
    */
   list_scalar(cudf::column_view const& data,
               bool is_valid                     = true,
-              rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+              cuda::stream_ref stream           = cudf::get_default_stream(),
               rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -753,7 +752,7 @@ class list_scalar : public scalar {
    */
   list_scalar(cudf::column&& data,
               bool is_valid                     = true,
-              rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+              cuda::stream_ref stream           = cudf::get_default_stream(),
               rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -790,7 +789,7 @@ class struct_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   struct_scalar(struct_scalar const& other,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -805,7 +804,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(table_view const& data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -820,7 +819,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(std::span<column_view const> data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -836,7 +835,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(table&& data,
                 bool is_valid                     = true,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -864,7 +863,7 @@ class struct_scalar : public scalar {
    */
   static table init_data(table&& data,
                          bool is_valid,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr);
 };
 

--- a/cpp/include/cudf/scalar/scalar_factories.hpp
+++ b/cpp/include/cudf/scalar/scalar_factories.hpp
@@ -10,6 +10,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuda/stream_ref>
+
 #include <span>
 
 /**
@@ -37,7 +39,7 @@ namespace CUDF_EXPORT cudf {
  */
 std::unique_ptr<scalar> make_numeric_scalar(
   data_type type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -54,7 +56,7 @@ std::unique_ptr<scalar> make_numeric_scalar(
  */
 std::unique_ptr<scalar> make_timestamp_scalar(
   data_type type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -71,7 +73,7 @@ std::unique_ptr<scalar> make_timestamp_scalar(
  */
 std::unique_ptr<scalar> make_duration_scalar(
   data_type type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -88,7 +90,7 @@ std::unique_ptr<scalar> make_duration_scalar(
  */
 std::unique_ptr<scalar> make_fixed_width_scalar(
   data_type type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -120,7 +122,7 @@ std::unique_ptr<scalar> make_string_scalar(
  */
 std::unique_ptr<scalar> make_default_constructed_scalar(
   data_type type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -135,7 +137,7 @@ std::unique_ptr<scalar> make_default_constructed_scalar(
  */
 std::unique_ptr<scalar> make_empty_scalar_like(
   column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -150,7 +152,7 @@ std::unique_ptr<scalar> make_empty_scalar_like(
 template <typename T>
 std::unique_ptr<scalar> make_fixed_width_scalar(
   T value,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   return std::make_unique<scalar_type_t<T>>(value, true, stream, mr);
@@ -170,7 +172,7 @@ template <typename T>
 std::unique_ptr<scalar> make_fixed_point_scalar(
   typename T::rep value,
   numeric::scale_type scale,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   return std::make_unique<scalar_type_t<T>>(value, scale, true, stream, mr);
@@ -186,7 +188,7 @@ std::unique_ptr<scalar> make_fixed_point_scalar(
  */
 std::unique_ptr<scalar> make_list_scalar(
   column_view elements,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -201,7 +203,7 @@ std::unique_ptr<scalar> make_list_scalar(
  */
 std::unique_ptr<scalar> make_struct_scalar(
   table_view const& data,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -216,7 +218,7 @@ std::unique_ptr<scalar> make_struct_scalar(
  */
 std::unique_ptr<scalar> make_struct_scalar(
   std::span<column_view const> data,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/search.hpp
+++ b/cpp/include/cudf/search.hpp
@@ -64,7 +64,7 @@ std::unique_ptr<column> lower_bound(
   table_view const& needles,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -106,7 +106,7 @@ std::unique_ptr<column> upper_bound(
   table_view const& needles,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -129,7 +129,7 @@ std::unique_ptr<column> upper_bound(
  */
 bool contains(column_view const& haystack,
               scalar const& needle,
-              rmm::cuda_stream_view stream = cudf::get_default_stream());
+              cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Check if the given `needles` values exists in the `haystack` column.
@@ -155,7 +155,7 @@ bool contains(column_view const& haystack,
 std::unique_ptr<column> contains(
   column_view const& haystack,
   column_view const& needles,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf_test/column_utilities.hpp
+++ b/cpp/include/cudf_test/column_utilities.hpp
@@ -18,8 +18,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 
@@ -57,7 +56,7 @@ bool expect_column_properties_equal(
   cudf::column_view const& lhs,
   cudf::column_view const& rhs,
   debug_output_level verbosity = debug_output_level::FIRST_ERROR,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
+  cuda::stream_ref stream      = cudf::test::get_default_stream(),
   cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
 
 /**
@@ -82,7 +81,7 @@ bool expect_column_properties_equivalent(
   cudf::column_view const& lhs,
   cudf::column_view const& rhs,
   debug_output_level verbosity = debug_output_level::FIRST_ERROR,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
+  cuda::stream_ref stream      = cudf::test::get_default_stream(),
   cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
 
 /**
@@ -104,7 +103,7 @@ bool expect_column_properties_equivalent(
 bool expect_columns_equal(cudf::column_view const& lhs,
                           cudf::column_view const& rhs,
                           debug_output_level verbosity = debug_output_level::FIRST_ERROR,
-                          rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
+                          cuda::stream_ref stream      = cudf::test::get_default_stream(),
                           cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
 
 /**
@@ -130,7 +129,7 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
                                cudf::column_view const& rhs,
                                debug_output_level verbosity = debug_output_level::FIRST_ERROR,
                                size_type fp_ulps            = cudf::test::default_ulp,
-                               rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
+                               cuda::stream_ref stream      = cudf::test::get_default_stream(),
                                cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -147,8 +146,8 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
 void expect_equal_buffers(void const* lhs,
                           void const* rhs,
                           std::size_t size_bytes,
-                          rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-                          cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+                          cuda::stream_ref stream   = cudf::test::get_default_stream(),
+                          cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 }  // namespace detail
 
@@ -169,8 +168,8 @@ void expect_column_empty(cudf::column_view const& col);
  */
 std::vector<bitmask_type> bitmask_to_host(
   cudf::column_view const& c,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+  cuda::stream_ref stream   = cudf::test::get_default_stream(),
+  cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Validates bitmask situated in host as per `number_of_elements`
@@ -200,8 +199,8 @@ bool validate_host_masks(std::vector<bitmask_type> const& expected_mask,
 template <typename T, std::enable_if_t<not cudf::is_fixed_point<T>()>* = nullptr>
 std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host(
   column_view c,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref())
+  cuda::stream_ref stream   = cudf::test::get_default_stream(),
+  cudf::memory_resources mr = cudf::get_current_device_resource_ref())
 {
   auto col_span  = cudf::device_span<T const>(c.data<T>(), c.size());
   auto host_data = cudf::detail::make_host_vector(col_span, stream);
@@ -227,8 +226,8 @@ std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host(
 template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
 CUDF_EXPORT std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host(
   column_view c,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+  cuda::stream_ref stream   = cudf::test::get_default_stream(),
+  cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Copies the data and bitmask of a `column_view` of strings
@@ -244,7 +243,7 @@ CUDF_EXPORT std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host
  */
 template <>
 CUDF_EXPORT std::pair<thrust::host_vector<std::string>, std::vector<bitmask_type>> to_host(
-  column_view c, rmm::cuda_stream_view stream, cudf::memory_resources mr);
+  column_view c, cuda::stream_ref stream, cudf::memory_resources mr);
 //! @endcond
 
 /**

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,9 +24,9 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <algorithm>
@@ -37,7 +37,7 @@
 namespace cudf {
 
 // Copy ctor w/ optional stream/mr
-column::column(column const& other, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+column::column(column const& other, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
   : _type{other._type},
     _size{other._size},
     _data{other._data, stream, mr},
@@ -137,7 +137,7 @@ void column::set_null_mask(rmm::device_buffer&& new_null_mask, size_type new_nul
 
 void column::set_null_mask(rmm::device_buffer const& new_null_mask,
                            size_type new_null_count,
-                           rmm::cuda_stream_view stream)
+                           cuda::stream_ref stream)
 {
   if (new_null_count > 0) {
     CUDF_EXPECTS(new_null_mask.size() >= cudf::bitmask_allocation_size_bytes(this->size()),
@@ -157,7 +157,7 @@ void column::set_null_count(size_type new_null_count)
 namespace {
 struct create_column_from_view {
   cudf::column_view view;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   template <typename ColumnType>
@@ -253,14 +253,14 @@ struct create_column_from_view {
 }  // anonymous namespace
 
 // Copy from a view
-column::column(column_view view, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+column::column(column_view view, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
   :  // Move is needed here because the dereference operator of unique_ptr returns
      // an lvalue reference, which would otherwise dispatch to the copy constructor
     column{std::move(*type_dispatcher(view.type(), create_column_from_view{view, stream, mr}))}
 {
 }
 
-std::unique_ptr<column> rebind_stream(column&& col, rmm::cuda_stream_view stream)
+std::unique_ptr<column> rebind_stream(column&& col, cuda::stream_ref stream)
 {
   auto const dtype      = col.type();
   auto const sz         = col.size();

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -9,7 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <functional>
 #include <numeric>
@@ -54,7 +54,7 @@ namespace {
 template <typename ColumnView, typename ColumnDeviceView>
 std::unique_ptr<ColumnDeviceView, std::function<void(ColumnDeviceView*)>>
 create_device_view_from_view(ColumnView const& source,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   size_type num_children = source.num_children();
@@ -112,7 +112,7 @@ column_device_view::column_device_view(column_view source, void* h_ptr, void* d_
 // Construct a unique_ptr that invokes `destroy()` as it's deleter
 std::unique_ptr<column_device_view, std::function<void(column_device_view*)>>
 column_device_view::create(column_view source,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr)
 {
   size_type num_children = source.num_children();
@@ -166,7 +166,7 @@ void mutable_column_device_view::destroy() { delete this; }
 // Construct a unique_ptr that invokes `destroy()` as it's deleter
 std::unique_ptr<mutable_column_device_view, std::function<void(mutable_column_device_view*)>>
 mutable_column_device_view::create(mutable_column_view source,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   return source.num_children() == 0

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -62,7 +62,7 @@ std::unique_ptr<column> make_empty_column(type_id id) { return make_empty_column
 std::unique_ptr<column> make_numeric_column(data_type type,
                                             size_type size,
                                             mask_state state,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -84,7 +84,7 @@ std::unique_ptr<column> make_numeric_column(data_type type,
 std::unique_ptr<column> make_fixed_point_column(data_type type,
                                                 size_type size,
                                                 mask_state state,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -104,7 +104,7 @@ std::unique_ptr<column> make_fixed_point_column(data_type type,
 std::unique_ptr<column> make_timestamp_column(data_type type,
                                               size_type size,
                                               mask_state state,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -124,7 +124,7 @@ std::unique_ptr<column> make_timestamp_column(data_type type,
 std::unique_ptr<column> make_duration_column(data_type type,
                                              size_type size,
                                              mask_state state,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -144,7 +144,7 @@ std::unique_ptr<column> make_duration_column(data_type type,
 std::unique_ptr<column> make_fixed_width_column(data_type type,
                                                 size_type size,
                                                 mask_state state,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -162,7 +162,7 @@ std::unique_ptr<column> make_fixed_width_column(data_type type,
 
 std::unique_ptr<column> make_dictionary_from_scalar(scalar const& s,
                                                     size_type size,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   if (size == 0) return make_empty_column(type_id::DICTIONARY32);

--- a/cpp/src/column/column_factories.cu
+++ b/cpp/src/column/column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,7 +23,7 @@ struct column_from_scalar_dispatch {
   template <typename T>
   std::unique_ptr<cudf::column> operator()(scalar const& value,
                                            size_type size,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     if (size == 0) return make_empty_column(value.type());
@@ -41,7 +41,7 @@ template <>
 std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::string_view>(
   scalar const& value,
   size_type size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr) const
 {
   if (size == 0) return make_empty_column(value.type());
@@ -77,7 +77,7 @@ std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::stri
 
 template <>
 std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::dictionary32>(
-  scalar const&, size_type, rmm::cuda_stream_view, rmm::device_async_resource_ref) const
+  scalar const&, size_type, cuda::stream_ref, rmm::device_async_resource_ref) const
 {
   CUDF_FAIL("dictionary not supported when creating from scalar");
 }
@@ -86,7 +86,7 @@ template <>
 std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::list_view>(
   scalar const& value,
   size_type size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr) const
 {
   auto lv = static_cast<list_scalar const*>(&value);
@@ -97,7 +97,7 @@ template <>
 std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::struct_view>(
   scalar const& value,
   size_type size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr) const
 {
   CUDF_EXPECTS(size != 0, "0-length struct column is unsupported.");
@@ -121,7 +121,7 @@ std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::stru
 
 std::unique_ptr<column> make_column_from_scalar(scalar const& s,
                                                 size_type size,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(s.type(), column_from_scalar_dispatch{}, s, size, stream, mr);

--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -135,7 +135,7 @@ column_view_base::column_view_base(data_type type,
 
 size_type column_view_base::null_count(size_type begin,
                                        size_type end,
-                                       rmm::cuda_stream_view stream) const
+                                       cuda::stream_ref stream) const
 {
   CUDF_EXPECTS((begin >= 0) && (end <= size()) && (begin <= end), "Range is out of bounds.");
   return (null_count() == 0)

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -27,11 +27,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
@@ -56,11 +56,11 @@ constexpr bool use_fused_kernel_heuristic(bool const has_nulls, size_t const num
   return has_nulls || num_columns > 4;
 }
 
-auto create_device_views(host_span<column_view const> views, rmm::cuda_stream_view stream)
+auto create_device_views(host_span<column_view const> views, cuda::stream_ref stream)
 {
   // Create device views for each input view
   using CDViewPtr         = decltype(column_device_view::create(std::declval<column_view>(),
-                                                        std::declval<rmm::cuda_stream_view>()));
+                                                        std::declval<cuda::stream_ref>()));
   auto device_view_owners = std::vector<CDViewPtr>(views.size());
   std::transform(views.begin(), views.end(), device_view_owners.begin(), [stream](auto const& col) {
     return column_device_view::create(col, stream);
@@ -153,14 +153,14 @@ size_type concatenate_masks(device_span<column_device_view const> d_views,
                             device_span<size_t const> d_offsets,
                             bitmask_type* dest_mask,
                             size_type output_size,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   cudf::detail::device_scalar<size_type> d_valid_count(
     0, stream, cudf::get_current_device_resource_ref());
   constexpr size_type block_size{256};
   cudf::detail::grid_1d config(output_size, block_size);
   concatenate_masks_kernel<block_size>
-    <<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+    <<<config.num_blocks, config.num_threads_per_block, 0, stream.get()>>>(
       d_views.data(),
       d_offsets.data(),
       static_cast<size_type>(d_views.size()),
@@ -173,7 +173,7 @@ size_type concatenate_masks(device_span<column_device_view const> d_views,
 
 size_type concatenate_masks(host_span<column_view const> views,
                             bitmask_type* dest_mask,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   // Preprocess and upload inputs to device memory
   auto const device_views = create_device_views(views, stream);
@@ -239,7 +239,7 @@ CUDF_KERNEL void fused_concatenate_kernel(column_device_view const* input_views,
 template <typename T>
 std::unique_ptr<column> fused_concatenate(host_span<column_view const> views,
                                           bool const has_nulls,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   using mask_policy = cudf::mask_allocation_policy;
@@ -268,7 +268,7 @@ std::unique_ptr<column> fused_concatenate(host_span<column_view const> views,
   cudf::detail::grid_1d config(output_size, block_size);
   auto const kernel = has_nulls ? fused_concatenate_kernel<T, block_size, true>
                                 : fused_concatenate_kernel<T, block_size, false>;
-  kernel<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+  kernel<<<config.num_blocks, config.num_threads_per_block, 0, stream.get()>>>(
     d_views.data(),
     d_offsets.data(),
     static_cast<size_type>(d_views.size()),
@@ -288,7 +288,7 @@ std::unique_ptr<column> fused_concatenate(host_span<column_view const> views,
 template <typename T>
 std::unique_ptr<column> for_each_concatenate(host_span<column_view const> views,
                                              bool const has_nulls,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   size_type const total_element_count =
@@ -329,7 +329,7 @@ std::unique_ptr<column> for_each_concatenate(host_span<column_view const> views,
 
 struct concatenate_dispatch {
   host_span<column_view const> views;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   // fixed width
@@ -372,7 +372,7 @@ std::unique_ptr<column> concatenate_dispatch::operator()<cudf::struct_view>()
   return cudf::structs::detail::concatenate(views, stream, mr);
 }
 
-void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_view stream);
+void bounds_and_type_check(host_span<column_view const> cols, cuda::stream_ref stream);
 
 /**
  * @brief Functor for traversing child columns and recursively verifying concatenation
@@ -382,7 +382,7 @@ class traverse_children {
  public:
   // nothing to do for simple types.
   template <typename T>
-  void operator()(host_span<column_view const>, rmm::cuda_stream_view)
+  void operator()(host_span<column_view const>, cuda::stream_ref)
   {
   }
 
@@ -407,7 +407,7 @@ class traverse_children {
 
 template <>
 void traverse_children::operator()<cudf::string_view>(host_span<column_view const> cols,
-                                                      rmm::cuda_stream_view stream)
+                                                      cuda::stream_ref stream)
 {
   // verify offsets
   check_offsets_size(cols);
@@ -417,7 +417,7 @@ void traverse_children::operator()<cudf::string_view>(host_span<column_view cons
 
 template <>
 void traverse_children::operator()<cudf::struct_view>(host_span<column_view const> cols,
-                                                      rmm::cuda_stream_view stream)
+                                                      cuda::stream_ref stream)
 {
   // march each child
   auto child_iter         = cuda::counting_iterator<cudf::size_type>{0};
@@ -440,7 +440,7 @@ void traverse_children::operator()<cudf::struct_view>(host_span<column_view cons
 
 template <>
 void traverse_children::operator()<cudf::list_view>(host_span<column_view const> cols,
-                                                    rmm::cuda_stream_view stream)
+                                                    cuda::stream_ref stream)
 {
   // verify offsets
   check_offsets_size(cols);
@@ -468,7 +468,7 @@ void traverse_children::operator()<cudf::list_view>(host_span<column_view const>
  *
  * @throws cudf::logic_error if all of the input column types don't match
  */
-void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_view stream)
+void bounds_and_type_check(host_span<column_view const> cols, cuda::stream_ref stream)
 {
   // total size of all concatenated rows
   size_t const total_row_count =
@@ -502,7 +502,7 @@ void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_v
 
 // Concatenates the elements from a vector of column_views
 std::unique_ptr<column> concatenate(std::span<column_view const> columns_to_concat,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(not columns_to_concat.empty(), "Unexpected empty list of columns to concatenate.");
@@ -533,7 +533,7 @@ std::unique_ptr<column> concatenate(std::span<column_view const> columns_to_conc
 }
 
 std::unique_ptr<table> concatenate(std::span<table_view const> tables_to_concat,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   if (tables_to_concat.empty()) { return std::make_unique<table>(); }
@@ -576,7 +576,7 @@ std::unique_ptr<table> concatenate(std::span<table_view const> tables_to_concat,
 }
 
 rmm::device_buffer concatenate_masks(std::span<column_view const> views,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   bool const has_nulls =
@@ -603,7 +603,7 @@ rmm::device_buffer concatenate_masks(std::span<column_view const> views,
 }  // namespace detail
 
 rmm::device_buffer concatenate_masks(std::span<column_view const> views,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -612,7 +612,7 @@ rmm::device_buffer concatenate_masks(std::span<column_view const> views,
 
 // Concatenates the elements from a vector of column_views
 std::unique_ptr<column> concatenate(std::span<column_view const> columns_to_concat,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -620,7 +620,7 @@ std::unique_ptr<column> concatenate(std::span<column_view const> columns_to_conc
 }
 
 std::unique_ptr<table> concatenate(std::span<table_view const> tables_to_concat,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -21,13 +21,13 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -472,7 +472,7 @@ std::pair<src_buf_info*, size_type> setup_source_buf_info(InputIter begin,
                                                           InputIter end,
                                                           src_buf_info* head,
                                                           src_buf_info* current,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           int offset_stack_pos    = 0,
                                                           int parent_offset_index = -1,
                                                           int offset_depth        = 0);
@@ -492,7 +492,7 @@ struct buf_info_functor {
                                                  int offset_stack_pos,
                                                  int parent_offset_index,
                                                  int offset_depth,
-                                                 rmm::cuda_stream_view)
+                                                 cuda::stream_ref)
   {
     if (col.nullable()) {
       std::tie(current, offset_stack_pos) =
@@ -535,7 +535,7 @@ std::pair<src_buf_info*, size_type> buf_info_functor::operator()<cudf::string_vi
   int offset_stack_pos,
   int parent_offset_index,
   int offset_depth,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   if (col.nullable()) {
     std::tie(current, offset_stack_pos) =
@@ -594,7 +594,7 @@ std::pair<src_buf_info*, size_type> buf_info_functor::operator()<cudf::list_view
   int offset_stack_pos,
   int parent_offset_index,
   int offset_depth,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   lists_column_view lcv(col);
 
@@ -646,7 +646,7 @@ std::pair<src_buf_info*, size_type> buf_info_functor::operator()<cudf::struct_vi
   int offset_stack_pos,
   int parent_offset_index,
   int offset_depth,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   if (col.nullable()) {
     std::tie(current, offset_stack_pos) =
@@ -684,7 +684,7 @@ std::pair<src_buf_info*, size_type> setup_source_buf_info(InputIter begin,
                                                           InputIter end,
                                                           src_buf_info* head,
                                                           src_buf_info* current,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           int offset_stack_pos,
                                                           int parent_offset_index,
                                                           int offset_depth)
@@ -1026,7 +1026,7 @@ struct packed_split_indices_and_src_buf_info {
                                         std::vector<size_type> const& splits,
                                         std::size_t num_partitions,
                                         cudf::size_type num_src_bufs,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref temp_mr)
     : indices_size(cudf::util::round_up_safe((num_partitions + 1) * sizeof(int64_t), split_align)),
       src_buf_info_size(
@@ -1087,7 +1087,7 @@ struct packed_split_indices_and_src_buf_info {
 struct packed_partition_buf_size_and_dst_buf_info {
   packed_partition_buf_size_and_dst_buf_info(std::size_t num_partitions,
                                              std::size_t num_bufs,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref temp_mr)
     : stream(stream),
       buf_sizes_size{cudf::util::round_up_safe(num_partitions * sizeof(std::size_t), split_align)},
@@ -1115,7 +1115,7 @@ struct packed_partition_buf_size_and_dst_buf_info {
     detail::cuda_memcpy_async<uint8_t>(h_buf_sizes_and_dst_info, d_buf_sizes_and_dst_info, stream);
   }
 
-  rmm::cuda_stream_view const stream;
+  cuda::stream_ref const stream;
 
   // buffer sizes and destination info (used in batched copies)
   std::size_t const buf_sizes_size;
@@ -1137,7 +1137,7 @@ struct packed_src_and_dst_pointers {
   packed_src_and_dst_pointers(cudf::table_view const& input,
                               std::size_t num_partitions,
                               cudf::size_type num_src_bufs,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref temp_mr)
     : stream(stream),
       src_bufs_size{cudf::util::round_up_safe(num_src_bufs * sizeof(uint8_t*), split_align)},
@@ -1166,7 +1166,7 @@ struct packed_src_and_dst_pointers {
       stream);
   }
 
-  rmm::cuda_stream_view const stream;
+  cuda::stream_ref const stream;
   std::size_t const src_bufs_size;
   std::size_t const dst_bufs_size;
 
@@ -1199,7 +1199,7 @@ std::unique_ptr<packed_src_and_dst_pointers> setup_src_and_dst_pointers(
   std::size_t num_partitions,
   cudf::size_type num_src_bufs,
   std::vector<rmm::device_buffer>& out_buffers,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref temp_mr)
 {
   auto src_and_dst_pointers = std::make_unique<packed_src_and_dst_pointers>(
@@ -1236,7 +1236,7 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
   std::size_t num_partitions,
   cudf::size_type num_src_bufs,
   std::size_t num_bufs,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref temp_mr)
 {
   auto partition_buf_size_and_dst_buf_info =
@@ -1367,7 +1367,7 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
 
   partition_buf_size_and_dst_buf_info->copy_to_host();
 
-  stream.synchronize();
+  stream.wait();
 
   return partition_buf_size_and_dst_buf_info;
 }
@@ -1384,7 +1384,7 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
 std::tuple<size_type, std::size_t, std::unique_ptr<packed_partition_buf_size_and_dst_buf_info>>
 compute_num_bufs_and_splits(cudf::table_view const& input,
                             std::vector<size_type> const& splits,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref temp_mr)
 {
   std::size_t const num_partitions = splits.size() + 1;
@@ -1435,7 +1435,7 @@ struct chunk_iteration_state {
     std::size_t const* const h_buf_sizes,
     std::size_t num_partitions,
     std::size_t user_buffer_size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
   /**
@@ -1495,7 +1495,7 @@ std::unique_ptr<chunk_iteration_state> chunk_iteration_state::create(
   std::size_t const* const h_buf_sizes,
   std::size_t num_partitions,
   std::size_t user_buffer_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref temp_mr)
 {
   rmm::device_uvector<size_type> d_batch_offsets(num_bufs + 1, stream, temp_mr);
@@ -1702,7 +1702,7 @@ std::unique_ptr<chunk_iteration_state> compute_batches(int num_bufs,
                                                        std::size_t const* const h_buf_sizes,
                                                        std::size_t num_partitions,
                                                        std::size_t user_buffer_size,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref temp_mr)
 {
   // Since we parallelize at one block per copy, performance is vulnerable to situations where we
@@ -1752,12 +1752,12 @@ void copy_data(int num_batches_to_copy,
                uint8_t** d_dst_bufs,
                device_span<dst_buf_info> d_dst_buf_info,
                uint8_t* user_buffer,
-               rmm::cuda_stream_view stream)
+               cuda::stream_ref stream)
 {
   constexpr size_type block_size = 256;
   if (user_buffer != nullptr) {
     auto index_to_buffer = [user_buffer] __device__(unsigned int) { return user_buffer; };
-    copy_partitions<block_size><<<num_batches_to_copy, block_size, 0, stream.value()>>>(
+    copy_partitions<block_size><<<num_batches_to_copy, block_size, 0, stream.get()>>>(
       index_to_buffer, d_src_bufs, d_dst_buf_info.data() + starting_batch);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
@@ -1767,7 +1767,7 @@ void copy_data(int num_batches_to_copy,
       auto const dst_buf_index = dst_buf_info[buf_index].dst_buf_index;
       return d_dst_bufs[dst_buf_index];
     };
-    copy_partitions<block_size><<<num_batches_to_copy, block_size, 0, stream.value()>>>(
+    copy_partitions<block_size><<<num_batches_to_copy, block_size, 0, stream.get()>>>(
       index_to_buffer, d_src_bufs, d_dst_buf_info.data() + starting_batch);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
@@ -1826,7 +1826,7 @@ namespace detail {
 struct contiguous_split_state {
   contiguous_split_state(cudf::table_view const& input,
                          std::size_t user_buffer_size,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          std::optional<rmm::device_async_resource_ref> mr,
                          rmm::device_async_resource_ref temp_mr)
     : contiguous_split_state(input, {}, user_buffer_size, stream, mr, temp_mr)
@@ -1835,7 +1835,7 @@ struct contiguous_split_state {
 
   contiguous_split_state(cudf::table_view const& input,
                          std::vector<size_type> const& splits,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          std::optional<rmm::device_async_resource_ref> mr,
                          rmm::device_async_resource_ref temp_mr)
     : contiguous_split_state(input, splits, 0, stream, mr, temp_mr)
@@ -1953,7 +1953,7 @@ struct contiguous_split_state {
   contiguous_split_state(cudf::table_view const& input,
                          std::vector<size_type> const& splits,
                          std::size_t user_buffer_size,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          std::optional<rmm::device_async_resource_ref> mr,
                          rmm::device_async_resource_ref temp_mr)
     : input(input),
@@ -2094,7 +2094,7 @@ struct contiguous_split_state {
 
   cudf::table_view const input;        ///< The input table_view to operate on
   std::size_t const user_buffer_size;  ///< The size of the user buffer for the chunked_pack case
-  rmm::cuda_stream_view const stream;
+  cuda::stream_ref const stream;
   std::optional<rmm::device_async_resource_ref> mr;  ///< The resource for any data returned
 
   // this resource defaults to `mr` for the contiguous_split case, but it can be useful for the
@@ -2145,7 +2145,7 @@ struct contiguous_split_state {
 
 std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            std::vector<size_type> const& splits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   // `temp_mr` is the same as `mr` for contiguous_split as it allocates all
@@ -2159,7 +2159,7 @@ std::vector<packed_table> contiguous_split(cudf::table_view const& input,
 
 std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            std::vector<size_type> const& splits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -2168,7 +2168,7 @@ std::vector<packed_table> contiguous_split(cudf::table_view const& input,
 
 chunked_pack::chunked_pack(cudf::table_view const& input,
                            std::size_t user_buffer_size,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref temp_mr)
 {
   CUDF_EXPECTS(user_buffer_size >= desired_batch_size,
@@ -2201,14 +2201,14 @@ std::unique_ptr<std::vector<uint8_t>> chunked_pack::build_metadata() const
 
 std::unique_ptr<chunked_pack> chunked_pack::create(cudf::table_view const& input,
                                                    std::size_t user_buffer_size,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref temp_mr)
 {
   return std::make_unique<chunked_pack>(input, user_buffer_size, stream, temp_mr);
 }
 
 std::size_t packed_size(cudf::table_view const& input,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref temp_mr)
 {
   // Handle empty table cases

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 
@@ -105,7 +105,7 @@ struct scalar_empty_like_functor {
 std::unique_ptr<column> allocate_like(column_view const& input,
                                       size_type size,
                                       mask_allocation_policy mask_alloc,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -169,7 +169,7 @@ std::unique_ptr<table> empty_like(table_view const& input_table)
 
 std::unique_ptr<column> allocate_like(column_view const& input,
                                       mask_allocation_policy mask_alloc,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -179,7 +179,7 @@ std::unique_ptr<column> allocate_like(column_view const& input,
 std::unique_ptr<column> allocate_like(column_view const& input,
                                       size_type size,
                                       mask_allocation_policy mask_alloc,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -19,11 +19,11 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 
 #include <stdexcept>
 
@@ -45,14 +45,14 @@ struct copy_if_else_functor_impl {
  */
 struct get_iterable_device_view {
   template <typename T>
-  auto operator()(T const& input, rmm::cuda_stream_view stream)
+  auto operator()(T const& input, cuda::stream_ref stream)
     requires(std::is_same_v<T, cudf::column_view>)
   {
     return cudf::column_device_view::create(input, stream);
   }
 
   template <typename T>
-  auto operator()(T const& input, rmm::cuda_stream_view)
+  auto operator()(T const& input, cuda::stream_ref)
     requires(std::is_same_v<T, cudf::scalar>)
   {
     return &input;
@@ -68,7 +68,7 @@ struct copy_if_else_functor_impl<T, std::enable_if_t<is_rep_layout_compatible<T>
                                      bool left_nullable,
                                      bool right_nullable,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto p_lhs      = get_iterable_device_view{}(lhs_h, stream);
@@ -101,7 +101,7 @@ struct copy_if_else_functor_impl<string_view> {
                                      bool left_nullable,
                                      bool right_nullable,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     using T = string_view;
@@ -153,7 +153,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::column_view const& lh
                                                      cudf::column_view const& rhs,
                                                      size_type size,
                                                      Filter is_left,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   auto gather_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
@@ -187,7 +187,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::scalar const& lhs,
                                                      cudf::column_view const& rhs,
                                                      size_type size,
                                                      Filter is_left,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   auto scatter_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
@@ -216,7 +216,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::column_view const& lh
                                                      cudf::scalar const& rhs,
                                                      size_type size,
                                                      Filter is_left,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   return scatter_gather_based_if_else(rhs, lhs, size, logical_not{is_left}, stream, mr);
@@ -227,7 +227,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::scalar const& lhs,
                                                      cudf::scalar const& rhs,
                                                      size_type size,
                                                      Filter is_left,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   auto rhs_col = cudf::make_column_from_scalar(rhs, size, stream, mr);
@@ -243,7 +243,7 @@ struct copy_if_else_functor_impl<struct_view> {
                                      bool,
                                      bool,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return scatter_gather_based_if_else(lhs, rhs, size, filter, stream, mr);
@@ -259,7 +259,7 @@ struct copy_if_else_functor_impl<list_view> {
                                      bool,
                                      bool,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return scatter_gather_based_if_else(lhs, rhs, size, filter, stream, mr);
@@ -275,7 +275,7 @@ struct copy_if_else_functor_impl<dictionary32> {
                                      bool,
                                      bool,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return scatter_gather_based_if_else(lhs, rhs, size, filter, stream, mr);
@@ -294,7 +294,7 @@ struct copy_if_else_functor {
                                      bool left_nullable,
                                      bool right_nullable,
                                      Filter filter,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     copy_if_else_functor_impl<T> copier{};
@@ -309,7 +309,7 @@ std::unique_ptr<column> copy_if_else(Left const& lhs,
                                      bool left_nullable,
                                      bool right_nullable,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(boolean_mask.type() == data_type(type_id::BOOL8),
@@ -347,7 +347,7 @@ std::unique_ptr<column> copy_if_else(Left const& lhs,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(boolean_mask.size() == lhs.size(),
@@ -364,7 +364,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(boolean_mask.size() == rhs.size(),
@@ -379,7 +379,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(boolean_mask.size() == lhs.size(),
@@ -394,7 +394,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -408,7 +408,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -418,7 +418,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      column_view const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -428,7 +428,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -438,7 +438,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      scalar const& rhs,
                                      column_view const& boolean_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,9 +24,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <stdexcept>
@@ -38,7 +37,7 @@ void in_place_copy_range(cudf::column_view const& source,
                          cudf::size_type source_begin,
                          cudf::size_type source_end,
                          cudf::size_type target_begin,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   auto p_source_device_view = cudf::column_device_view::create(source, stream);
   if (source.has_nulls()) {
@@ -67,7 +66,7 @@ struct in_place_copy_range_dispatch {
   void operator()(cudf::size_type source_begin,
                   cudf::size_type source_end,
                   cudf::size_type target_begin,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     in_place_copy_range<T>(source, target, source_begin, source_end, target_begin, stream);
   }
@@ -88,7 +87,7 @@ struct out_of_place_copy_range_dispatch {
     cudf::size_type source_begin,
     cudf::size_type source_end,
     cudf::size_type target_begin,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
   {
     auto p_ret = std::make_unique<cudf::column>(target, stream, mr);
@@ -119,7 +118,7 @@ std::unique_ptr<cudf::column> out_of_place_copy_range_dispatch::operator()<cudf:
   cudf::size_type source_begin,
   cudf::size_type source_end,
   cudf::size_type target_begin,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return cudf::strings::detail::copy_range(
@@ -131,7 +130,7 @@ std::unique_ptr<cudf::column> out_of_place_copy_range_dispatch::operator()<cudf:
   cudf::size_type source_begin,
   cudf::size_type source_end,
   cudf::size_type target_begin,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // check the keys in the source and target
@@ -192,7 +191,7 @@ void copy_range_in_place(column_view const& source,
                          size_type source_begin,
                          size_type source_end,
                          size_type target_begin,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   CUDF_EXPECTS(cudf::is_fixed_width(target.type()),
                "In-place copy_range does not support variable-sized types.",
@@ -222,7 +221,7 @@ std::unique_ptr<column> copy_range(column_view const& source,
                                    size_type source_begin,
                                    size_type source_end,
                                    size_type target_begin,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS((source_begin >= 0) && (source_end <= source.size()) &&
@@ -249,7 +248,7 @@ void copy_range_in_place(column_view const& source,
                          size_type source_begin,
                          size_type source_end,
                          size_type target_begin,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::copy_range_in_place(
@@ -261,7 +260,7 @@ std::unique_ptr<column> copy_range(column_view const& source,
                                    size_type source_begin,
                                    size_type source_end,
                                    size_type target_begin,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <stdexcept>
@@ -28,7 +27,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                               column_view const& gather_map,
                               out_of_bounds_policy bounds_policy,
                               negative_index_policy neg_indices,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(not gather_map.has_nulls(), "gather_map contains nulls", std::invalid_argument);
@@ -55,7 +54,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                               device_span<size_type const> const gather_map,
                               out_of_bounds_policy bounds_policy,
                               negative_index_policy neg_indices,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(gather_map.size() <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
@@ -74,7 +73,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
 std::unique_ptr<table> gather(table_view const& source_table,
                               column_view const& gather_map,
                               out_of_bounds_policy bounds_policy,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -89,7 +88,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                               column_view const& gather_map,
                               out_of_bounds_policy bounds_policy,
                               negative_index_policy neg_indices,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <stdexcept>
 
@@ -32,7 +32,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<is_fixed_width<T>() && !is_fixed_point<T>()>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto s = make_fixed_width_scalar(data_type(type_to_id<T>()), stream, mr);
@@ -55,7 +55,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<std::is_same_v<T, string_view>>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto device_col = column_device_view::create(input, stream);
@@ -79,7 +79,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<std::is_same_v<T, dictionary32>>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto dict_view    = dictionary_column_view(input);
@@ -113,7 +113,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<std::is_same_v<T, list_view>>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     bool valid               = is_element_valid_sync(input, index, stream);
@@ -137,7 +137,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     using Type = typename T::rep;
@@ -163,7 +163,7 @@ struct get_element_functor {
   template <typename T, std::enable_if_t<std::is_same_v<T, struct_view>>* p = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      size_type index,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     bool valid = is_element_valid_sync(input, index, stream);
@@ -178,7 +178,7 @@ struct get_element_functor {
 
 std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(index >= 0 and index < input.size(), "Index out of bounds", std::out_of_range);
@@ -189,7 +189,7 @@ std::unique_ptr<scalar> get_element(column_view const& input,
 
 std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -7,7 +7,7 @@
 #include <cudf/detail/contiguous_split.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <cstddef>
@@ -272,7 +272,7 @@ table_view unpack(uint8_t const* metadata, uint8_t const* gpu_data)
  * @copydoc cudf::detail::pack
  */
 packed_columns pack(cudf::table_view const& input,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr)
 {
   // do a contiguous_split with no splits to get the memory for the table
@@ -441,7 +441,7 @@ packed_metadata_view::column_view packed_metadata_view::column(size_type i) cons
  * @copydoc cudf::pack
  */
 packed_columns pack(cudf::table_view const& input,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/copying.hpp>
@@ -26,7 +26,7 @@ bool type_may_have_nonempty_nulls(cudf::type_id const& type)
 }
 
 /// Check if the (STRING/LIST) column has any null rows with non-zero length.
-bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_view stream)
+bool has_nonempty_null_rows(cudf::column_view const& input, cuda::stream_ref stream)
 {
   if (not input.has_nulls()) { return false; }  // No nulls => no dirty rows.
 
@@ -53,7 +53,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
 /**
  * @copydoc cudf::detail::has_nonempty_nulls
  */
-bool has_nonempty_nulls(cudf::column_view const& input, rmm::cuda_stream_view stream)
+bool has_nonempty_nulls(cudf::column_view const& input, cuda::stream_ref stream)
 {
   auto const type = input.type().id();
 
@@ -77,7 +77,7 @@ bool has_nonempty_nulls(cudf::column_view const& input, rmm::cuda_stream_view st
 }
 
 std::unique_ptr<column> purge_nonempty_nulls(column_view const& input,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   // If not compound types (LIST/STRING/STRUCT/DICTIONARY) then just copy the input into output.
@@ -117,7 +117,7 @@ bool may_have_nonempty_nulls(column_view const& input)
 /**
  * @copydoc cudf::has_nonempty_nulls
  */
-bool has_nonempty_nulls(column_view const& input, rmm::cuda_stream_view stream)
+bool has_nonempty_nulls(column_view const& input, cuda::stream_ref stream)
 {
   return detail::has_nonempty_nulls(input, stream);
 }
@@ -126,7 +126,7 @@ bool has_nonempty_nulls(column_view const& input, rmm::cuda_stream_view stream)
  * @copydoc cudf::purge_nonempty_nulls(column_view const&, rmm::device_async_resource_ref)
  */
 std::unique_ptr<cudf::column> purge_nonempty_nulls(column_view const& input,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   return detail::purge_nonempty_nulls(input, stream, mr);

--- a/cpp/src/copying/reverse.cu
+++ b/cpp/src/copying/reverse.cu
@@ -12,17 +12,17 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 
 namespace cudf {
 namespace detail {
 std::unique_ptr<table> reverse(table_view const& source_table,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   size_type num_rows = source_table.num_rows();
@@ -36,7 +36,7 @@ std::unique_ptr<table> reverse(table_view const& source_table,
 }
 
 std::unique_ptr<column> reverse(column_view const& source_column,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   return std::move(
@@ -45,7 +45,7 @@ std::unique_ptr<column> reverse(column_view const& source_column,
 }  // namespace detail
 
 std::unique_ptr<table> reverse(table_view const& source_table,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -53,7 +53,7 @@ std::unique_ptr<table> reverse(table_view const& source_table,
 }
 
 std::unique_ptr<column> reverse(column_view const& source_column,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,10 +15,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/random.h>
 #include <thrust/random/uniform_int_distribution.h>
 #include <thrust/shuffle.h>
@@ -30,7 +29,7 @@ std::unique_ptr<table> sample(table_view const& input,
                               size_type const n,
                               sample_with_replacement replacement,
                               int64_t const seed,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(n >= 0, "expected number of samples should be non-negative");
@@ -85,7 +84,7 @@ std::unique_ptr<table> sample(table_view const& input,
                               size_type const n,
                               sample_with_replacement replacement,
                               int64_t const seed,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -26,10 +26,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scatter.h>
@@ -67,7 +66,7 @@ void scatter_scalar_bitmask_inplace(std::reference_wrapper<scalar const> const& 
                                     MapIterator scatter_map,
                                     size_type num_scatter_rows,
                                     column& target,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   constexpr size_type block_size = 256;
@@ -85,7 +84,7 @@ void scatter_scalar_bitmask_inplace(std::reference_wrapper<scalar const> const& 
 
     auto bitmask_kernel = source_is_valid ? marking_bitmask_kernel<true, decltype(scatter_map)>
                                           : marking_bitmask_kernel<false, decltype(scatter_map)>;
-    bitmask_kernel<<<grid_size, block_size, 0, stream.value()>>>(
+    bitmask_kernel<<<grid_size, block_size, 0, stream.get()>>>(
       *target_view, scatter_map, num_scatter_rows);
     CUDF_CUDA_TRY(cudaGetLastError());
 
@@ -100,7 +99,7 @@ struct column_scalar_scatterer_impl {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(cudf::have_same_types(target, source.get()),
@@ -133,7 +132,7 @@ struct column_scalar_scatterer_impl<string_view, MapIterator> {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(cudf::have_same_types(target, source.get()),
@@ -157,7 +156,7 @@ struct column_scalar_scatterer_impl<list_view, MapIterator> {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(source.get().type() == target.type(),
@@ -177,7 +176,7 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     auto dict_target = dictionary::detail::add_keys(
@@ -218,7 +217,7 @@ struct column_scalar_scatterer {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     column_scalar_scatterer_impl<Element, MapIterator> scatterer{};
@@ -232,7 +231,7 @@ struct column_scalar_scatterer_impl<struct_view, MapIterator> {
                                      MapIterator scatter_iter,
                                      size_type scatter_rows,
                                      column_view const& target,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(source.get().type() == target.type(),
@@ -286,7 +285,7 @@ struct column_scalar_scatterer_impl<struct_view, MapIterator> {
 std::unique_ptr<table> scatter(table_view const& source,
                                column_view const& scatter_map,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(source.num_columns() == target.num_columns(),
@@ -311,7 +310,7 @@ std::unique_ptr<table> scatter(table_view const& source,
 std::unique_ptr<table> scatter(table_view const& source,
                                device_span<size_type const> const scatter_map,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(scatter_map.size() <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
@@ -328,7 +327,7 @@ std::unique_ptr<table> scatter(table_view const& source,
 std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>> const& source,
                                column_view const& indices,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(source.size() == static_cast<size_t>(target.num_columns()),
@@ -380,7 +379,7 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>>
 std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
                                              column_view const& target,
                                              column_view const& boolean_mask,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   auto indices         = cudf::make_numeric_column(data_type{type_id::INT32},
@@ -411,7 +410,7 @@ std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
 std::unique_ptr<column> boolean_mask_scatter(scalar const& input,
                                              column_view const& target,
                                              column_view const& boolean_mask,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   return detail::copy_if_else(input, target, boolean_mask, stream, mr);
@@ -420,7 +419,7 @@ std::unique_ptr<column> boolean_mask_scatter(scalar const& input,
 std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
                                             table_view const& target,
                                             column_view const& boolean_mask,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.num_columns() == target.num_columns(),
@@ -462,7 +461,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   std::vector<std::reference_wrapper<scalar const>> const& input,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(static_cast<size_type>(input.size()) == target.num_columns(),
@@ -506,7 +505,7 @@ std::unique_ptr<table> boolean_mask_scatter(
 std::unique_ptr<table> scatter(table_view const& source,
                                column_view const& scatter_map,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -516,7 +515,7 @@ std::unique_ptr<table> scatter(table_view const& source,
 std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>> const& source,
                                column_view const& indices,
                                table_view const& target,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -526,7 +525,7 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<scalar const>>
 std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
                                             table_view const& target,
                                             column_view const& boolean_mask,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -537,7 +536,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   std::vector<std::reference_wrapper<scalar const>> const& input,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/segmented_shift.cu
+++ b/cpp/src/copying/segmented_shift.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,8 +13,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -62,7 +61,7 @@ struct segmented_shift_functor<T, std::enable_if_t<is_rep_layout_compatible<T>()
                                      device_span<size_type const> segment_offsets,
                                      size_type offset,
                                      scalar const& fill_value,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto values_device_view = column_device_view::create(segmented_values, stream);
@@ -91,7 +90,7 @@ struct segmented_shift_functor<string_view> {
                                      device_span<size_type const> segment_offsets,
                                      size_type offset,
                                      scalar const& fill_value,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto values_device_view = column_device_view::create(segmented_values, stream);
@@ -118,7 +117,7 @@ struct segmented_shift_functor_forwarder {
                                      device_span<size_type const> segment_offsets,
                                      size_type offset,
                                      scalar const& fill_value,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     segmented_shift_functor<T> shifter;
@@ -132,7 +131,7 @@ std::unique_ptr<column> segmented_shift(column_view const& segmented_values,
                                         device_span<size_type const> segment_offsets,
                                         size_type offset,
                                         scalar const& fill_value,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   if (segmented_values.is_empty()) { return empty_like(segmented_values); }

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,10 +19,10 @@
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 #include <thrust/transform.h>
 
@@ -41,7 +41,7 @@ inline bool __device__ out_of_bounds(size_type size, size_type idx)
 std::pair<rmm::device_buffer, size_type> create_null_mask(column_device_view const& input,
                                                           size_type offset,
                                                           scalar const& fill_value,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr)
 {
   auto const size = input.size();
@@ -69,7 +69,7 @@ struct shift_functor {
   std::unique_ptr<column> operator()(column_view const& input,
                                      size_type offset,
                                      scalar const& fill_value,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_same_v<cudf::string_view, T>)
   {
@@ -89,7 +89,7 @@ struct shift_functor {
   std::unique_ptr<column> operator()(column_view const& input,
                                      size_type offset,
                                      scalar const& fill_value,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_width<T>())
   {
@@ -148,7 +148,7 @@ namespace detail {
 std::unique_ptr<column> shift(column_view const& input,
                               size_type offset,
                               scalar const& fill_value,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::have_same_types(input, fill_value),
@@ -166,7 +166,7 @@ std::unique_ptr<column> shift(column_view const& input,
 std::unique_ptr<column> shift(column_view const& input,
                               size_type offset,
                               scalar const& fill_value,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -13,8 +13,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <algorithm>
@@ -24,10 +23,7 @@ namespace cudf {
 namespace detail {
 
 template <typename ColumnView>
-ColumnView slice(ColumnView const& input,
-                 size_type begin,
-                 size_type end,
-                 rmm::cuda_stream_view stream)
+ColumnView slice(ColumnView const& input, size_type begin, size_type end, cuda::stream_ref stream)
 {
   CUDF_EXPECTS(begin >= 0, "Invalid beginning of range.", std::out_of_range);
   CUDF_EXPECTS(end >= begin, "Invalid end of range.", std::invalid_argument);
@@ -49,18 +45,15 @@ ColumnView slice(ColumnView const& input,
     children);
 }
 
-template column_view slice<column_view>(column_view const&,
-                                        size_type,
-                                        size_type,
-                                        rmm::cuda_stream_view);
+template column_view slice<column_view>(column_view const&, size_type, size_type, cuda::stream_ref);
 template mutable_column_view slice<mutable_column_view>(mutable_column_view const&,
                                                         size_type,
                                                         size_type,
-                                                        rmm::cuda_stream_view);
+                                                        cuda::stream_ref);
 
 std::vector<column_view> slice(column_view const& input,
                                std::span<size_type const> indices,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_EXPECTS(indices.size() % 2 == 0, "indices size must be even", std::invalid_argument);
 
@@ -96,7 +89,7 @@ std::vector<column_view> slice(column_view const& input,
 
 std::vector<table_view> slice(table_view const& input,
                               std::span<size_type const> indices,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   CUDF_EXPECTS(indices.size() % 2 == 0, "indices size must be even", std::invalid_argument);
   if (indices.empty()) { return {}; }
@@ -141,14 +134,14 @@ std::vector<table_view> slice(table_view const& input,
 
 std::vector<column_view> slice(column_view const& input,
                                std::initializer_list<size_type> indices,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   return detail::slice(input, std::span<size_type const>(indices.begin(), indices.size()), stream);
 }
 
 std::vector<table_view> slice(table_view const& input,
                               std::initializer_list<size_type> indices,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   return detail::slice(input, std::span<size_type const>(indices.begin(), indices.size()), stream);
 };
@@ -157,7 +150,7 @@ std::vector<table_view> slice(table_view const& input,
 
 std::vector<column_view> slice(column_view const& input,
                                std::span<size_type const> indices,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::slice(input, indices, stream);
@@ -165,7 +158,7 @@ std::vector<column_view> slice(column_view const& input,
 
 std::vector<table_view> slice(table_view const& input,
                               std::span<size_type const> indices,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::slice(input, indices, stream);
@@ -173,7 +166,7 @@ std::vector<table_view> slice(table_view const& input,
 
 std::vector<column_view> slice(column_view const& input,
                                std::initializer_list<size_type> indices,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::slice(input, indices, stream);
@@ -181,7 +174,7 @@ std::vector<column_view> slice(column_view const& input,
 
 std::vector<table_view> slice(table_view const& input,
                               std::initializer_list<size_type> indices,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::slice(input, indices, stream);

--- a/cpp/src/copying/split.cpp
+++ b/cpp/src/copying/split.cpp
@@ -7,7 +7,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <stdexcept>
@@ -19,7 +19,7 @@ template <typename T>
 std::vector<T> split(T const& input,
                      size_type column_size,
                      std::span<size_type const> splits,
-                     rmm::cuda_stream_view stream)
+                     cuda::stream_ref stream)
 {
   if (splits.empty() or column_size == 0) { return std::vector<T>{input}; }
   CUDF_EXPECTS(
@@ -41,14 +41,14 @@ std::vector<T> split(T const& input,
 
 std::vector<cudf::column_view> split(cudf::column_view const& input,
                                      std::span<size_type const> splits,
-                                     rmm::cuda_stream_view stream)
+                                     cuda::stream_ref stream)
 {
   return split(input, input.size(), splits, stream);
 }
 
 std::vector<cudf::table_view> split(cudf::table_view const& input,
                                     std::span<size_type const> splits,
-                                    rmm::cuda_stream_view stream)
+                                    cuda::stream_ref stream)
 {
   // A genuinely empty table (no columns and no rows) has nothing to split.
   if (input.num_columns() == 0 && input.num_rows() == 0) { return {}; }
@@ -57,14 +57,14 @@ std::vector<cudf::table_view> split(cudf::table_view const& input,
 
 std::vector<column_view> split(column_view const& input,
                                std::initializer_list<size_type> splits,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   return detail::split(input, std::span<size_type const>(splits.begin(), splits.size()), stream);
 }
 
 std::vector<table_view> split(table_view const& input,
                               std::initializer_list<size_type> splits,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   return detail::split(input, std::span<size_type const>(splits.begin(), splits.size()), stream);
 }
@@ -73,7 +73,7 @@ std::vector<table_view> split(table_view const& input,
 
 std::vector<cudf::column_view> split(cudf::column_view const& input,
                                      std::span<size_type const> splits,
-                                     rmm::cuda_stream_view stream)
+                                     cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::split(input, splits, stream);
@@ -81,7 +81,7 @@ std::vector<cudf::column_view> split(cudf::column_view const& input,
 
 std::vector<cudf::table_view> split(cudf::table_view const& input,
                                     std::span<size_type const> splits,
-                                    rmm::cuda_stream_view stream)
+                                    cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::split(input, splits, stream);
@@ -89,7 +89,7 @@ std::vector<cudf::table_view> split(cudf::table_view const& input,
 
 std::vector<column_view> split(column_view const& input,
                                std::initializer_list<size_type> splits,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::split(input, splits, stream);
@@ -97,7 +97,7 @@ std::vector<column_view> split(column_view const& input,
 
 std::vector<table_view> split(table_view const& input,
                               std::initializer_list<size_type> splits,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::split(input, splits, stream);

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ namespace detail {
 
 std::unique_ptr<column> add_keys(dictionary_column_view const& input,
                                  column_view const& new_keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!new_keys.has_nulls(), "Keys must not have nulls", std::invalid_argument);
@@ -59,7 +59,7 @@ std::unique_ptr<column> add_keys(dictionary_column_view const& input,
 
 std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column,
                                  column_view const& keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary {
@@ -35,7 +35,7 @@ struct indices_handler_fn {
  * @brief Decode a column from a dictionary.
  */
 std::unique_ptr<column> decode(dictionary_column_view const& source,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   if (source.is_empty()) return make_empty_column(type_id::EMPTY);
@@ -66,7 +66,7 @@ std::unique_ptr<column> decode(dictionary_column_view const& source,
 }  // namespace detail
 
 std::unique_ptr<column> decode(dictionary_column_view const& source,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -21,7 +21,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -30,6 +29,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/gather.h>
@@ -105,7 +105,7 @@ struct compute_children_offsets_fn {
    * @param stream Stream used for allocating the output rmm::device_uvector.
    * @return Vector of offsets_pair objects for keys and indices.
    */
-  rmm::device_uvector<offsets_pair> create_children_offsets(rmm::cuda_stream_view stream)
+  rmm::device_uvector<offsets_pair> create_children_offsets(cuda::stream_ref stream)
   {
     auto offsets = cudf::detail::make_host_vector<offsets_pair>(columns_ptrs.size(), stream);
     thrust::transform_exclusive_scan(
@@ -154,7 +154,7 @@ struct map_indices_fn {
 }  // namespace
 
 std::unique_ptr<column> concatenate(host_span<column_view const> columns,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   // exception here is the same behavior as in cudf::concatenate
@@ -196,7 +196,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
   auto probe           = encode_probe_t{row_hash.device_hasher(cudf::nullate::NO{})};
   auto allocator = rmm::mr::polymorphic_allocator<char>(cudf::get_current_device_resource_ref());
   auto set       = cuco::static_set{
-    all_keys->size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.value()};
+    all_keys->size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.get()};
   auto set_ref    = set.ref(cuco::insert_and_find);
   using set_ref_t = decltype(set_ref);
 
@@ -210,7 +210,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
     policy, iota, iota + all_keys->size(), d_indices.begin(), insert_keys_fn{set_ref, *d_all_keys});
   auto keys_indices = rmm::device_uvector<size_type>(
     all_keys->size(), stream, cudf::get_current_device_resource_ref());
-  auto keys_end = set.retrieve_all(keys_indices.begin(), stream.value());
+  auto keys_end = set.retrieve_all(keys_indices.begin(), stream.get());
   keys_indices.resize(cuda::std::distance(keys_indices.begin(), keys_end), stream);
 
   // use keys_indices to retrieve the keys (gather)

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,9 +13,9 @@
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -25,7 +25,7 @@ namespace detail {
 std::unique_ptr<column> merge(dictionary_column_view const& lcol,
                               dictionary_column_view const& rcol,
                               cudf::detail::index_vector const& row_order,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   auto const lcol_iter = cudf::detail::indexalator_factory::make_input_iterator(lcol.indices());

--- a/cpp/src/dictionary/dictionary_factories.cu
+++ b/cpp/src/dictionary/dictionary_factories.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,14 +12,14 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace {
 struct dispatch_create_indices {
   template <typename IndexType>
   std::unique_ptr<column> operator()(column_view const& indices,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_index_type<IndexType>())
   {
@@ -31,7 +31,7 @@ struct dispatch_create_indices {
   }
   template <typename IndexType>
   std::unique_ptr<column> operator()(column_view const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(!is_index_type<IndexType>())
   {
@@ -42,7 +42,7 @@ struct dispatch_create_indices {
 
 std::unique_ptr<column> make_dictionary_column(column_view const& keys_column,
                                                column_view const& indices_column,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!keys_column.has_nulls(), "keys column must not have nulls", std::invalid_argument);
@@ -114,7 +114,7 @@ struct make_signed_fn {
 
 std::unique_ptr<column> make_dictionary_column(std::unique_ptr<column> keys,
                                                std::unique_ptr<column> indices,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!keys->has_nulls(), "keys column must not have nulls", std::invalid_argument);

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,7 +23,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -32,6 +31,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
@@ -55,7 +55,7 @@ struct encode_fn {
 
 std::unique_ptr<column> encode(column_view const& input,
                                data_type indices_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_signed(indices_type) && is_index_type(indices_type),
@@ -89,8 +89,8 @@ std::unique_ptr<column> encode(column_view const& input,
   auto const empty_key  = cuco::empty_key{cudf::detail::CUDF_SIZE_TYPE_SENTINEL};
   auto probe            = encode_probe_t{row_hash.device_hasher(has_nulls)};
   auto allocator        = rmm::mr::polymorphic_allocator<char>{};
-  auto set              = cuco::static_set{
-    input.size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.value()};
+  auto set =
+    cuco::static_set{input.size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.get()};
   auto set_ref    = set.ref(cuco::insert_and_find);
   using set_ref_t = decltype(set_ref);
 
@@ -105,7 +105,7 @@ std::unique_ptr<column> encode(column_view const& input,
                     encode_fn{set_ref, *d_input});
 
   auto keys_indices = rmm::device_uvector<size_type>(input.size(), stream);
-  auto keys_end     = set.retrieve_all(keys_indices.begin(), stream.value());
+  auto keys_end     = set.retrieve_all(keys_indices.begin(), stream.get());
   keys_indices.resize(cuda::std::distance(keys_indices.begin(), keys_end), stream);
 
   // sort the keys_indices so we can use lower-bound on them
@@ -154,7 +154,7 @@ data_type get_indices_type_for_size(size_type keys_size)
 
 std::unique_ptr<column> encode(column_view const& input_column,
                                data_type indices_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/match_keys.cu
+++ b/cpp/src/dictionary/match_keys.cu
@@ -19,13 +19,13 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <iterator>
@@ -39,7 +39,7 @@ namespace {
 struct unique_keys_dispatch_fn {
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& all_keys,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(cudf::is_dictionary_key<T>())
   {
@@ -58,15 +58,15 @@ struct unique_keys_dispatch_fn {
     auto probe            = probe_t{row_hash.device_hasher(has_nulls)};
     auto allocator        = rmm::mr::polymorphic_allocator<char>{};
     auto set              = cuco::static_set{
-      all_keys.size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.value()};
+      all_keys.size(), 0.5, empty_key, d_equal, probe, {}, {}, allocator, stream.get()};
 
     // use a static_set to find the unique elements of all_keys
     auto const iter = cuda::counting_iterator<cudf::size_type>{0};
-    set.insert_async(iter, iter + all_keys.size(), stream.value());
+    set.insert_async(iter, iter + all_keys.size(), stream.get());
 
     // retrieve the indices of all the unique keys
     auto keys_indices = rmm::device_uvector<size_type>(all_keys.size(), stream);
-    auto keys_end     = set.retrieve_all(keys_indices.begin(), stream.value());
+    auto keys_end     = set.retrieve_all(keys_indices.begin(), stream.get());
     keys_indices.resize(cuda::std::distance(keys_indices.begin(), keys_end), stream);
 
     // gather the unique keys using the keys_indices
@@ -81,7 +81,7 @@ struct unique_keys_dispatch_fn {
 
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref)
     requires(not cudf::is_dictionary_key<T>())
   {
@@ -92,7 +92,7 @@ struct unique_keys_dispatch_fn {
 
 std::vector<std::unique_ptr<column>> match_dictionaries(
   std::span<dictionary_column_view const> input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(not input.empty(), "expect at least one dictionary", std::invalid_argument);
@@ -114,7 +114,7 @@ std::vector<std::unique_ptr<column>> match_dictionaries(
 }
 
 std::pair<std::vector<std::unique_ptr<column>>, std::vector<table_view>> match_dictionaries(
-  std::vector<table_view> tables, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  std::vector<table_view> tables, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   // Make a copy of all the column views from each table_view
   std::vector<std::vector<column_view>> updated_columns;
@@ -164,7 +164,7 @@ std::pair<std::vector<std::unique_ptr<column>>, std::vector<table_view>> match_d
 
 std::vector<std::unique_ptr<column>> match_dictionaries(
   std::span<dictionary_column_view const> input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -20,10 +20,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
@@ -51,7 +51,7 @@ namespace {
 template <typename KeysKeeper>
 std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_column,
                                        KeysKeeper keys_to_keep_fn,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto const keys_view    = dictionary_column.keys();
@@ -150,7 +150,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
 
 std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_column,
                                     column_view const& keys_to_remove,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!keys_to_remove.has_nulls(), "keys_to_remove must not have nulls");
@@ -168,7 +168,7 @@ std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_col
 }
 
 std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   // locate the keys to remove
@@ -200,7 +200,7 @@ std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& diction
 
 std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_column,
                                     column_view const& keys_to_remove,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -208,7 +208,7 @@ std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_col
 }
 
 std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,7 +17,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary {
@@ -43,7 +43,7 @@ namespace {
 template <typename ReplacementIter>
 std::unique_ptr<column> replace_indices(column_view const& input,
                                         ReplacementIter replacement_iter,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto const input_view = column_device_view::create(input, stream);
@@ -66,11 +66,11 @@ std::unique_ptr<column> replace_indices(column_view const& input,
 
 /**
  * @copydoc cudf::dictionary::detail::replace_nulls(cudf::column_view const&,cudf::column_view
- * const& rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * const& cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
                                       dictionary_column_view const& replacement,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::empty_like(input.parent()); }
@@ -101,11 +101,11 @@ std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
 
 /**
  * @copydoc cudf::dictionary::detail::replace_nulls(cudf::column_view const&,cudf::scalar
- * const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * const&, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
                                       scalar const& replacement,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::empty_like(input.parent()); }

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -15,9 +15,8 @@
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cub/device/device_find.cuh>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace dictionary {
@@ -36,7 +35,7 @@ struct find_index_fn {
   template <typename Element>
   std::unique_ptr<scalar> operator()(dictionary_column_view const& input,
                                      scalar const& key,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
     requires(not std::is_same_v<Element, dictionary32> and
              not std::is_same_v<Element, list_view> and not std::is_same_v<Element, struct_view>)
@@ -60,10 +59,10 @@ struct find_index_fn {
     auto find_fn  = [find_key] __device__(auto const& k) { return k == find_key.value(); };
     auto tmp_size = std::size_t{0};
     CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
-      nullptr, tmp_size, keys, result->data(), find_fn, num_keys, stream.value()));
+      nullptr, tmp_size, keys, result->data(), find_fn, num_keys, stream.get()));
     auto tmp = rmm::device_buffer(tmp_size, stream);
     CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
-      tmp.data(), tmp_size, keys, result->data(), find_fn, num_keys, stream.value()));
+      tmp.data(), tmp_size, keys, result->data(), find_fn, num_keys, stream.get()));
     if (result->value(stream) == num_keys) { result->set_valid_async(false, stream); }
     return result;
   }
@@ -71,7 +70,7 @@ struct find_index_fn {
   template <typename Element>
   std::unique_ptr<scalar> operator()(dictionary_column_view const&,
                                      scalar const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref) const
     requires(std::is_same_v<Element, dictionary32> or std::is_same_v<Element, list_view> or
              std::is_same_v<Element, struct_view>)
@@ -85,7 +84,7 @@ struct find_index_fn {
 
 std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   scalar const& key,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   if (dictionary.is_empty()) {
@@ -101,7 +100,7 @@ std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
 
 std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   scalar const& key,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -22,11 +22,11 @@
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
@@ -69,7 +69,7 @@ struct set_keys_dispatch_fn {
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::dictionary_column_view const& input,
                                            cudf::column_view const& new_keys,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(cudf::is_dictionary_key<T>())
   {
@@ -124,7 +124,7 @@ struct set_keys_dispatch_fn {
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::dictionary_column_view const&,
                                            cudf::column_view const&,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref)
     requires(not cudf::is_dictionary_key<T>())
   {
@@ -135,7 +135,7 @@ struct set_keys_dispatch_fn {
 
 std::unique_ptr<column> set_keys(dictionary_column_view const& input,
                                  column_view const& new_keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!new_keys.has_nulls(), "keys parameter must not have nulls", std::invalid_argument);
@@ -153,7 +153,7 @@ std::unique_ptr<column> set_keys(dictionary_column_view const& input,
 
 std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column,
                                  column_view const& keys,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,15 +12,16 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          scalar const& init,
                                                          size_type months,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(
@@ -31,7 +32,7 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
 std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          scalar const& init,
                                                          size_type months,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,9 +25,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -37,7 +36,7 @@ void in_place_fill(cudf::mutable_column_view& destination,
                    cudf::size_type begin,
                    cudf::size_type end,
                    cudf::scalar const& value,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
 {
   using ScalarType = cudf::scalar_type_t<T>;
   auto p_scalar    = static_cast<ScalarType const*>(&value);
@@ -57,7 +56,7 @@ struct in_place_fill_range_dispatch {
 
   template <typename T>
   std::enable_if_t<cudf::is_fixed_width<T>() && not cudf::is_fixed_point<T>(), void> operator()(
-    cudf::size_type begin, cudf::size_type end, rmm::cuda_stream_view stream)
+    cudf::size_type begin, cudf::size_type end, cuda::stream_ref stream)
   {
     in_place_fill<T>(destination, begin, end, value, stream);
   }
@@ -65,7 +64,7 @@ struct in_place_fill_range_dispatch {
   template <typename T>
   std::enable_if_t<cudf::is_fixed_point<T>(), void> operator()(cudf::size_type begin,
                                                                cudf::size_type end,
-                                                               rmm::cuda_stream_view stream)
+                                                               cuda::stream_ref stream)
   {
     auto unscaled = static_cast<cudf::fixed_point_scalar<T> const&>(value).value(stream);
     using RepType = typename T::rep;
@@ -97,7 +96,7 @@ struct out_of_place_fill_range_dispatch {
             CUDF_ENABLE_IF(cudf::is_rep_layout_compatible<T>() or cudf::is_fixed_point<T>())>
   std::unique_ptr<cudf::column> operator()(cudf::size_type begin,
                                            cudf::size_type end,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
   {
     CUDF_EXPECTS(cudf::have_same_types(input, value), "Data type mismatch.", cudf::data_type_error);
@@ -124,7 +123,7 @@ template <>
 std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf::string_view>(
   cudf::size_type begin,
   cudf::size_type end,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::have_same_types(input, value), "Data type mismatch.", cudf::data_type_error);
@@ -138,7 +137,7 @@ template <>
 std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf::dictionary32>(
   cudf::size_type begin,
   cudf::size_type end,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) return std::make_unique<cudf::column>(input, stream, mr);
@@ -189,7 +188,7 @@ void fill_in_place(mutable_column_view& destination,
                    size_type begin,
                    size_type end,
                    scalar const& value,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
 {
   CUDF_EXPECTS(cudf::is_fixed_width(destination.type()),
                "In-place fill does not support variable-sized types.");
@@ -212,7 +211,7 @@ std::unique_ptr<column> fill(column_view const& input,
                              size_type begin,
                              size_type end,
                              scalar const& value,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS((begin >= 0) && (end <= input.size()) && (begin <= end), "Range is out of bounds.");
@@ -227,7 +226,7 @@ void fill_in_place(mutable_column_view& destination,
                    size_type begin,
                    size_type end,
                    scalar const& value,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::fill_in_place(destination, begin, end, value, stream);
@@ -237,7 +236,7 @@ std::unique_ptr<column> fill(column_view const& input,
                              size_type begin,
                              size_type end,
                              scalar const& value,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -19,12 +19,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
@@ -38,7 +38,7 @@ struct count_accessor {
   cudf::scalar const* p_scalar = nullptr;
 
   template <typename T>
-  cudf::size_type operator()(rmm::cuda_stream_view stream)
+  cudf::size_type operator()(cuda::stream_ref stream)
     requires(std::is_integral_v<T>)
   {
     using ScalarType = cudf::scalar_type_t<T>;
@@ -52,7 +52,7 @@ struct count_accessor {
   }
 
   template <typename T>
-  cudf::size_type operator()(rmm::cuda_stream_view)
+  cudf::size_type operator()(cuda::stream_ref)
     requires(not std::is_integral_v<T>)
   {
     CUDF_FAIL("count value should be a integral type.");
@@ -63,7 +63,7 @@ struct count_checker {
   cudf::column_view const& count;
 
   template <typename T>
-  void operator()(rmm::cuda_stream_view stream)
+  void operator()(cuda::stream_ref stream)
     requires(std::is_integral_v<T>)
   {
     // static_cast is necessary due to bool
@@ -82,7 +82,7 @@ struct count_checker {
   }
 
   template <typename T>
-  void operator()(rmm::cuda_stream_view)
+  void operator()(cuda::stream_ref)
     requires(not std::is_integral_v<T>)
   {
     CUDF_FAIL("count value type should be integral.");
@@ -95,7 +95,7 @@ namespace cudf {
 namespace detail {
 std::unique_ptr<table> repeat(table_view const& input_table,
                               column_view const& count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input_table.num_rows() == count.size(), "in and count must have equal size");
@@ -126,7 +126,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
 
 std::unique_ptr<table> repeat(table_view const& input_table,
                               size_type count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   if ((input_table.num_rows() == 0) || (count == 0)) { return cudf::empty_like(input_table); }
@@ -149,7 +149,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
 
 std::unique_ptr<table> repeat(table_view const& input_table,
                               column_view const& count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -158,7 +158,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
 
 std::unique_ptr<table> repeat(table_view const& input_table,
                               size_type count,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,9 +17,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/sequence.h>
 #include <thrust/tabulate.h>
 
@@ -56,7 +56,7 @@ struct sequence_functor {
   std::unique_ptr<column> operator()(size_type size,
                                      scalar const& init,
                                      scalar const& step,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<T>() and not cudf::is_boolean<T>())
   {
@@ -82,7 +82,7 @@ struct sequence_functor {
   template <typename T>
   std::unique_ptr<column> operator()(size_type size,
                                      scalar const& init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<T>() and not cudf::is_boolean<T>())
   {
@@ -116,7 +116,7 @@ struct sequence_functor {
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  scalar const& step,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::have_same_types(init, step),
@@ -133,7 +133,7 @@ std::unique_ptr<column> sequence(size_type size,
 
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(size >= 0, "size must be >= 0", std::invalid_argument);
@@ -148,7 +148,7 @@ std::unique_ptr<column> sequence(size_type size,
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  scalar const& step,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -157,7 +157,7 @@ std::unique_ptr<column> sequence(size_type size,
 
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -20,7 +20,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -29,6 +28,7 @@
 #include <cuda/atomic>
 #include <cuda/devices>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
@@ -346,7 +346,7 @@ void copy_block_partitions_impl(InputIter const input,
                                 size_type const* block_partition_sizes,
                                 size_type const* scanned_block_partition_sizes,
                                 size_type grid_size,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   // We need 3 chunks of shared memory:
   // 1. BLOCK_SIZE * ROWS_PER_THREAD elements of size_type for copying to output
@@ -355,7 +355,7 @@ void copy_block_partitions_impl(InputIter const input,
   int const smem = OPTIMIZED_BLOCK_SIZE * OPTIMIZED_ROWS_PER_THREAD * sizeof(*output) +
                    (num_partitions + 1) * sizeof(size_type) * 2;
 
-  copy_block_partitions<<<grid_size, OPTIMIZED_BLOCK_SIZE, smem, stream.value()>>>(
+  copy_block_partitions<<<grid_size, OPTIMIZED_BLOCK_SIZE, smem, stream.get()>>>(
     input,
     output,
     num_rows,
@@ -374,7 +374,7 @@ rmm::device_uvector<size_type> compute_gather_map(size_type num_rows,
                                                   size_type const* block_partition_sizes,
                                                   size_type const* scanned_block_partition_sizes,
                                                   size_type grid_size,
-                                                  rmm::cuda_stream_view stream)
+                                                  cuda::stream_ref stream)
 {
   auto sequence = cuda::counting_iterator<cudf::size_type>{0};
   rmm::device_uvector<size_type> gather_map(num_rows, stream);
@@ -410,7 +410,7 @@ struct copy_block_partitions_dispatcher {
                                      size_type const* block_partition_sizes,
                                      size_type const* scanned_block_partition_sizes,
                                      size_type grid_size,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     rmm::device_buffer output(input.size() * sizeof(DataType), stream, mr);
@@ -438,7 +438,7 @@ struct copy_block_partitions_dispatcher {
                                      size_type const* block_partition_sizes,
                                      size_type const* scanned_block_partition_sizes,
                                      size_type grid_size,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     // Use move_to_output_buffer to create an equivalent gather map
@@ -470,7 +470,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   size_type num_rows,
   size_type num_partitions,
   Hasher hasher,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_partitions < std::numeric_limits<size_type>::max(),
@@ -518,7 +518,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
                                         lower_level,
                                         upper_level,
                                         num_rows,
-                                        stream.value());
+                                        stream.get());
     rmm::device_buffer temp_storage(temp_storage_bytes, stream);
     cub::DeviceHistogram::HistogramEven(temp_storage.data(),
                                         temp_storage_bytes,
@@ -528,7 +528,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
                                         lower_level,
                                         upper_level,
                                         num_rows,
-                                        stream.value());
+                                        stream.get());
   }
 
   // Exclusive scan on histogram to get partition offsets.
@@ -556,7 +556,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Scatter input rows into partitioned output
   auto output = detail::scatter(input, scatter_map, input, stream, mr);
 
-  stream.synchronize();  // Pinned async D2H copy must finish before returning host vec
+  stream.wait();  // Pinned async D2H copy must finish before returning host vec
 
   // Convert pinned host_vector to std::vector for the return type
   auto partition_offsets = std::vector<size_type>(pinned_offsets.begin(), pinned_offsets.end());
@@ -571,7 +571,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   table_view const& table_to_hash,
   size_type num_partitions,
   uint32_t seed,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const num_rows = table_to_hash.num_rows();
@@ -634,14 +634,14 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
     compute_row_partition_numbers<<<grid_size,
                                     block_size,
                                     num_partitions * sizeof(size_type),
-                                    stream.value()>>>(hasher,
-                                                      num_rows,
-                                                      num_partitions,
-                                                      partitioner_type(num_partitions),
-                                                      row_partition_numbers.data(),
-                                                      row_partition_offset.data(),
-                                                      block_partition_sizes.data(),
-                                                      global_partition_sizes.data());
+                                    stream.get()>>>(hasher,
+                                                    num_rows,
+                                                    num_partitions,
+                                                    partitioner_type(num_partitions),
+                                                    row_partition_numbers.data(),
+                                                    row_partition_offset.data(),
+                                                    block_partition_sizes.data(),
+                                                    global_partition_sizes.data());
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     // Determines how the mapping between hash value and partition number is
@@ -655,14 +655,14 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
     compute_row_partition_numbers<<<grid_size,
                                     block_size,
                                     num_partitions * sizeof(size_type),
-                                    stream.value()>>>(hasher,
-                                                      num_rows,
-                                                      num_partitions,
-                                                      partitioner_type(num_partitions),
-                                                      row_partition_numbers.data(),
-                                                      row_partition_offset.data(),
-                                                      block_partition_sizes.data(),
-                                                      global_partition_sizes.data());
+                                    stream.get()>>>(hasher,
+                                                    num_rows,
+                                                    num_partitions,
+                                                    partitioner_type(num_partitions),
+                                                    row_partition_numbers.data(),
+                                                    row_partition_offset.data(),
+                                                    block_partition_sizes.data(),
+                                                    global_partition_sizes.data());
     CUDF_CUDA_TRY(cudaGetLastError());
   }
 
@@ -724,7 +724,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
         input, gather_map.begin(), output_cols, detail::gather_bitmask_op::DONT_CHECK, stream, mr);
     }
 
-    stream.synchronize();  // Async D2H copy must finish before returning host vec
+    stream.wait();  // Async D2H copy must finish before returning host vec
     return std::pair{std::make_unique<table>(std::move(output_cols), num_rows),
                      std::move(partition_offsets)};
   } else {
@@ -735,14 +735,14 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
     compute_row_output_locations<<<grid_size,
                                    block_size,
                                    num_partitions * sizeof(size_type),
-                                   stream.value()>>>(
+                                   stream.get()>>>(
       row_output_locations, num_rows, num_partitions, scanned_block_partition_sizes_ptr);
     CUDF_CUDA_TRY(cudaGetLastError());
 
     // Use the resulting scatter map to materialize the output
     auto output = detail::scatter(input, row_partition_numbers, input, stream, mr);
 
-    stream.synchronize();  // Async D2H copy must finish before returning host vec
+    stream.wait();  // Async D2H copy must finish before returning host vec
     return std::pair{std::move(output), std::move(partition_offsets)};
   }
 }
@@ -772,7 +772,7 @@ struct dispatch_map_type {
     table_view const& t,
     column_view const& partition_map,
     size_type num_partitions,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
     requires(is_index_type<MapType>())
   {
@@ -790,7 +790,7 @@ struct dispatch_map_type {
                                         lower_level,
                                         upper_level,
                                         partition_map.size(),
-                                        stream.value());
+                                        stream.get());
 
     rmm::device_buffer temp_storage(temp_storage_bytes, stream);
 
@@ -802,7 +802,7 @@ struct dispatch_map_type {
                                         lower_level,
                                         upper_level,
                                         partition_map.size(),
-                                        stream.value());
+                                        stream.get());
 
     // `histogram` was created with an extra entry at the end such that an
     // exclusive scan will put the total number of rows at the end
@@ -877,7 +877,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   table_view const& table_to_hash,
   int num_partitions,
   uint32_t seed,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Return empty result if there are no partitions or nothing to hash
@@ -904,7 +904,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> partition(
   table_view const& t,
   column_view const& partition_map,
   size_type num_partitions,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(t.num_rows() == partition_map.size(),
@@ -926,7 +926,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function,
   uint32_t seed,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -951,7 +951,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function,
   uint32_t seed,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -965,7 +965,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function,
   uint32_t seed,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -977,7 +977,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> partition(
   table_view const& t,
   column_view const& partition_map,
   size_type num_partitions,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -19,12 +19,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -72,7 +72,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
   cudf::table_view const& input,
   cudf::size_type num_partitions,
   cudf::size_type start_partition,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto nrows = input.num_rows();
@@ -152,7 +152,7 @@ std::pair<std::unique_ptr<table>, std::vector<cudf::size_type>> round_robin_part
   table_view const& input,
   cudf::size_type num_partitions,
   cudf::size_type start_partition,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto nrows = input.num_rows();
@@ -269,7 +269,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> round_robi
   table_view const& input,
   cudf::size_type num_partitions,
   cudf::size_type start_partition,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -12,8 +12,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+
+#include <cuda/stream_ref>
 
 #include <string>
 
@@ -21,25 +22,25 @@ namespace cudf {
 
 scalar::scalar(data_type type,
                bool is_valid,
-               rmm::cuda_stream_view stream,
+               cuda::stream_ref stream,
                rmm::device_async_resource_ref mr)
   : _type(type), _is_valid(is_valid, stream, mr)
 {
 }
 
-scalar::scalar(scalar const& other, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+scalar::scalar(scalar const& other, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
   : _type(other.type()), _is_valid(other._is_valid, stream, mr)
 {
 }
 
 data_type scalar::type() const noexcept { return _type; }
 
-void scalar::set_valid_async(bool is_valid, rmm::cuda_stream_view stream)
+void scalar::set_valid_async(bool is_valid, cuda::stream_ref stream)
 {
   _is_valid.set_value_async(is_valid, stream);
 }
 
-bool scalar::is_valid(rmm::cuda_stream_view stream) const { return _is_valid.value(stream); }
+bool scalar::is_valid(cuda::stream_ref stream) const { return _is_valid.value(stream); }
 
 bool* scalar::validity_data() { return _is_valid.data(); }
 
@@ -47,7 +48,7 @@ bool const* scalar::validity_data() const { return _is_valid.data(); }
 
 string_scalar::string_scalar(std::string_view string,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRING), is_valid, stream, mr),
     _data(string.data(), string.size(), stream, mr)
@@ -59,7 +60,7 @@ string_scalar::string_scalar(std::string_view string,
 }
 
 string_scalar::string_scalar(string_scalar const& other,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(other, stream, mr), _data(other._data, stream, mr)
 {
@@ -67,7 +68,7 @@ string_scalar::string_scalar(string_scalar const& other,
 
 string_scalar::string_scalar(rmm::device_scalar<value_type>& data,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : string_scalar(data.value(stream), is_valid, stream, mr)
 {
@@ -75,7 +76,7 @@ string_scalar::string_scalar(rmm::device_scalar<value_type>& data,
 
 string_scalar::string_scalar(value_type const& source,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRING), is_valid, stream, mr),
     _data(source.data(), source.size_bytes(), stream, mr)
@@ -84,13 +85,13 @@ string_scalar::string_scalar(value_type const& source,
 
 string_scalar::string_scalar(rmm::device_buffer&& data,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRING), is_valid, stream, mr), _data(std::move(data))
 {
 }
 
-string_scalar::value_type string_scalar::value(rmm::cuda_stream_view stream) const
+string_scalar::value_type string_scalar::value(cuda::stream_ref stream) const
 {
   return value_type{data(), size()};
 }
@@ -99,7 +100,7 @@ size_type string_scalar::size() const { return _data.size(); }
 
 char const* string_scalar::data() const { return static_cast<char const*>(_data.data()); }
 
-std::string string_scalar::to_string(rmm::cuda_stream_view stream) const
+std::string string_scalar::to_string(cuda::stream_ref stream) const
 {
   std::string result(size(), '\0');
   detail::cuda_memcpy(host_span<char>{result.data(), result.size()},
@@ -112,7 +113,7 @@ template <typename T>
 fixed_point_scalar<T>::fixed_point_scalar(rep_type value,
                                           numeric::scale_type scale,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{data_type{type_to_id<T>(), static_cast<int32_t>(scale)}, is_valid, stream, mr},
     _data{value, stream, mr}
@@ -122,7 +123,7 @@ fixed_point_scalar<T>::fixed_point_scalar(rep_type value,
 template <typename T>
 fixed_point_scalar<T>::fixed_point_scalar(rep_type value,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{data_type{type_to_id<T>(), 0}, is_valid, stream, mr}, _data{value, stream, mr}
 {
@@ -131,7 +132,7 @@ fixed_point_scalar<T>::fixed_point_scalar(rep_type value,
 template <typename T>
 fixed_point_scalar<T>::fixed_point_scalar(T value,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{data_type{type_to_id<T>(), value.scale()}, is_valid, stream, mr},
     _data{value.value(), stream, mr}
@@ -142,7 +143,7 @@ template <typename T>
 fixed_point_scalar<T>::fixed_point_scalar(rmm::device_scalar<rep_type>&& data,
                                           numeric::scale_type scale,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{data_type{type_to_id<T>(), scale}, is_valid, stream, mr}, _data{std::move(data)}
 {
@@ -150,21 +151,20 @@ fixed_point_scalar<T>::fixed_point_scalar(rmm::device_scalar<rep_type>&& data,
 
 template <typename T>
 fixed_point_scalar<T>::fixed_point_scalar(fixed_point_scalar<T> const& other,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{other, stream, mr}, _data(other._data, stream, mr)
 {
 }
 
 template <typename T>
-typename fixed_point_scalar<T>::rep_type fixed_point_scalar<T>::value(
-  rmm::cuda_stream_view stream) const
+typename fixed_point_scalar<T>::rep_type fixed_point_scalar<T>::value(cuda::stream_ref stream) const
 {
   return _data.value(stream);
 }
 
 template <typename T>
-T fixed_point_scalar<T>::fixed_point_value(rmm::cuda_stream_view stream) const
+T fixed_point_scalar<T>::fixed_point_value(cuda::stream_ref stream) const
 {
   return value_type{
     numeric::scaled_integer<rep_type>{_data.value(stream), numeric::scale_type{type().scale()}}};
@@ -199,7 +199,7 @@ namespace CUDF_HIDDEN detail {
 template <typename T>
 fixed_width_scalar<T>::fixed_width_scalar(T value,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar(data_type(type_to_id<T>()), is_valid, stream, mr), _data(value, stream, mr)
 {
@@ -208,7 +208,7 @@ fixed_width_scalar<T>::fixed_width_scalar(T value,
 template <typename T>
 fixed_width_scalar<T>::fixed_width_scalar(rmm::device_scalar<T>&& data,
                                           bool is_valid,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar(data_type(type_to_id<T>()), is_valid, stream, mr), _data{std::move(data)}
 {
@@ -216,21 +216,21 @@ fixed_width_scalar<T>::fixed_width_scalar(rmm::device_scalar<T>&& data,
 
 template <typename T>
 fixed_width_scalar<T>::fixed_width_scalar(fixed_width_scalar<T> const& other,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
   : scalar{other, stream, mr}, _data(other._data, stream, mr)
 {
 }
 
 template <typename T>
-void fixed_width_scalar<T>::set_value(T value, rmm::cuda_stream_view stream)
+void fixed_width_scalar<T>::set_value(T value, cuda::stream_ref stream)
 {
   _data.set_value_async(value, stream);
   this->set_valid_async(true, stream);
 }
 
 template <typename T>
-T fixed_width_scalar<T>::value(rmm::cuda_stream_view stream) const
+T fixed_width_scalar<T>::value(cuda::stream_ref stream) const
 {
   return _data.value(stream);
 }
@@ -283,7 +283,7 @@ template class fixed_width_scalar<duration_ns>;
 template <typename T>
 numeric_scalar<T>::numeric_scalar(T value,
                                   bool is_valid,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>(value, is_valid, stream, mr)
 {
@@ -292,7 +292,7 @@ numeric_scalar<T>::numeric_scalar(T value,
 template <typename T>
 numeric_scalar<T>::numeric_scalar(rmm::device_scalar<T>&& data,
                                   bool is_valid,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>(std::forward<rmm::device_scalar<T>>(data), is_valid, stream, mr)
 {
@@ -300,7 +300,7 @@ numeric_scalar<T>::numeric_scalar(rmm::device_scalar<T>&& data,
 
 template <typename T>
 numeric_scalar<T>::numeric_scalar(numeric_scalar<T> const& other,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>{other, stream, mr}
 {
@@ -330,7 +330,7 @@ template class numeric_scalar<double>;
 template <typename T>
 chrono_scalar<T>::chrono_scalar(T value,
                                 bool is_valid,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>(value, is_valid, stream, mr)
 {
@@ -339,7 +339,7 @@ chrono_scalar<T>::chrono_scalar(T value,
 template <typename T>
 chrono_scalar<T>::chrono_scalar(rmm::device_scalar<T>&& data,
                                 bool is_valid,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>(std::forward<rmm::device_scalar<T>>(data), is_valid, stream, mr)
 {
@@ -347,7 +347,7 @@ chrono_scalar<T>::chrono_scalar(rmm::device_scalar<T>&& data,
 
 template <typename T>
 chrono_scalar<T>::chrono_scalar(chrono_scalar<T> const& other,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
   : detail::fixed_width_scalar<T>{other, stream, mr}
 {
@@ -375,7 +375,7 @@ template class chrono_scalar<duration_ns>;
 template <typename T>
 duration_scalar<T>::duration_scalar(rep_type value,
                                     bool is_valid,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
   : chrono_scalar<T>(T{value}, is_valid, stream, mr)
 {
@@ -383,14 +383,14 @@ duration_scalar<T>::duration_scalar(rep_type value,
 
 template <typename T>
 duration_scalar<T>::duration_scalar(duration_scalar<T> const& other,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
   : chrono_scalar<T>{other, stream, mr}
 {
 }
 
 template <typename T>
-typename duration_scalar<T>::rep_type duration_scalar<T>::count(rmm::cuda_stream_view stream)
+typename duration_scalar<T>::rep_type duration_scalar<T>::count(cuda::stream_ref stream)
 {
   return this->value(stream).count();
 }
@@ -411,7 +411,7 @@ template class duration_scalar<duration_ns>;
 
 template <typename T>
 typename timestamp_scalar<T>::rep_type timestamp_scalar<T>::ticks_since_epoch(
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   return this->value(stream).time_since_epoch().count();
 }
@@ -434,7 +434,7 @@ template <typename T>
 template <typename D>
 timestamp_scalar<T>::timestamp_scalar(D const& value,
                                       bool is_valid,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
   : chrono_scalar<T>(T{typename T::duration{value}}, is_valid, stream, mr)
 {
@@ -442,7 +442,7 @@ timestamp_scalar<T>::timestamp_scalar(D const& value,
 
 template <typename T>
 timestamp_scalar<T>::timestamp_scalar(timestamp_scalar<T> const& other,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
   : chrono_scalar<T>{other, stream, mr}
 {
@@ -450,7 +450,7 @@ timestamp_scalar<T>::timestamp_scalar(timestamp_scalar<T> const& other,
 
 #define TS_CTOR(TimestampType, DurationType)                  \
   template timestamp_scalar<TimestampType>::timestamp_scalar( \
-    DurationType const&, bool, rmm::cuda_stream_view, rmm::device_async_resource_ref);
+    DurationType const&, bool, cuda::stream_ref, rmm::device_async_resource_ref);
 
 /**
  * @brief These are the valid combinations of duration types to timestamp types.
@@ -478,7 +478,7 @@ TS_CTOR(timestamp_ns, int64_t)
 
 list_scalar::list_scalar(cudf::column_view const& data,
                          bool is_valid,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::LIST), is_valid, stream, mr), _data(data, stream, mr)
 {
@@ -486,14 +486,14 @@ list_scalar::list_scalar(cudf::column_view const& data,
 
 list_scalar::list_scalar(cudf::column&& data,
                          bool is_valid,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::LIST), is_valid, stream, mr), _data(std::move(data))
 {
 }
 
 list_scalar::list_scalar(list_scalar const& other,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
   : scalar{other, stream, mr}, _data(other._data, stream, mr)
 {
@@ -502,7 +502,7 @@ list_scalar::list_scalar(list_scalar const& other,
 column_view list_scalar::view() const { return _data.view(); }
 
 struct_scalar::struct_scalar(struct_scalar const& other,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar{other, stream, mr}, _data(other._data, stream, mr)
 {
@@ -510,7 +510,7 @@ struct_scalar::struct_scalar(struct_scalar const& other,
 
 struct_scalar::struct_scalar(table_view const& data,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRUCT), is_valid, stream, mr),
     _data{init_data(table{data, stream, mr}, is_valid, stream, mr)}
@@ -520,7 +520,7 @@ struct_scalar::struct_scalar(table_view const& data,
 
 struct_scalar::struct_scalar(std::span<column_view const> data,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRUCT), is_valid, stream, mr),
     _data{
@@ -534,7 +534,7 @@ struct_scalar::struct_scalar(std::span<column_view const> data,
 
 struct_scalar::struct_scalar(table&& data,
                              bool is_valid,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
   : scalar(data_type(type_id::STRUCT), is_valid, stream, mr),
     _data{init_data(std::move(data), is_valid, stream, mr)}
@@ -554,7 +554,7 @@ void struct_scalar::assert_valid_size()
 
 table struct_scalar::init_data(table&& data,
                                bool is_valid,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   if (is_valid) { return std::move(data); }

--- a/cpp/src/scalar/scalar_factories.cpp
+++ b/cpp/src/scalar/scalar_factories.cpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace {
@@ -19,7 +19,7 @@ struct scalar_construction_helper {
 
   template <typename T,
             std::enable_if_t<is_fixed_width<T>() and not is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<scalar> operator()(rmm::cuda_stream_view stream,
+  std::unique_ptr<scalar> operator()(cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     using Type       = device_storage_type_t<T>;
@@ -28,7 +28,7 @@ struct scalar_construction_helper {
   }
 
   template <typename T, std::enable_if_t<is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<scalar> operator()(rmm::cuda_stream_view stream,
+  std::unique_ptr<scalar> operator()(cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     using Type       = device_storage_type_t<T>;
@@ -47,7 +47,7 @@ struct scalar_construction_helper {
 
 // Allocate storage for a single numeric element
 std::unique_ptr<scalar> make_numeric_scalar(data_type type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
@@ -57,7 +57,7 @@ std::unique_ptr<scalar> make_numeric_scalar(data_type type,
 
 // Allocate storage for a single timestamp element
 std::unique_ptr<scalar> make_timestamp_scalar(data_type type,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
@@ -67,7 +67,7 @@ std::unique_ptr<scalar> make_timestamp_scalar(data_type type,
 
 // Allocate storage for a single duration element
 std::unique_ptr<scalar> make_duration_scalar(data_type type,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
@@ -77,7 +77,7 @@ std::unique_ptr<scalar> make_duration_scalar(data_type type,
 
 // Allocate storage for a single fixed width element
 std::unique_ptr<scalar> make_fixed_width_scalar(data_type type,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_fixed_width(type), "Invalid, non-fixed-width type.");
@@ -86,21 +86,21 @@ std::unique_ptr<scalar> make_fixed_width_scalar(data_type type,
 }
 
 std::unique_ptr<scalar> make_list_scalar(column_view elements,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   return std::make_unique<list_scalar>(elements, true, stream, mr);
 }
 
 std::unique_ptr<scalar> make_struct_scalar(table_view const& data,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return std::make_unique<struct_scalar>(data, true, stream, mr);
 }
 
 std::unique_ptr<scalar> make_struct_scalar(std::span<column_view const> data,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return std::make_unique<struct_scalar>(data, true, stream, mr);
@@ -111,14 +111,14 @@ struct default_scalar_functor {
   data_type type;
 
   template <typename T, std::enable_if_t<not is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<cudf::scalar> operator()(rmm::cuda_stream_view stream,
+  std::unique_ptr<cudf::scalar> operator()(cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
   {
     return make_fixed_width_scalar(data_type(type_to_id<T>()), stream, mr);
   }
 
   template <typename T, std::enable_if_t<is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<cudf::scalar> operator()(rmm::cuda_stream_view stream,
+  std::unique_ptr<cudf::scalar> operator()(cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
   {
     auto const scale_ = numeric::scale_type{type.scale()};
@@ -130,28 +130,28 @@ struct default_scalar_functor {
 
 template <>
 std::unique_ptr<cudf::scalar> default_scalar_functor::operator()<string_view>(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   return std::unique_ptr<scalar>(new string_scalar("", false, stream, mr));
 }
 
 template <>
 std::unique_ptr<cudf::scalar> default_scalar_functor::operator()<dictionary32>(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FAIL("dictionary type not supported");
 }
 
 template <>
 std::unique_ptr<cudf::scalar> default_scalar_functor::operator()<list_view>(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FAIL("list_view type not supported");
 }
 
 template <>
 std::unique_ptr<cudf::scalar> default_scalar_functor::operator()<struct_view>(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FAIL("struct_view type not supported");
 }
@@ -159,14 +159,14 @@ std::unique_ptr<cudf::scalar> default_scalar_functor::operator()<struct_view>(
 }  // namespace
 
 std::unique_ptr<scalar> make_default_constructed_scalar(data_type type,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(type, default_scalar_functor{type}, stream, mr);
 }
 
 std::unique_ptr<scalar> make_empty_scalar_like(column_view const& column,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   std::unique_ptr<scalar> result;

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -12,7 +12,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -21,7 +21,7 @@ namespace {
 
 std::unique_ptr<column> contains_dictionary(column_view const& haystack_in,
                                             column_view const& needles_in,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   dictionary_column_view const haystack(haystack_in);
@@ -52,7 +52,7 @@ std::unique_ptr<column> contains_dictionary(column_view const& haystack_in,
 
 std::unique_ptr<column> contains(column_view const& haystack,
                                  column_view const& needles,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   // Dictionary columns require key normalization; all other types share the type-erased path.
@@ -73,7 +73,7 @@ std::unique_ptr<column> contains(column_view const& haystack,
 
 std::unique_ptr<column> contains(column_view const& haystack,
                                  column_view const& needles,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,9 +20,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -53,7 +53,7 @@ struct contains_scalar_dispatch {
   template <typename Element>
   std::enable_if_t<!is_nested<Element>(), bool> operator()(column_view const& haystack,
                                                            scalar const& needle,
-                                                           rmm::cuda_stream_view stream) const
+                                                           cuda::stream_ref stream) const
   {
     CUDF_EXPECTS(cudf::have_same_types(haystack, needle),
                  "Scalar and column types must match",
@@ -83,7 +83,7 @@ struct contains_scalar_dispatch {
   template <typename Element>
   std::enable_if_t<is_nested<Element>(), bool> operator()(column_view const& haystack,
                                                           scalar const& needle,
-                                                          rmm::cuda_stream_view stream) const
+                                                          cuda::stream_ref stream) const
   {
     CUDF_EXPECTS(cudf::have_same_types(haystack, needle),
                  "Scalar and column types must match",
@@ -137,7 +137,7 @@ struct contains_scalar_dispatch {
 template <>
 bool contains_scalar_dispatch::operator()<cudf::dictionary32>(column_view const& haystack,
                                                               scalar const& needle,
-                                                              rmm::cuda_stream_view stream) const
+                                                              cuda::stream_ref stream) const
 {
   auto const dict_col = cudf::dictionary_column_view(haystack);
   // first, find the needle in the dictionary's key set
@@ -153,7 +153,7 @@ bool contains_scalar_dispatch::operator()<cudf::dictionary32>(column_view const&
 
 }  // namespace
 
-bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_stream_view stream)
+bool contains(column_view const& haystack, scalar const& needle, cuda::stream_ref stream)
 {
   if (haystack.is_empty()) { return false; }
   if (not needle.is_valid(stream)) { return haystack.has_nulls(); }
@@ -164,7 +164,7 @@ bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_strea
 
 }  // namespace detail
 
-bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_stream_view stream)
+bool contains(column_view const& haystack, scalar const& needle, cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::contains(haystack, needle, stream);

--- a/cpp/src/search/contains_table.cu
+++ b/cpp/src/search/contains_table.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,10 +13,10 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuco/static_set.cuh>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 
@@ -26,7 +26,7 @@ rmm::device_uvector<bool> contains(table_view const& haystack,
                                    table_view const& needles,
                                    null_equality compare_nulls,
                                    nan_equality compare_nans,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::have_same_types(haystack, needles), "Column types mismatch");

--- a/cpp/src/search/contains_table_impl.cu
+++ b/cpp/src/search/contains_table_impl.cu
@@ -20,7 +20,7 @@ namespace cudf::detail {
  * @return A pair of pointer to the output bitmask and the buffer containing the bitmask
  */
 std::pair<rmm::device_buffer, bitmask_type const*> build_row_bitmask(table_view const& input,
-                                                                     rmm::cuda_stream_view stream)
+                                                                     cuda::stream_ref stream)
 {
   auto const nullable_columns = get_nullable_columns(input);
   CUDF_EXPECTS(nullable_columns.size() > 0,

--- a/cpp/src/search/contains_table_impl.cuh
+++ b/cpp/src/search/contains_table_impl.cuh
@@ -15,13 +15,13 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
@@ -94,7 +94,7 @@ struct comparator_adapter {
  * @return A pair of pointer to the output bitmask and the buffer containing the bitmask
  */
 std::pair<rmm::device_buffer, bitmask_type const*> build_row_bitmask(table_view const& input,
-                                                                     rmm::cuda_stream_view stream);
+                                                                     cuda::stream_ref stream);
 
 /**
  * @brief Helper function to perform the contains operation using a hash set
@@ -121,7 +121,7 @@ void perform_contains(table_view const& haystack,
                       Comparator const& d_equal,
                       ProbingScheme const& probing_scheme,
                       rmm::device_uvector<bool>& contained,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   auto const haystack_iter = cudf::detail::make_counting_transform_iterator(
     size_type{0}, cuda::proclaim_return_type<rhs_index_type>([] __device__(auto idx) {
@@ -141,7 +141,7 @@ void perform_contains(table_view const& haystack,
                               {},
                               {},
                               rmm::mr::polymorphic_allocator<char>{},
-                              stream.value()};
+                              stream.get()};
 
   if (haystack_has_nulls && compare_nulls == null_equality::UNEQUAL) {
     auto const bitmask_buffer_and_ptr = build_row_bitmask(haystack, stream);
@@ -155,9 +155,9 @@ void perform_contains(table_view const& haystack,
                         haystack_iter + haystack.num_rows(),
                         cuda::counting_iterator<size_type>{0},  // stencil
                         row_is_valid{row_bitmask_ptr},
-                        stream.value());
+                        stream.get());
   } else {
-    set.insert_async(haystack_iter, haystack_iter + haystack.num_rows(), stream.value());
+    set.insert_async(haystack_iter, haystack_iter + haystack.num_rows(), stream.get());
   }
 
   if (needles_has_nulls && compare_nulls == null_equality::UNEQUAL) {
@@ -168,10 +168,10 @@ void perform_contains(table_view const& haystack,
                           cuda::counting_iterator<size_type>{0},  // stencil
                           row_is_valid{row_bitmask_ptr},
                           contained.begin(),
-                          stream.value());
+                          stream.get());
   } else {
     set.contains_async(
-      needles_iter, needles_iter + needles.num_rows(), contained.begin(), stream.value());
+      needles_iter, needles_iter + needles.num_rows(), contained.begin(), stream.get());
   }
 }
 
@@ -207,7 +207,7 @@ void dispatch_nan_comparator(table_view const& haystack,
                              cudf::detail::row::equality::two_table_comparator two_table_equal,
                              Hasher const& d_hasher,
                              rmm::device_uvector<bool>& contained,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   // Distinguish probing scheme CG sizes between nested and flat types for better performance
   auto const probing_scheme = [&]() {

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 
 namespace cudf {
@@ -28,7 +28,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                                        bool find_first,
                                        std::vector<order> const& column_order,
                                        std::vector<null_order> const& null_precedence,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -45,8 +45,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
 
   // Handle empty inputs
   if (haystack.num_rows() == 0) {
-    CUDF_CUDA_TRY(
-      cudaMemsetAsync(out_it, 0, needles.num_rows() * sizeof(size_type), stream.value()));
+    CUDF_CUDA_TRY(cudaMemsetAsync(out_it, 0, needles.num_rows() * sizeof(size_type), stream.get()));
     return result;
   }
 
@@ -111,7 +110,7 @@ std::unique_ptr<column> lower_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   return search_ordered(haystack, needles, true, column_order, null_precedence, stream, mr);
@@ -121,7 +120,7 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   return search_ordered(haystack, needles, false, column_order, null_precedence, stream, mr);
@@ -135,7 +134,7 @@ std::unique_ptr<column> lower_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -146,7 +145,7 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
                                     table_view const& needles,
                                     std::vector<order> const& column_order,
                                     std::vector<null_order> const& null_precedence,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -16,9 +16,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 
 struct ColumnDeviceViewTest : public cudf::test::BaseFixture {};
@@ -26,7 +26,7 @@ struct ColumnDeviceViewTest : public cudf::test::BaseFixture {};
 TEST_F(ColumnDeviceViewTest, Sample)
 {
   using T = int32_t;
-  rmm::cuda_stream_view stream{cudf::get_default_stream()};
+  cuda::stream_ref stream{cudf::get_default_stream()};
   cudf::test::fixed_width_column_wrapper<T> input({1, 2, 3, 4, 5, 6});
   auto output            = cudf::allocate_like(input);
   auto input_device_view = cudf::column_device_view::create(input, stream);
@@ -44,7 +44,7 @@ TEST_F(ColumnDeviceViewTest, Sample)
 TEST_F(ColumnDeviceViewTest, MismatchingType)
 {
   using T = int32_t;
-  rmm::cuda_stream_view stream{cudf::get_default_stream()};
+  cuda::stream_ref stream{cudf::get_default_stream()};
   cudf::test::fixed_width_column_wrapper<T> input({1, 2, 3, 4, 5, 6});
   auto output            = cudf::allocate_like(input);
   auto input_device_view = cudf::column_device_view::create(input, stream);

--- a/cpp/tests/column/column_test.cpp
+++ b/cpp/tests/column/column_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,16 +35,16 @@ template <typename T>
 struct TypedColumnTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 
-  TypedColumnTest(rmm::cuda_stream_view stream = cudf::get_default_stream())
+  TypedColumnTest(cuda::stream_ref stream = cudf::get_default_stream())
     : data{_num_elements * sizeof(T), stream},
       mask{cudf::bitmask_allocation_size_bytes(_num_elements), stream}
   {
     std::vector<char> h_data(std::max(data.size(), mask.size()));
     std::iota(h_data.begin(), h_data.end(), 0);
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(data.data(), h_data.data(), data.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(data.data(), h_data.data(), data.size(), cudaMemcpyDefault, stream.get()));
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(mask.data(), h_data.data(), mask.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(mask.data(), h_data.data(), mask.size(), cudaMemcpyDefault, stream.get()));
   }
 
   cudf::size_type num_elements() { return _num_elements; }

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -45,7 +45,7 @@ template <typename T>
 struct TypedColumnTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 
-  TypedColumnTest(rmm::cuda_stream_view stream = cudf::get_default_stream())
+  TypedColumnTest(cuda::stream_ref stream = cudf::get_default_stream())
     : data{_num_elements * sizeof(T), stream},
       mask{cudf::bitmask_allocation_size_bytes(_num_elements), stream}
   {
@@ -56,11 +56,11 @@ struct TypedColumnTest : public cudf::test::BaseFixture {
     std::vector<char> h_mask(mask.size());
     std::iota(h_mask.begin(), h_mask.end(), char{0});
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(typed_data, h_data.data(), data.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(typed_data, h_data.data(), data.size(), cudaMemcpyDefault, stream.get()));
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(typed_mask, h_mask.data(), mask.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(typed_mask, h_mask.data(), mask.size(), cudaMemcpyDefault, stream.get()));
     _null_count = cudf::null_count(static_cast<cudf::bitmask_type*>(mask.data()), 0, _num_elements);
-    stream.synchronize();
+    stream.wait();
   }
 
   [[nodiscard]] cudf::size_type num_elements() const { return _num_elements; }

--- a/cpp/tests/copying/shift_tests.cpp
+++ b/cpp/tests/copying/shift_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <limits>
 #include <memory>
@@ -23,7 +23,7 @@ using TestTypes = cudf::test::Types<int32_t>;
 
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
 std::unique_ptr<cudf::scalar> make_scalar(
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto s = new ScalarType(cudf::test::make_type_param_scalar<T>(0), false, stream, mr);
@@ -33,7 +33,7 @@ std::unique_ptr<cudf::scalar> make_scalar(
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
 std::unique_ptr<cudf::scalar> make_scalar(
   T value,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto s = new ScalarType(value, true, stream, mr);

--- a/cpp/tests/streams/column_view_test.cpp
+++ b/cpp/tests/streams/column_view_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,16 +20,16 @@ template <typename T>
 struct TypedColumnTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 
-  TypedColumnTest(rmm::cuda_stream_view stream = cudf::test::get_default_stream())
+  TypedColumnTest(cuda::stream_ref stream = cudf::test::get_default_stream())
     : data{_num_elements * sizeof(T), stream},
       mask{cudf::bitmask_allocation_size_bytes(_num_elements), stream}
   {
     std::vector<char> h_data(std::max(data.size(), mask.size()));
     std::iota(h_data.begin(), h_data.end(), 0);
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(data.data(), h_data.data(), data.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(data.data(), h_data.data(), data.size(), cudaMemcpyDefault, stream.get()));
     CUDF_CUDA_TRY(
-      cudaMemcpyAsync(mask.data(), h_data.data(), mask.size(), cudaMemcpyDefault, stream.value()));
+      cudaMemcpyAsync(mask.data(), h_data.data(), mask.size(), cudaMemcpyDefault, stream.get()));
   }
 
   cudf::size_type num_elements() { return _num_elements; }

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -30,6 +30,7 @@
 #include <cuda/std/cmath>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
@@ -53,7 +54,7 @@ namespace test {
 namespace {
 
 std::unique_ptr<column> generate_all_row_indices(size_type num_rows,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  cudf::memory_resources mr)
 {
   auto indices = cudf::make_fixed_width_column(
@@ -91,7 +92,7 @@ std::unique_ptr<column> generate_all_row_indices(size_type num_rows,
 std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
                                                    column_view const& row_indices,
                                                    bool check_exact_equality,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    cudf::memory_resources mr)
 {
   // if we are checking for exact equality, we should be checking for "unsanitized" data that may
@@ -242,7 +243,7 @@ struct column_property_comparator {
                       cudf::column_view const& lhs_row_indices,
                       cudf::column_view const& rhs_row_indices,
                       debug_output_level verbosity,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       cudf::memory_resources mr)
   {
     bool result = true;
@@ -276,7 +277,7 @@ struct column_property_comparator {
                   cudf::column_view const& lhs_row_indices,
                   cudf::column_view const& rhs_row_indices,
                   debug_output_level verbosity,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(!std::is_same_v<T, cudf::list_view> && !std::is_same_v<T, cudf::struct_view>)
   {
@@ -289,7 +290,7 @@ struct column_property_comparator {
                   cudf::column_view const& lhs_row_indices,
                   cudf::column_view const& rhs_row_indices,
                   debug_output_level verbosity,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<T, cudf::list_view>)
   {
@@ -330,7 +331,7 @@ struct column_property_comparator {
                   cudf::column_view const& lhs_row_indices,
                   cudf::column_view const& rhs_row_indices,
                   debug_output_level verbosity,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<T, cudf::struct_view>)
   {
@@ -477,7 +478,7 @@ std::string stringify_column_differences(cudf::device_span<int const> difference
                                          column_view const& rhs_row_indices,
                                          debug_output_level verbosity,
                                          int depth,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          cudf::memory_resources mr)
 {
   CUDF_EXPECTS(not differences.empty(), "Shouldn't enter this function if `differences` is empty");
@@ -527,7 +528,7 @@ struct column_comparator_impl {
                   debug_output_level verbosity,
                   size_type fp_ulps,
                   int depth,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
   {
     auto d_lhs_row_indices =
@@ -607,7 +608,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
                   debug_output_level verbosity,
                   size_type fp_ulps,
                   int depth,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
   {
     lists_column_view lhs_l(lhs);
@@ -752,7 +753,7 @@ struct column_comparator_impl<struct_view, check_exact_equality> {
                   debug_output_level verbosity,
                   size_type fp_ulps,
                   int depth,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
   {
     structs_column_view l_scv(lhs);
@@ -789,7 +790,7 @@ struct column_comparator {
                   debug_output_level verbosity,
                   size_type fp_ulps,
                   int depth,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
   {
     // compare properties
@@ -812,9 +813,7 @@ struct column_comparator {
   }
 };
 
-void check_non_empty_nulls(column_view const& lhs,
-                           column_view const& rhs,
-                           rmm::cuda_stream_view stream)
+void check_non_empty_nulls(column_view const& lhs, column_view const& rhs, cuda::stream_ref stream)
 {
   auto check_column_nulls = [stream](column_view const& col, char const* col_name) {
     if (cudf::detail::has_nonempty_nulls(col, stream)) {
@@ -835,7 +834,7 @@ namespace detail {
 bool expect_column_properties_equal(column_view const& lhs,
                                     column_view const& rhs,
                                     debug_output_level verbosity,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     cudf::memory_resources mr)
 {
   check_non_empty_nulls(lhs, rhs, stream);
@@ -858,7 +857,7 @@ bool expect_column_properties_equal(column_view const& lhs,
 bool expect_column_properties_equivalent(column_view const& lhs,
                                          column_view const& rhs,
                                          debug_output_level verbosity,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          cudf::memory_resources mr)
 {
   check_non_empty_nulls(lhs, rhs, stream);
@@ -881,7 +880,7 @@ bool expect_column_properties_equivalent(column_view const& lhs,
 bool expect_columns_equal(cudf::column_view const& lhs,
                           cudf::column_view const& rhs,
                           debug_output_level verbosity,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           cudf::memory_resources mr)
 {
   check_non_empty_nulls(lhs, rhs, stream);
@@ -907,7 +906,7 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
                                cudf::column_view const& rhs,
                                debug_output_level verbosity,
                                size_type fp_ulps,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                cudf::memory_resources mr)
 {
   check_non_empty_nulls(lhs, rhs, stream);
@@ -932,7 +931,7 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
 void expect_equal_buffers(void const* lhs,
                           void const* rhs,
                           std::size_t size_bytes,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           cudf::memory_resources mr)
 {
   if (size_bytes > 0) {
@@ -961,7 +960,7 @@ void expect_column_empty(cudf::column_view const& col)
  * @copydoc cudf::test::bitmask_to_host
  */
 std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           cudf::memory_resources mr)
 {
   if (c.nullable()) {
@@ -1000,7 +999,7 @@ bool validate_host_masks(std::vector<bitmask_type> const& expected_mask,
 
 template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>*>
 std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host(column_view c,
-                                                                     rmm::cuda_stream_view stream,
+                                                                     cuda::stream_ref stream,
                                                                      cudf::memory_resources mr)
 {
   using namespace numeric;
@@ -1017,11 +1016,11 @@ std::pair<thrust::host_vector<T>, std::vector<bitmask_type>> to_host(column_view
 }
 
 template std::pair<thrust::host_vector<numeric::decimal32>, std::vector<bitmask_type>> to_host(
-  column_view c, rmm::cuda_stream_view stream, cudf::memory_resources mr);
+  column_view c, cuda::stream_ref stream, cudf::memory_resources mr);
 template std::pair<thrust::host_vector<numeric::decimal64>, std::vector<bitmask_type>> to_host(
-  column_view c, rmm::cuda_stream_view stream, cudf::memory_resources mr);
+  column_view c, cuda::stream_ref stream, cudf::memory_resources mr);
 template std::pair<thrust::host_vector<numeric::decimal128>, std::vector<bitmask_type>> to_host(
-  column_view c, rmm::cuda_stream_view stream, cudf::memory_resources mr);
+  column_view c, cuda::stream_ref stream, cudf::memory_resources mr);
 
 namespace {
 struct strings_to_host_fn {
@@ -1029,7 +1028,7 @@ struct strings_to_host_fn {
   void operator()(thrust::host_vector<std::string>& host_data,
                   char const* chars,
                   cudf::column_view const& offsets,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
     requires(std::is_same_v<OffsetType, int32_t> || std::is_same_v<OffsetType, int64_t>)
   {
     auto const h_offsets = cudf::detail::make_std_vector(
@@ -1046,7 +1045,7 @@ struct strings_to_host_fn {
   void operator()(thrust::host_vector<std::string>&,
                   char const*,
                   cudf::column_view const&,
-                  rmm::cuda_stream_view)
+                  cuda::stream_ref)
     requires(!std::is_same_v<OffsetType, int32_t> && !std::is_same_v<OffsetType, int64_t>)
   {
     CUDF_FAIL("invalid offsets type");
@@ -1056,7 +1055,7 @@ struct strings_to_host_fn {
 
 template <>
 std::pair<thrust::host_vector<std::string>, std::vector<bitmask_type>> to_host(
-  column_view c, rmm::cuda_stream_view stream, cudf::memory_resources mr)
+  column_view c, cuda::stream_ref stream, cudf::memory_resources mr)
 {
   thrust::host_vector<std::string> host_data(c.size());
   if (c.size() > c.null_count()) {


### PR DESCRIPTION
## Description
This second batch migrates core libcudf column, scalar, copying, dictionary, filling, search, and partitioning APIs and tests from `rmm::cuda_stream_view` to `cuda::stream_ref`. It leaves default stream helpers and owning RMM stream types unchanged for later batches.

Contributes to https://github.com/NVIDIA/cudf/issues/23636

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.