### PR TITLE
Use cuda::stream_ref for compute APIs

### DIFF
--- a/cpp/include/cudf/aggregation/host_udf.hpp
+++ b/cpp/include/cudf/aggregation/host_udf.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,9 +11,8 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
-
-#include <cuda/stream_ref>
 
 #include <functional>
 #include <optional>
@@ -97,7 +96,7 @@ class host_udf_base {
  *     column_view const& input,
  *     data_type output_dtype,
  *     std::optional<std::reference_wrapper<scalar const>> init,
- *     cuda::stream_ref stream,
+ *     rmm::cuda_stream_view stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform reduction computation using the input data and return the reduction result.
@@ -133,7 +132,7 @@ struct reduce_host_udf : host_udf_base {
     column_view const& input,
     data_type output_dtype,
     std::optional<std::reference_wrapper<scalar const>> init,
-    cuda::stream_ref stream,
+    rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const = 0;
 };
 
@@ -155,7 +154,7 @@ struct reduce_host_udf : host_udf_base {
  *     data_type output_dtype,
  *     null_policy null_handling,
  *     std::optional<std::reference_wrapper<scalar const>> init,
- *     cuda::stream_ref stream,
+ *     rmm::cuda_stream_view stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform computation using the input data and return the result.
@@ -197,7 +196,7 @@ struct segmented_reduce_host_udf : host_udf_base {
     data_type output_dtype,
     null_policy null_handling,
     std::optional<std::reference_wrapper<scalar const>> init,
-    cuda::stream_ref stream,
+    rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const = 0;
 };
 
@@ -227,14 +226,14 @@ struct aggregate_result_functor;
  *   my_udf_aggregation() = default;
  *
  *   [[nodiscard]] std::unique_ptr<column> get_empty_output(
- *     cuda::stream_ref stream,
+ *     rmm::cuda_stream_view stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Return a column corresponding to the result when the input values column is empty.
  *   }
  *
  *   [[nodiscard]] std::unique_ptr<column> operator()(
- *     cuda::stream_ref stream,
+ *     rmm::cuda_stream_view stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform UDF computation using the input data and return the result.
@@ -266,7 +265,7 @@ struct groupby_host_udf : host_udf_base {
    * @return The output result of the aggregation when the input values column is empty
    */
   [[nodiscard]] virtual std::unique_ptr<column> get_empty_output(
-    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const = 0;
+    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const = 0;
 
   /**
    * @brief Perform the main groupby computation for the host-based UDF.
@@ -276,7 +275,7 @@ struct groupby_host_udf : host_udf_base {
    * @return The output result of the aggregation
    */
   [[nodiscard]] virtual std::unique_ptr<column> operator()(
-    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const = 0;
+    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const = 0;
 
  private:
   // Allow the struct `aggregate_result_functor` to set its private callback variables.

--- a/cpp/include/cudf/aggregation/host_udf.hpp
+++ b/cpp/include/cudf/aggregation/host_udf.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,8 +11,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <functional>
 #include <optional>
@@ -96,7 +97,7 @@ class host_udf_base {
  *     column_view const& input,
  *     data_type output_dtype,
  *     std::optional<std::reference_wrapper<scalar const>> init,
- *     rmm::cuda_stream_view stream,
+ *     cuda::stream_ref stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform reduction computation using the input data and return the reduction result.
@@ -132,7 +133,7 @@ struct reduce_host_udf : host_udf_base {
     column_view const& input,
     data_type output_dtype,
     std::optional<std::reference_wrapper<scalar const>> init,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const = 0;
 };
 
@@ -154,7 +155,7 @@ struct reduce_host_udf : host_udf_base {
  *     data_type output_dtype,
  *     null_policy null_handling,
  *     std::optional<std::reference_wrapper<scalar const>> init,
- *     rmm::cuda_stream_view stream,
+ *     cuda::stream_ref stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform computation using the input data and return the result.
@@ -196,7 +197,7 @@ struct segmented_reduce_host_udf : host_udf_base {
     data_type output_dtype,
     null_policy null_handling,
     std::optional<std::reference_wrapper<scalar const>> init,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const = 0;
 };
 
@@ -226,14 +227,14 @@ struct aggregate_result_functor;
  *   my_udf_aggregation() = default;
  *
  *   [[nodiscard]] std::unique_ptr<column> get_empty_output(
- *     rmm::cuda_stream_view stream,
+ *     cuda::stream_ref stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Return a column corresponding to the result when the input values column is empty.
  *   }
  *
  *   [[nodiscard]] std::unique_ptr<column> operator()(
- *     rmm::cuda_stream_view stream,
+ *     cuda::stream_ref stream,
  *     rmm::device_async_resource_ref mr) const override
  *   {
  *     // Perform UDF computation using the input data and return the result.
@@ -265,7 +266,7 @@ struct groupby_host_udf : host_udf_base {
    * @return The output result of the aggregation when the input values column is empty
    */
   [[nodiscard]] virtual std::unique_ptr<column> get_empty_output(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const = 0;
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const = 0;
 
   /**
    * @brief Perform the main groupby computation for the host-based UDF.
@@ -275,7 +276,7 @@ struct groupby_host_udf : host_udf_base {
    * @return The output result of the aggregation
    */
   [[nodiscard]] virtual std::unique_ptr<column> operator()(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const = 0;
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const = 0;
 
  private:
   // Allow the struct `aggregate_result_functor` to set its private callback variables.

--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -160,7 +160,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -191,7 +191,7 @@ std::unique_ptr<column> binary_operation(
   scalar const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -221,7 +221,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -252,7 +252,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   std::string const& ptx,
   data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -305,7 +305,7 @@ bool is_supported_operation(data_type out, data_type lhs, data_type rhs, binary_
 std::pair<rmm::device_buffer, size_type> scalar_col_valid_mask_and(
   column_view const& col,
   scalar const& s,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace binops
@@ -333,6 +333,6 @@ void apply_sorting_struct_binary_op(mutable_column_view& out,
                                     bool is_lhs_scalar,
                                     bool is_rhs_scalar,
                                     binary_operator op,
-                                    rmm::cuda_stream_view stream);
+                                    cuda::stream_ref stream);
 }  // namespace binops::compiled::detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/contiguous_split.hpp
+++ b/cpp/include/cudf/contiguous_split.hpp
@@ -104,6 +104,7 @@ struct contiguous_split_state;
  * // data. In memory constrained cases, this can be used to set aside scratch memory
  * // for `chunked_pack` at the beginning of a program.
  * auto mr = cudf::get_current_device_resource_ref();
+ * cuda::stream_ref stream = cudf::get_default_stream();
  *
  * // Define a buffer size for each chunk: the larger the buffer is, the more SMs can be
  * // occupied by this algorithm.
@@ -116,7 +117,7 @@ struct contiguous_split_state;
  * //
  * std::size_t user_buffer_size = 128*1024*1024;
  *
- * auto chunked_packer = cudf::chunked_pack::create(tv, user_buffer_size, mr);
+ * auto chunked_packer = cudf::chunked_pack::create(tv, user_buffer_size, stream, mr);
  *
  * std::size_t host_offset = 0;
  * auto host_buffer = ...; // obtain a host buffer you would like to copy to
@@ -134,7 +135,7 @@ struct contiguous_split_state;
  *     user_buffer.data(),
  *     bytes_copied,
  *     cudaMemcpyDefault,
- *     stream);
+ *     stream.get());
  *
  *   host_offset += bytes_copied;
  * }

--- a/cpp/include/cudf/detail/binaryop.hpp
+++ b/cpp/include/cudf/detail/binaryop.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -8,7 +8,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 //! Inner interfaces and implementations
@@ -16,46 +16,46 @@ namespace detail {
 
 /**
  * @copydoc cudf::binary_operation(column_view const&, column_view const&,
- * std::string const&, data_type, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * std::string const&, data_type, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          std::string const& ptx,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::binary_operation(scalar const&, column_view const&, binary_operator,
- * data_type, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * data_type, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::binary_operation(column_view const&, scalar const&, binary_operator,
- * data_type, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * data_type, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::binary_operation(column_view const&, column_view const&,
- * binary_operator, data_type, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+ * binary_operator, data_type, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/groupby.hpp
+++ b/cpp/include/cudf/detail/groupby.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -32,7 +32,7 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby(
   table_view const& keys,
   std::span<aggregation_request const> requests,
   null_policy include_null_keys,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 }  // namespace groupby::detail::hash
 }  // namespace cudf

--- a/cpp/include/cudf/detail/groupby/group_replace_nulls.hpp
+++ b/cpp/include/cudf/detail/groupby/group_replace_nulls.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ namespace detail {
 std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_value,
                                             device_span<size_type const> group_labels,
                                             cudf::replace_policy replace_policy,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/groupby/sort_helper.hpp
+++ b/cpp/include/cudf/detail/groupby/sort_helper.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,8 +11,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby::detail::sort {
@@ -76,7 +77,7 @@ struct sort_groupby_helper {
    * @return the sorted and grouped column
    */
   std::unique_ptr<column> sorted_values(column_view const& values,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
   /**
@@ -92,7 +93,7 @@ struct sort_groupby_helper {
    * @return the grouped column
    */
   std::unique_ptr<column> grouped_values(column_view const& values,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
   /**
@@ -100,21 +101,19 @@ struct sort_groupby_helper {
    *
    * @return a new table in which each row is a unique row in the sorted key table.
    */
-  std::unique_ptr<table> unique_keys(rmm::cuda_stream_view stream,
-                                     rmm::device_async_resource_ref mr);
+  std::unique_ptr<table> unique_keys(cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   /**
    * @brief Get a table of sorted keys
    *
    * @return a new table containing the sorted keys.
    */
-  std::unique_ptr<table> sorted_keys(rmm::cuda_stream_view stream,
-                                     rmm::device_async_resource_ref mr);
+  std::unique_ptr<table> sorted_keys(cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   /**
    * @brief Get the number of groups in `keys`
    */
-  size_type num_groups(rmm::cuda_stream_view stream) { return group_offsets(stream).size() - 1; }
+  size_type num_groups(cuda::stream_ref stream) { return group_offsets(stream).size() - 1; }
 
   /**
    * @brief check if the groupby keys are presorted
@@ -128,7 +127,7 @@ struct sort_groupby_helper {
    * When include_null_keys = NO, returned value is the number of rows in `keys`
    *  in which no element is null
    */
-  size_type num_keys(rmm::cuda_stream_view stream);
+  size_type num_keys(cuda::stream_ref stream);
 
   /**
    * @brief Get the sorted order of `keys`.
@@ -143,7 +142,7 @@ struct sort_groupby_helper {
    *
    * @return the sort order indices for `keys`.
    */
-  column_view key_sort_order(rmm::cuda_stream_view stream);
+  column_view key_sort_order(cuda::stream_ref stream);
 
   /**
    * @brief Get each group's offset into the sorted order of `keys`.
@@ -156,7 +155,7 @@ struct sort_groupby_helper {
    * @return vector of offsets of the starting point of each group in the sorted
    * key table
    */
-  index_vector const& group_offsets(rmm::cuda_stream_view stream);
+  index_vector const& group_offsets(cuda::stream_ref stream);
 
   /**
    * @brief Get the group labels corresponding to the sorted order of `keys`.
@@ -171,7 +170,7 @@ struct sort_groupby_helper {
    *
    * @return vector of group labels for each row in the sorted key column
    */
-  index_vector const& group_labels(rmm::cuda_stream_view stream);
+  index_vector const& group_labels(cuda::stream_ref stream);
 
  private:
   /**
@@ -188,7 +187,7 @@ struct sort_groupby_helper {
    * @return A nullable column of `INT32` containing group labels in the order
    *         of the unsorted key table
    */
-  column_view unsorted_keys_labels(rmm::cuda_stream_view stream);
+  column_view unsorted_keys_labels(cuda::stream_ref stream);
 
   /**
    * @brief Get the column representing the row bitmask for the `keys`
@@ -202,7 +201,7 @@ struct sort_groupby_helper {
    * Computes and stores bitmask on first invocation and returns stored column
    * on subsequent calls.
    */
-  column_view keys_bitmask_column(rmm::cuda_stream_view stream);
+  column_view keys_bitmask_column(cuda::stream_ref stream);
 
   column_ptr _key_sorted_order;      ///< Indices to produce _keys in sorted order
   column_ptr _unsorted_keys_labels;  ///< Group labels for unsorted _keys

--- a/cpp/include/cudf/detail/join/distinct_hash_join.cuh
+++ b/cpp/include/cudf/detail/join/distinct_hash_join.cuh
@@ -8,11 +8,11 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -115,11 +115,11 @@ class distinct_hash_join {
    */
   distinct_hash_join(cudf::table_view const& right,
                      cudf::null_equality compare_nulls,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
-   * @copydoc distinct_hash_join(cudf::table_view const&, null_equality, rmm::cuda_stream_view,
+   * @copydoc distinct_hash_join(cudf::table_view const&, null_equality, cuda::stream_ref,
    * cuda::mr::any_resource<cuda::mr::device_accessible>)
    *
    * @param load_factor The hash table occupancy ratio in (0,1]. A value of 0.5 means 50% occupancy.
@@ -127,7 +127,7 @@ class distinct_hash_join {
   distinct_hash_join(cudf::table_view const& right,
                      cudf::null_equality compare_nulls,
                      double load_factor,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
@@ -136,16 +136,14 @@ class distinct_hash_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(cudf::table_view const& left,
-             rmm::cuda_stream_view stream,
+             cuda::stream_ref stream,
              rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::distinct_hash_join::left_join
    */
   std::unique_ptr<rmm::device_uvector<size_type>> left_join(
-    cudf::table_view const& left,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const;
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
  private:
   using probing_scheme_type = cuco::linear_probing<1, hasher>;

--- a/cpp/include/cudf/detail/join/filtered_join.cuh
+++ b/cpp/include/cudf/detail/join/filtered_join.cuh
@@ -11,7 +11,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 #include <rmm/resource_ref.hpp>
@@ -21,6 +20,7 @@
 #include <cuco/pair.cuh>
 #include <cuco/probing_scheme.cuh>
 #include <cuco/types.cuh>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -135,26 +135,26 @@ class filtered_join {
   filtered_join(cudf::table_view const& right,
                 cudf::null_equality compare_nulls,
                 double load_factor,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
    * @brief Returns indices of left table rows that have matching keys in the right table
    */
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> semi_join(
-    cudf::table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   /**
    * @brief Returns indices of left table rows that do not have matching keys in the right table
    */
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> anti_join(
-    cudf::table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
  private:
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> semi_anti_join(
     cudf::table_view const& left,
     join_kind kind,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
   // Queries the hash table for every left row and writes the matches to contains_map.
@@ -163,25 +163,25 @@ class filtered_join {
                          Iterator left_iter,
                          Ref query_ref,
                          cudf::device_span<bool> contains_map,
-                         rmm::cuda_stream_view stream);
+                         cuda::stream_ref stream);
 
   void query_right_table_primitive(
     cudf::table_view const& left,
     std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
     cudf::device_span<bool> contains_map,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
   void query_right_table_flat(
     cudf::table_view const& left,
     std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
     cudf::device_span<bool> contains_map,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
   void query_right_table_nested(
     cudf::table_view const& left,
     std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
     cudf::device_span<bool> contains_map,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
   enum class row_operator_mode : uint8_t { PRIMITIVE, FLAT, NESTED };
 
@@ -212,13 +212,13 @@ class filtered_join {
 
   // Build and probe row operators must use matching nullate modes. Since probe nullability is
   // unknown at build time, primitive paths use DYNAMIC true and other paths use YES.
-  void insert_right_table_primitive(rmm::cuda_stream_view stream);
+  void insert_right_table_primitive(cuda::stream_ref stream);
   // Populates the hash table from the right-row iterator.
   template <int32_t CGSize, typename Iterator, typename Ref>
-  void insert_right_table(Iterator right_iter, Ref const& insert_ref, rmm::cuda_stream_view stream);
+  void insert_right_table(Iterator right_iter, Ref const& insert_ref, cuda::stream_ref stream);
 
-  void insert_right_table_flat(rmm::cuda_stream_view stream);
-  void insert_right_table_nested(rmm::cuda_stream_view stream);
+  void insert_right_table_flat(cuda::stream_ref stream);
+  void insert_right_table_nested(cuda::stream_ref stream);
 
   /**
    * @brief Calculates the required storage size for the hash table

--- a/cpp/include/cudf/detail/join/hash_join.hpp
+++ b/cpp/include/cudf/detail/join/hash_join.hpp
@@ -13,9 +13,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -64,11 +65,11 @@ class hash_join {
   hash_join(cudf::table_view const& right,
             bool has_nulls,
             cudf::null_equality compare_nulls,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
-   * @copydoc hash_join(cudf::table_view const&, bool, null_equality, rmm::cuda_stream_view,
+   * @copydoc hash_join(cudf::table_view const&, bool, null_equality, cuda::stream_ref,
    * cuda::mr::any_resource<cuda::mr::device_accessible>)
    *
    * @param load_factor The hash table occupancy ratio in (0,1]. A value of 0.5 means 50% occupancy.
@@ -77,7 +78,7 @@ class hash_join {
             bool has_nulls,
             cudf::null_equality compare_nulls,
             double load_factor,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
@@ -87,7 +88,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(cudf::table_view const& left,
              std::optional<std::size_t> output_size,
-             rmm::cuda_stream_view stream,
+             cuda::stream_ref stream,
              rmm::device_async_resource_ref mr) const;
 
   /**
@@ -97,7 +98,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             rmm::device_async_resource_ref mr) const;
 
   /**
@@ -107,51 +108,45 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   full_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::hash_join::inner_join_size
    */
   [[nodiscard]] std::size_t inner_join_size(cudf::table_view const& left,
-                                            rmm::cuda_stream_view stream) const;
+                                            cuda::stream_ref stream) const;
 
   /**
    * @copydoc cudf::hash_join::left_join_size
    */
   [[nodiscard]] std::size_t left_join_size(cudf::table_view const& left,
-                                           rmm::cuda_stream_view stream) const;
+                                           cuda::stream_ref stream) const;
 
   /**
    * @copydoc cudf::hash_join::full_join_size
    */
   [[nodiscard]] std::size_t full_join_size(cudf::table_view const& left,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::hash_join::inner_join_match_context
    */
   [[nodiscard]] cudf::join_match_context inner_join_match_context(
-    cudf::table_view const& left,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const;
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::hash_join::left_join_match_context
    */
   [[nodiscard]] cudf::join_match_context left_join_match_context(
-    cudf::table_view const& left,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const;
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::hash_join::full_join_match_context
    */
   [[nodiscard]] cudf::join_match_context full_join_match_context(
-    cudf::table_view const& left,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const;
+    cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
   /**
    * @copydoc cudf::hash_join::partitioned_inner_join
@@ -159,7 +154,7 @@ class hash_join {
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_inner_join(cudf::join_partition_context const& context,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr) const;
 
   /**
@@ -168,7 +163,7 @@ class hash_join {
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_left_join(cudf::join_partition_context const& context,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr) const;
 
   /**
@@ -177,7 +172,7 @@ class hash_join {
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_full_join(cudf::join_partition_context const& context,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr) const;
 
  private:
@@ -192,14 +187,14 @@ class hash_join {
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> make_match_counts(
     join_kind join,
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const;
 
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_join_retrieve(join_kind join,
                             cudf::join_partition_context const& context,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr) const;
 
   template <join_kind Join>
@@ -207,16 +202,15 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   join_retrieve(cudf::table_view const& probe,
                 std::optional<std::size_t> output_size,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr) const;
 
   template <join_kind Join>
-  [[nodiscard]] std::size_t join_size(cudf::table_view const& left,
-                                      rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::size_t join_size(cudf::table_view const& left, cuda::stream_ref stream) const;
 
   template <join_kind Join>
   [[nodiscard]] std::size_t join_size(cudf::table_view const& left,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr) const;
 };
 

--- a/cpp/include/cudf/detail/join/join.hpp
+++ b/cpp/include/cudf/detail/join/join.hpp
@@ -10,9 +10,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -44,7 +45,7 @@ filter_join_indices(table_view const& left,
                     ast::expression const& predicate,
                     join_kind join_kind,
                     std::optional<std::size_t> output_size,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/rolling.hpp
+++ b/cpp/include/cudf/detail/rolling.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -49,7 +49,7 @@ struct preprocessed_group_info {
 [[nodiscard]] rmm::device_uvector<cudf::size_type> nulls_per_group(
   column_view const& orderby,
   rmm::device_uvector<size_type> const& offsets,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 /**
  * @copydoc std::unique_ptr<column> rolling_window(
@@ -67,7 +67,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        column_view const& following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -96,7 +96,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
   order order,
   null_order null_order,
   range_window_type window,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -8,7 +8,7 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -39,7 +39,7 @@ namespace detail {
 std::unique_ptr<column> scan_exclusive(column_view const& input,
                                        scan_aggregation const& agg,
                                        null_policy null_handling,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -65,7 +65,7 @@ std::unique_ptr<column> scan_exclusive(column_view const& input,
 std::unique_ptr<column> scan_inclusive(column_view const& input,
                                        scan_aggregation const& agg,
                                        null_policy null_handling,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -77,7 +77,7 @@ std::unique_ptr<column> scan_inclusive(column_view const& input,
  * @return rank values.
  */
 std::unique_ptr<column> inclusive_rank_scan(column_view const& order_by,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 /**
@@ -90,7 +90,7 @@ std::unique_ptr<column> inclusive_rank_scan(column_view const& order_by,
  */
 CUDF_EXPORT
 std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -104,7 +104,7 @@ std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
  * @return rank values.
  */
 std::unique_ptr<column> inclusive_one_normalized_percent_rank_scan(
-  column_view const& order_by, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  column_view const& order_by, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/scatter.hpp
+++ b/cpp/include/cudf/detail/scatter.hpp
@@ -58,7 +58,7 @@ std::unique_ptr<table> scatter(table_view const& source,
 
 /**
  * @copydoc cudf::detail::scatter(table_view const&,column_view const&,table_view
- * const&,bool,cuda::stream_ref,rmm::device_async_resource_ref)
+ * const&,cuda::stream_ref,rmm::device_async_resource_ref)
  *
  * @throws cudf::logic_error if `scatter_map` span size is larger than max of `size_type`.
  */

--- a/cpp/include/cudf/detail/sorting.hpp
+++ b/cpp/include/cudf/detail/sorting.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <vector>
@@ -26,7 +26,7 @@ namespace detail {
 std::unique_ptr<column> sorted_order(table_view const& input,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -37,7 +37,7 @@ std::unique_ptr<column> sorted_order(table_view const& input,
 std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             std::vector<order> const& column_order,
                                             std::vector<null_order> const& null_precedence,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 /**
@@ -49,7 +49,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
                                    table_view const& keys,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -63,7 +63,7 @@ std::unique_ptr<column> rank(column_view const& input,
                              null_policy null_handling,
                              null_order null_precedence,
                              bool percentage,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr);
 
 /**
@@ -75,7 +75,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
                                           table_view const& keys,
                                           std::vector<order> const& column_order,
                                           std::vector<null_order> const& null_precedence,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -87,7 +87,7 @@ std::unique_ptr<column> segmented_sorted_order(table_view const& keys,
                                                column_view const& segment_offsets,
                                                std::vector<order> const& column_order,
                                                std::vector<null_order> const& null_precedence,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr);
 
 /**
@@ -100,7 +100,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -113,7 +113,7 @@ std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
                                              column_view const& segment_offsets,
                                              std::vector<order> const& column_order,
                                              std::vector<null_order> const& null_precedence,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr);
 
 /**
@@ -126,7 +126,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
                                                     column_view const& segment_offsets,
                                                     std::vector<order> const& column_order,
                                                     std::vector<null_order> const& null_precedence,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -137,7 +137,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
 std::unique_ptr<table> sort(table_view const& values,
                             std::vector<order> const& column_order,
                             std::vector<null_order> const& null_precedence,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -148,7 +148,7 @@ std::unique_ptr<table> sort(table_view const& values,
 std::unique_ptr<table> stable_sort(table_view const& values,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -159,7 +159,7 @@ std::unique_ptr<column> segmented_top_k(column_view const& col,
                                         column_view const& segment_offsets,
                                         size_type k,
                                         order topk_order,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/transform.hpp
+++ b/cpp/include/cudf/detail/transform.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -23,7 +23,7 @@ namespace detail {
  */
 std::unique_ptr<column> compute_column(table_view const& table,
                                        ast::expression const& expr,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -32,7 +32,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
-  column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::encode
@@ -40,7 +40,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
-  cudf::table_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  cudf::table_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::one_hot_encode
@@ -49,7 +49,7 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
  */
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const& input,
                                                               column_view const& categories,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr);
 
 /**
@@ -60,7 +60,7 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
 std::unique_ptr<column> mask_to_bools(bitmask_type const* null_mask,
                                       size_type begin_bit,
                                       size_type end_bit,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -69,7 +69,7 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* null_mask,
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> row_bit_count(table_view const& t,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -79,7 +79,7 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
  */
 std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
                                                 size_type segment_length,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -20,14 +20,14 @@ namespace detail {
  */
 std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
                                               cudf::unary_operator op,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::is_valid
  */
 std::unique_ptr<cudf::column> is_valid(cudf::column_view const& input,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -35,21 +35,21 @@ std::unique_ptr<cudf::column> is_valid(cudf::column_view const& input,
  */
 std::unique_ptr<column> cast(column_view const& input,
                              data_type type,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::is_nan
  */
 std::unique_ptr<column> is_nan(cudf::column_view const& input,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::is_not_nan
  */
 std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -14,7 +14,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <span>
@@ -180,7 +180,7 @@ class groupby {
    */
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> aggregate(
     std::span<aggregation_request const> requests,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
   /**
    * @brief Performs grouped scans on the specified values.
@@ -236,7 +236,7 @@ class groupby {
    */
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> scan(
     std::span<scan_request const> requests,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -294,7 +294,7 @@ class groupby {
     table_view const& values,
     std::span<size_type const> offsets,
     std::vector<std::reference_wrapper<scalar const>> const& fill_values,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -325,7 +325,7 @@ class groupby {
    * @return A `groups` object representing grouped keys and values
    */
   groups get_groups(cudf::table_view values           = {},
-                    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                    cuda::stream_ref stream           = cudf::get_default_stream(),
                     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -367,7 +367,7 @@ class groupby {
   std::pair<std::unique_ptr<table>, std::unique_ptr<table>> replace_nulls(
     table_view const& values,
     std::span<cudf::replace_policy const> replace_policies,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
  private:
@@ -398,18 +398,18 @@ class groupby {
    */
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> dispatch_aggregation(
     std::span<aggregation_request const> requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
   // Sort-based groupby
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> sort_aggregate(
     std::span<aggregation_request const> requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> sort_scan(
     std::span<scan_request const> requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 };
 
@@ -525,7 +525,7 @@ class streaming_groupby {
    * @throws std::invalid_argument if `data.num_rows()` exceeds `max_distinct_keys`
    * @throws cudf::logic_error if cumulative distinct keys exceed `max_distinct_keys`
    */
-  void aggregate(table_view const& data, rmm::cuda_stream_view stream = cudf::get_default_stream());
+  void aggregate(table_view const& data, cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Merge another streaming_groupby's accumulated partial state into this one.
@@ -543,8 +543,7 @@ class streaming_groupby {
    * @throws cudf::logic_error if this object has not been initialized via `aggregate()`
    * @throws cudf::logic_error if distinct keys exceed `max_distinct_keys` after merge
    */
-  void merge(streaming_groupby const& other,
-             rmm::cuda_stream_view stream = cudf::get_default_stream());
+  void merge(streaming_groupby const& other, cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Finalize the accumulated partial aggregates into final results.
@@ -562,7 +561,7 @@ class streaming_groupby {
    * @throws cudf::logic_error if no data has been accumulated
    */
   [[nodiscard]] std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> finalize(
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -578,10 +577,10 @@ class streaming_groupby {
   struct impl;
   std::unique_ptr<impl> _impl;
 
-  void do_aggregate(table_view const& data, rmm::cuda_stream_view stream);
-  void do_merge(streaming_groupby const& other, rmm::cuda_stream_view stream);
+  void do_aggregate(table_view const& data, cuda::stream_ref stream);
+  void do_merge(streaming_groupby const& other, cuda::stream_ref stream);
   [[nodiscard]] std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> do_finalize(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const;
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 };
 
 /**

--- a/cpp/include/cudf/join/conditional_join.hpp
+++ b/cpp/include/cudf/join/conditional_join.hpp
@@ -13,8 +13,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <optional>
 #include <utility>
@@ -73,7 +74,7 @@ conditional_inner_join(table_view const& left,
                        table_view const& right,
                        ast::expression const& binary_predicate,
                        std::optional<std::size_t> output_size = {},
-                       rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                       cuda::stream_ref stream                = cudf::get_default_stream(),
                        rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -120,7 +121,7 @@ conditional_left_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
                       std::optional<std::size_t> output_size = {},
-                      rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                      cuda::stream_ref stream                = cudf::get_default_stream(),
                       rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -164,7 +165,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 conditional_full_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
-                      rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                      cuda::stream_ref stream           = cudf::get_default_stream(),
                       rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -205,7 +206,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
   table_view const& right,
   ast::expression const& binary_predicate,
   std::optional<std::size_t> output_size = {},
-  rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+  cuda::stream_ref stream                = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
 
 /**
@@ -246,7 +247,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
   table_view const& right,
   ast::expression const& binary_predicate,
   std::optional<std::size_t> output_size = {},
-  rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+  cuda::stream_ref stream                = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
 
 /**
@@ -271,7 +272,7 @@ std::size_t conditional_inner_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -296,7 +297,7 @@ std::size_t conditional_left_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -321,7 +322,7 @@ std::size_t conditional_left_semi_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -346,7 +347,7 @@ std::size_t conditional_left_anti_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/join/direct_join.hpp
+++ b/cpp/include/cudf/join/direct_join.hpp
@@ -11,8 +11,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -58,7 +59,7 @@ namespace CUDF_EXPORT cudf {
 direct_inner_join(column_view const& left_keys,
                   column_view const& right_keys,
                   std::size_t capacity,
-                  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                  cuda::stream_ref stream           = cudf::get_default_stream(),
                   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/join/distinct_hash_join.hpp
+++ b/cpp/include/cudf/join/distinct_hash_join.hpp
@@ -12,8 +12,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <utility>
 
@@ -71,9 +72,9 @@ class distinct_hash_join {
    * @param mr Device memory resource used to allocate the internal hash table
    */
   distinct_hash_join(cudf::table_view const& right,
-                     null_equality compare_nulls  = null_equality::EQUAL,
-                     double load_factor           = 0.5,
-                     rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                     null_equality compare_nulls = null_equality::EQUAL,
+                     double load_factor          = 0.5,
+                     cuda::stream_ref stream     = cudf::get_default_stream(),
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                        cudf::get_current_device_resource_ref());
 
@@ -92,7 +93,7 @@ class distinct_hash_join {
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(cudf::table_view const& left,
-             rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+             cuda::stream_ref stream           = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -114,7 +115,7 @@ class distinct_hash_join {
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> left_join(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
  private:

--- a/cpp/include/cudf/join/filtered_join.hpp
+++ b/cpp/include/cudf/join/filtered_join.hpp
@@ -11,8 +11,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 /**
  * @file
@@ -70,7 +71,7 @@ class filtered_join {
    */
   filtered_join(cudf::table_view const& right,
                 cudf::null_equality compare_nulls,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                   cudf::get_current_device_resource_ref());
 
@@ -93,7 +94,7 @@ class filtered_join {
   filtered_join(cudf::table_view const& right,
                 cudf::null_equality compare_nulls,
                 double load_factor,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                   cudf::get_current_device_resource_ref());
 
@@ -119,7 +120,7 @@ class filtered_join {
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> semi_join(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -144,7 +145,7 @@ class filtered_join {
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> anti_join(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
  private:

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -14,8 +14,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <optional>
 #include <utility>
@@ -94,7 +95,7 @@ class hash_join {
    */
   hash_join(cudf::table_view const& right,
             null_equality compare_nulls,
-            rmm::cuda_stream_view stream = cudf::get_default_stream(),
+            cuda::stream_ref stream = cudf::get_default_stream(),
             cuda::mr::any_resource<cuda::mr::device_accessible> mr =
               cudf::get_current_device_resource_ref());
 
@@ -120,7 +121,7 @@ class hash_join {
             nullable_join has_nulls,
             null_equality compare_nulls,
             double load_factor,
-            rmm::cuda_stream_view stream = cudf::get_default_stream(),
+            cuda::stream_ref stream = cudf::get_default_stream(),
             cuda::mr::any_resource<cuda::mr::device_accessible> mr =
               cudf::get_current_device_resource_ref());
 
@@ -146,7 +147,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(cudf::table_view const& left,
              std::optional<std::size_t> output_size = {},
-             rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+             cuda::stream_ref stream                = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -171,7 +172,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size = {},
-            rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+            cuda::stream_ref stream                = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -196,7 +197,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   full_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size = {},
-            rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+            cuda::stream_ref stream                = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -213,7 +214,7 @@ class hash_join {
    * `left` and `right` as the join keys .
    */
   [[nodiscard]] std::size_t inner_join_size(
-    cudf::table_view const& left, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+    cudf::table_view const& left, cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * Returns the exact number of matches (rows) when performing a left join with the specified left
@@ -229,7 +230,7 @@ class hash_join {
    * and `right` as the join keys .
    */
   [[nodiscard]] std::size_t left_join_size(
-    cudf::table_view const& left, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+    cudf::table_view const& left, cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * Returns the exact number of matches (rows) when performing a full join with the specified left
@@ -248,7 +249,7 @@ class hash_join {
    */
   [[nodiscard]] std::size_t full_join_size(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -274,7 +275,7 @@ class hash_join {
    */
   [[nodiscard]] cudf::join_match_context inner_join_match_context(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -299,7 +300,7 @@ class hash_join {
    */
   [[nodiscard]] cudf::join_match_context left_join_match_context(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -324,7 +325,7 @@ class hash_join {
    */
   [[nodiscard]] cudf::join_match_context full_join_match_context(
     cudf::table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -351,7 +352,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_inner_join(
     cudf::join_partition_context const& context,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -377,7 +378,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_left_join(
     cudf::join_partition_context const& context,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -407,7 +408,7 @@ class hash_join {
                           std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_full_join(
     cudf::join_partition_context const& context,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -436,7 +437,7 @@ class hash_join {
     cudf::host_span<cudf::device_span<size_type const> const> right_partials,
     size_type left_table_num_rows,
     size_type right_table_num_rows,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
  private:

--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -12,10 +12,10 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -162,7 +162,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 inner_join(cudf::table_view const& left_keys,
            cudf::table_view const& right_keys,
            null_equality compare_nulls       = null_equality::EQUAL,
-           rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+           cuda::stream_ref stream           = cudf::get_default_stream(),
            rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -203,7 +203,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 left_join(cudf::table_view const& left_keys,
           cudf::table_view const& right_keys,
           null_equality compare_nulls       = null_equality::EQUAL,
-          rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+          cuda::stream_ref stream           = cudf::get_default_stream(),
           rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -244,7 +244,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 full_join(cudf::table_view const& left_keys,
           cudf::table_view const& right_keys,
           null_equality compare_nulls       = null_equality::EQUAL,
-          rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+          cuda::stream_ref stream           = cudf::get_default_stream(),
           rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -278,7 +278,7 @@ full_join(cudf::table_view const& left_keys,
 std::unique_ptr<cudf::table> cross_join(
   cudf::table_view const& left,
   cudf::table_view const& right,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -362,7 +362,7 @@ filter_join_indices(cudf::table_view const& left,
                     cudf::ast::expression const& predicate,
                     cudf::join_kind join_kind,
                     std::optional<std::size_t> output_size = std::nullopt,
-                    rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                    cuda::stream_ref stream                = cudf::get_default_stream(),
                     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -408,7 +408,7 @@ filter_join_indices_output_size(
   cudf::device_span<size_type const> right_indices,
   cudf::ast::expression const& predicate,
   cudf::join_kind join_kind,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -483,7 +483,7 @@ filter_join_indices_jit(
   std::string const& predicate_code,
   cudf::join_kind join_kind,
   bool is_ptx                       = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -511,7 +511,7 @@ filter_join_indices_jit(
   cudf::device_span<size_type const> right_indices,
   cudf::ast::expression const& predicate,
   cudf::join_kind join_kind,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/join/key_remapping.hpp
+++ b/cpp/include/cudf/join/key_remapping.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -101,7 +101,7 @@ class key_remapping {
   key_remapping(cudf::table_view const& right,
                 null_equality compare_nulls   = null_equality::EQUAL,
                 cudf::compute_metrics metrics = cudf::compute_metrics::YES,
-                rmm::cuda_stream_view stream  = cudf::get_default_stream(),
+                cuda::stream_ref stream       = cudf::get_default_stream(),
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                   cudf::get_current_device_resource_ref());
 
@@ -121,7 +121,7 @@ class key_remapping {
    * @return A column of INT32 values with the remapped key IDs
    */
   [[nodiscard]] std::unique_ptr<cudf::column> remap_right_keys(
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -143,7 +143,7 @@ class key_remapping {
    */
   [[nodiscard]] std::unique_ptr<cudf::column> remap_left_keys(
     cudf::table_view const& keys,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**

--- a/cpp/include/cudf/join/mark_join.hpp
+++ b/cpp/include/cudf/join/mark_join.hpp
@@ -12,8 +12,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -83,7 +84,7 @@ class mark_join {
   mark_join(cudf::table_view const& left,
             cudf::null_equality compare_nulls,
             cudf::join_prefilter prefilter,
-            rmm::cuda_stream_view stream = cudf::get_default_stream(),
+            cuda::stream_ref stream = cudf::get_default_stream(),
             cuda::mr::any_resource<cuda::mr::device_accessible> mr =
               cudf::get_current_device_resource_ref());
 
@@ -104,7 +105,7 @@ class mark_join {
             double load_factor,
             cudf::null_equality compare_nulls = cudf::null_equality::EQUAL,
             cudf::join_prefilter prefilter    = cudf::join_prefilter::NO,
-            rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+            cuda::stream_ref stream           = cudf::get_default_stream(),
             cuda::mr::any_resource<cuda::mr::device_accessible> mr =
               cudf::get_current_device_resource_ref());
 
@@ -118,7 +119,7 @@ class mark_join {
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> semi_join(
     cudf::table_view const& right,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -131,7 +132,7 @@ class mark_join {
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> anti_join(
     cudf::table_view const& right,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
  private:

--- a/cpp/include/cudf/join/mixed_join.hpp
+++ b/cpp/include/cudf/join/mixed_join.hpp
@@ -13,8 +13,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <optional>
 #include <utility>
@@ -96,7 +97,7 @@ mixed_inner_join(table_view const& left_equality,
                  ast::expression const& binary_predicate,
                  null_equality compare_nulls            = null_equality::EQUAL,
                  output_size_data_type output_size_data = {},
-                 rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                 cuda::stream_ref stream                = cudf::get_default_stream(),
                  rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
 
 /**
@@ -157,7 +158,7 @@ mixed_left_join(table_view const& left_equality,
                 ast::expression const& binary_predicate,
                 null_equality compare_nulls            = null_equality::EQUAL,
                 output_size_data_type output_size_data = {},
-                rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                cuda::stream_ref stream                = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
 
 /**
@@ -218,7 +219,7 @@ mixed_full_join(table_view const& left_equality,
                 ast::expression const& binary_predicate,
                 null_equality compare_nulls            = null_equality::EQUAL,
                 output_size_data_type output_size_data = {},
-                rmm::cuda_stream_view stream           = cudf::get_default_stream(),
+                cuda::stream_ref stream                = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
 
 /**
@@ -265,7 +266,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_semi_join(
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls       = null_equality::EQUAL,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -313,7 +314,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_anti_join(
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls       = null_equality::EQUAL,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -355,7 +356,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_in
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls       = null_equality::EQUAL,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -397,7 +398,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls       = null_equality::EQUAL,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/join/sort_merge_join.hpp
+++ b/cpp/include/cudf/join/sort_merge_join.hpp
@@ -11,8 +11,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -65,8 +66,8 @@ class sort_merge_join {
    */
   sort_merge_join(table_view const& right,
                   sorted is_right_sorted,
-                  null_equality compare_nulls  = null_equality::EQUAL,
-                  rmm::cuda_stream_view stream = cudf::get_default_stream());
+                  null_equality compare_nulls = null_equality::EQUAL,
+                  cuda::stream_ref stream     = cudf::get_default_stream());
 
   /**
    * @brief Returns the row indices that can be used to construct the result of performing
@@ -87,7 +88,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(table_view const& left,
-             rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+             cuda::stream_ref stream           = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -112,7 +113,7 @@ class sort_merge_join {
                             std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(table_view const& left,
              sorted is_left_sorted,
-             rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+             cuda::stream_ref stream           = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -133,7 +134,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(table_view const& left,
-            rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+            cuda::stream_ref stream           = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -158,7 +159,7 @@ class sort_merge_join {
                             std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(table_view const& left,
             sorted is_left_sorted,
-            rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+            cuda::stream_ref stream           = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -187,7 +188,7 @@ class sort_merge_join {
    */
   std::unique_ptr<join_match_context> inner_join_match_context(
     table_view const& left,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -209,7 +210,7 @@ class sort_merge_join {
   inner_join_match_context(
     table_view const& left,
     sorted is_left_sorted,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
@@ -268,7 +269,7 @@ class sort_merge_join {
             std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_inner_join(
     cudf::join_partition_context const& context,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
  private:

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -96,7 +96,7 @@ std::unique_ptr<scalar> reduce(
   column_view const& col,
   reduce_aggregation const& agg,
   data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 // clang-format on
 
@@ -108,7 +108,7 @@ std::unique_ptr<scalar> reduce(
  * detection is performed throughout the entire computation.
  *
  * @see cudf::reduce(column_view const&,reduce_aggregation
- * const&,data_type,rmm::cuda_stream_view,rmm::device_async_resource_ref) for more details
+ * const&,data_type,cuda::stream_ref,rmm::device_async_resource_ref) for more details
  *
  * @throw std::invalid_argument if reduction is not `sum`, `product`, `min`, `max`, `any`, `all`,
  * or `sum_overflow` and `init` is specified.
@@ -126,7 +126,7 @@ std::unique_ptr<scalar> reduce(
   reduce_aggregation const& agg,
   data_type output_type,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -178,7 +178,7 @@ std::unique_ptr<column> segmented_reduce(
   segmented_reduce_aggregation const& agg,
   data_type output_type,
   null_policy null_handling,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -205,7 +205,7 @@ std::unique_ptr<column> segmented_reduce(
   data_type output_type,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -231,7 +231,7 @@ std::unique_ptr<column> scan(
   scan_aggregation const& agg,
   scan_type inclusive,
   null_policy null_handling         = null_policy::EXCLUDE,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -246,7 +246,7 @@ std::unique_ptr<column> scan(
  */
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
   column_view const& col,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**

--- a/cpp/include/cudf/reduction/approx_distinct_count.hpp
+++ b/cpp/include/cudf/reduction/approx_distinct_count.hpp
@@ -11,9 +11,8 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -127,10 +126,10 @@ class approx_distinct_count {
    * @param mr Device memory resource used to allocate the sketch storage
    */
   approx_distinct_count(table_view const& input,
-                        std::int32_t precision       = 12,
-                        null_policy null_handling    = null_policy::EXCLUDE,
-                        nan_policy nan_handling      = nan_policy::NAN_IS_NULL,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                        std::int32_t precision    = 12,
+                        null_policy null_handling = null_policy::EXCLUDE,
+                        nan_policy nan_handling   = nan_policy::NAN_IS_NULL,
+                        cuda::stream_ref stream   = cudf::get_default_stream(),
                         cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                           cudf::get_current_device_resource_ref());
 
@@ -157,9 +156,9 @@ class approx_distinct_count {
    */
   approx_distinct_count(table_view const& input,
                         desired_standard_error error,
-                        null_policy null_handling    = null_policy::EXCLUDE,
-                        nan_policy nan_handling      = nan_policy::NAN_IS_NULL,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                        null_policy null_handling = null_policy::EXCLUDE,
+                        nan_policy nan_handling   = nan_policy::NAN_IS_NULL,
+                        cuda::stream_ref stream   = cudf::get_default_stream(),
                         cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                           cudf::get_current_device_resource_ref());
 
@@ -201,7 +200,7 @@ class approx_distinct_count {
    * @param input Table whose rows will be added
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void add(table_view const& input, rmm::cuda_stream_view stream = cudf::get_default_stream());
+  void add(table_view const& input, cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Merges another sketch into this sketch
@@ -216,7 +215,7 @@ class approx_distinct_count {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   void merge(approx_distinct_count const& other,
-             rmm::cuda_stream_view stream = cudf::get_default_stream());
+             cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Merges a sketch from raw bytes into this sketch
@@ -232,7 +231,7 @@ class approx_distinct_count {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   void merge(cuda::std::span<cuda::std::byte const> sketch_span,
-             rmm::cuda_stream_view stream = cudf::get_default_stream());
+             cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Estimates the approximate number of distinct rows in the sketch
@@ -240,8 +239,7 @@ class approx_distinct_count {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Approximate number of distinct rows
    */
-  [[nodiscard]] std::size_t estimate(
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+  [[nodiscard]] std::size_t estimate(cuda::stream_ref stream = cudf::get_default_stream()) const;
 
   /**
    * @brief Gets the raw sketch bytes for serialization or external merging

--- a/cpp/include/cudf/reduction/detail/approx_distinct_count.cuh
+++ b/cpp/include/cudf/reduction/detail/approx_distinct_count.cuh
@@ -11,12 +11,12 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuco/hyperloglog_ref.cuh>
 #include <cuda/functional>
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -85,7 +85,7 @@ class approx_distinct_count {
                         std::int32_t precision,
                         null_policy null_handling,
                         nan_policy nan_handling,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
@@ -111,7 +111,7 @@ class approx_distinct_count {
                         cudf::approx_distinct_count::desired_standard_error error,
                         null_policy null_handling,
                         nan_policy nan_handling,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   /**
@@ -154,7 +154,7 @@ class approx_distinct_count {
    * @param input Table whose rows will be added
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void add(table_view const& input, rmm::cuda_stream_view stream);
+  void add(table_view const& input, cuda::stream_ref stream);
 
   /**
    * @brief Merges another sketch into this sketch
@@ -168,7 +168,7 @@ class approx_distinct_count {
    * @param other The sketch to merge into this sketch
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void merge(approx_distinct_count const& other, rmm::cuda_stream_view stream);
+  void merge(approx_distinct_count const& other, cuda::stream_ref stream);
 
   /**
    * @brief Merges a sketch from raw bytes into this sketch
@@ -183,7 +183,7 @@ class approx_distinct_count {
    * @param sketch_span The sketch bytes to merge into this sketch
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void merge(cuda::std::span<cuda::std::byte const> sketch_span, rmm::cuda_stream_view stream);
+  void merge(cuda::std::span<cuda::std::byte const> sketch_span, cuda::stream_ref stream);
 
   /**
    * @brief Estimates the approximate number of distinct rows in the sketch
@@ -191,7 +191,7 @@ class approx_distinct_count {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Approximate number of distinct rows
    */
-  [[nodiscard]] std::size_t estimate(rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::size_t estimate(cuda::stream_ref stream) const;
 
   /**
    * @brief Gets the raw sketch bytes

--- a/cpp/include/cudf/reduction/detail/distinct_count.hpp
+++ b/cpp/include/cudf/reduction/detail/distinct_count.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,25 +10,25 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 
 /**
- * @copydoc cudf::distinct_count(column_view const&, null_policy, nan_policy, rmm::cuda_stream_view)
+ * @copydoc cudf::distinct_count(column_view const&, null_policy, nan_policy, cuda::stream_ref)
  */
 cudf::size_type distinct_count(column_view const& input,
                                null_policy null_handling,
                                nan_policy nan_handling,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 
 /**
- * @copydoc cudf::distinct_count(table_view const&, null_equality, rmm::cuda_stream_view)
+ * @copydoc cudf::distinct_count(table_view const&, null_equality, cuda::stream_ref)
  */
 cudf::size_type distinct_count(table_view const& input,
                                null_equality nulls_equal,
-                               rmm::cuda_stream_view stream);
+                               cuda::stream_ref stream);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/reduction/detail/histogram.hpp
+++ b/cpp/include/cudf/reduction/detail/histogram.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,8 +11,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -33,7 +34,7 @@ namespace reduction::detail {
 [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>, std::unique_ptr<column>>
 compute_row_frequencies(table_view const& input,
                         std::optional<column_view> const& partial_counts,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr);
 
 /**

--- a/cpp/include/cudf/reduction/detail/reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/reduction.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,12 +13,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_reduce.cuh>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 #include <optional>
@@ -48,7 +48,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                                cudf::size_type num_items,
                                op::simple_op<Op> op,
                                std::optional<OutputType> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
   requires(is_fixed_width<OutputType>() && not cudf::is_fixed_point<OutputType>())
 {
@@ -67,7 +67,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
   d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
 
   // Run reduction
@@ -78,7 +78,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
   return result;
 }
 
@@ -89,7 +89,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                                cudf::size_type num_items,
                                op::simple_op<Op> op,
                                std::optional<OutputType> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
   requires(is_fixed_point<OutputType>())
 {
@@ -106,7 +106,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                                cudf::size_type num_items,
                                op::simple_op<Op> op,
                                std::optional<OutputType> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
   requires(std::is_same_v<OutputType, string_view>)
 {
@@ -125,7 +125,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
   d_temp_storage =
     rmm::device_buffer{temp_storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
@@ -137,7 +137,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
 
   return std::make_unique<cudf::string_scalar>(dev_result, true, stream, mr);
 }
@@ -171,7 +171,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                                op::compound_op<Op> op,
                                cudf::size_type valid_count,
                                cudf::size_type ddof,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   auto const binary_op     = cudf::detail::cast_functor<IntermediateType>(op.get_binary_op());
@@ -190,7 +190,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
   d_temp_storage =
     rmm::device_buffer{temp_storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
@@ -202,7 +202,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             num_items,
                             binary_op,
                             initial_value,
-                            stream.value());
+                            stream.get());
 
   // compute the result value from intermediate value in device
   using ScalarType = cudf::scalar_type_t<OutputType>;

--- a/cpp/include/cudf/reduction/detail/reduction.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                reduce_aggregation const& agg,
                                data_type output_dtype,
                                std::optional<std::reference_wrapper<scalar const>> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 }  // namespace reduction::detail

--- a/cpp/include/cudf/reduction/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction_functions.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 
@@ -36,7 +36,7 @@ namespace reduction::detail {
 std::unique_ptr<scalar> sum(column_view const& col,
                             data_type const output_dtype,
                             std::optional<std::reference_wrapper<scalar const>> init,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -58,7 +58,7 @@ std::unique_ptr<scalar> sum(column_view const& col,
 std::unique_ptr<scalar> sum_overflow(column_view const& col,
                                      data_type const output_type,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -78,7 +78,7 @@ std::unique_ptr<scalar> sum_overflow(column_view const& col,
 std::unique_ptr<scalar> min(column_view const& col,
                             data_type const output_dtype,
                             std::optional<std::reference_wrapper<scalar const>> init,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -98,7 +98,7 @@ std::unique_ptr<scalar> min(column_view const& col,
 std::unique_ptr<scalar> max(column_view const& col,
                             data_type const output_dtype,
                             std::optional<std::reference_wrapper<scalar const>> init,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -115,7 +115,7 @@ std::unique_ptr<scalar> max(column_view const& col,
  */
 std::unique_ptr<scalar> argmin(column_view const& col,
                                data_type dispatch_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
@@ -132,7 +132,7 @@ std::unique_ptr<scalar> argmin(column_view const& col,
  */
 std::unique_ptr<scalar> argmax(column_view const& col,
                                data_type dispatch_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 /**
@@ -144,7 +144,7 @@ std::unique_ptr<scalar> argmax(column_view const& col,
  * @return A pair consisting of the minimum value and the maximum value
  */
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
-  cudf::column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  cudf::column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
 /**
  * @brief Computes any of elements in input column is true when typecasted to bool
@@ -164,7 +164,7 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
 std::unique_ptr<scalar> any(column_view const& col,
                             data_type const output_dtype,
                             std::optional<std::reference_wrapper<scalar const>> init,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -185,7 +185,7 @@ std::unique_ptr<scalar> any(column_view const& col,
 std::unique_ptr<scalar> all(column_view const& col,
                             data_type const output_dtype,
                             std::optional<std::reference_wrapper<scalar const>> init,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 /**
@@ -200,7 +200,7 @@ std::unique_ptr<scalar> all(column_view const& col,
  * @return A list_scalar storing a structs column as the result histogram
  */
 std::unique_ptr<scalar> histogram(column_view const& input,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -212,7 +212,7 @@ std::unique_ptr<scalar> histogram(column_view const& input,
  * @return A list_scalar storing the result histogram
  */
 std::unique_ptr<scalar> merge_histogram(column_view const& input,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -233,7 +233,7 @@ std::unique_ptr<scalar> merge_histogram(column_view const& input,
 std::unique_ptr<scalar> product(column_view const& col,
                                 data_type const output_dtype,
                                 std::optional<std::reference_wrapper<scalar const>> init,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr);
 
 /**
@@ -252,7 +252,7 @@ std::unique_ptr<scalar> product(column_view const& col,
  */
 std::unique_ptr<scalar> sum_of_squares(column_view const& col,
                                        data_type const output_dtype,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -271,7 +271,7 @@ std::unique_ptr<scalar> sum_of_squares(column_view const& col,
  */
 std::unique_ptr<scalar> mean(column_view const& col,
                              data_type const output_dtype,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr);
 
 /**
@@ -293,7 +293,7 @@ std::unique_ptr<scalar> mean(column_view const& col,
 std::unique_ptr<scalar> variance(column_view const& col,
                                  data_type const output_dtype,
                                  size_type ddof,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -315,7 +315,7 @@ std::unique_ptr<scalar> variance(column_view const& col,
 std::unique_ptr<scalar> standard_deviation(column_view const& col,
                                            data_type const output_dtype,
                                            size_type ddof,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr);
 
 /**
@@ -345,7 +345,7 @@ std::unique_ptr<scalar> standard_deviation(column_view const& col,
 std::unique_ptr<scalar> nth_element(column_view const& col,
                                     size_type n,
                                     null_policy null_handling,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -359,7 +359,7 @@ std::unique_ptr<scalar> nth_element(column_view const& col,
  */
 std::unique_ptr<scalar> collect_list(column_view const& col,
                                      null_policy null_handling,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -371,7 +371,7 @@ std::unique_ptr<scalar> collect_list(column_view const& col,
  * @return merged list as scalar
  */
 std::unique_ptr<scalar> merge_lists(lists_column_view const& col,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -389,7 +389,7 @@ std::unique_ptr<scalar> collect_set(column_view const& col,
                                     null_policy null_handling,
                                     null_equality nulls_equal,
                                     nan_equality nans_equal,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 /**
@@ -405,7 +405,7 @@ std::unique_ptr<scalar> collect_set(column_view const& col,
 std::unique_ptr<scalar> merge_sets(lists_column_view const& col,
                                    null_equality nulls_equal,
                                    nan_equality nans_equal,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -419,7 +419,7 @@ std::unique_ptr<scalar> merge_sets(lists_column_view const& col,
  */
 std::unique_ptr<scalar> bitwise_reduction(bitwise_op bit_op,
                                           column_view const& col,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -441,7 +441,7 @@ std::unique_ptr<cudf::scalar> quantile(column_view const& col,
                                        double quantile_value,
                                        cudf::interpolation interpolation,
                                        cudf::data_type const output_type,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -458,7 +458,7 @@ std::unique_ptr<cudf::scalar> quantile(column_view const& col,
 std::unique_ptr<scalar> nunique(column_view const& col,
                                 null_policy null_handling,
                                 data_type const output_dtype,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr);
 
 /**
@@ -476,7 +476,7 @@ std::unique_ptr<scalar> nunique(column_view const& col,
 std::unique_ptr<scalar> count(column_view const& col,
                               null_policy null_handling,
                               data_type const output_type,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 }  // namespace reduction::detail

--- a/cpp/include/cudf/reduction/detail/segmented_reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/segmented_reduction.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,12 +10,12 @@
 #include <cudf/detail/utilities/cast_functor.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -52,7 +52,7 @@ void segmented_reduce(InputIterator d_in,
                       OutputIterator d_out,
                       BinaryOp op,
                       OutputType initial_value,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
   requires(is_fixed_width<OutputType>() && !cudf::is_fixed_point<OutputType>())
 {
   auto const num_segments = static_cast<size_type>(std::distance(d_offset_begin, d_offset_end)) - 1;
@@ -68,7 +68,7 @@ void segmented_reduce(InputIterator d_in,
                                      d_offset_begin + 1,
                                      binary_op,
                                      initial_value,
-                                     stream.value());
+                                     stream.get());
   auto d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
 
   // Run reduction
@@ -81,7 +81,7 @@ void segmented_reduce(InputIterator d_in,
                                      d_offset_begin + 1,
                                      binary_op,
                                      initial_value,
-                                     stream.value());
+                                     stream.get());
 }
 
 template <typename InputIterator,
@@ -95,7 +95,7 @@ void segmented_reduce(InputIterator,
                       OutputIterator,
                       BinaryOp,
                       OutputType,
-                      rmm::cuda_stream_view)
+                      cuda::stream_ref)
   requires(!(is_fixed_width<OutputType>() && !cudf::is_fixed_point<OutputType>()))
 {
   CUDF_FAIL(
@@ -132,7 +132,7 @@ void segmented_reduce(InputIterator d_in,
                       op::compound_op<Op> op,
                       size_type ddof,
                       size_type* d_valid_counts,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   using OutputType       = cuda::std::iter_value_t<OutputIterator>;
   using IntermediateType = cuda::std::iter_value_t<InputIterator>;
@@ -154,7 +154,7 @@ void segmented_reduce(InputIterator d_in,
                                      d_offset_begin + 1,
                                      binary_op,
                                      initial_value,
-                                     stream.value());
+                                     stream.get());
   auto d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
 
   // Run reduction
@@ -167,7 +167,7 @@ void segmented_reduce(InputIterator d_in,
                                      d_offset_begin + 1,
                                      binary_op,
                                      initial_value,
-                                     stream.value());
+                                     stream.get());
 
   // compute the result value from intermediate value in device
   thrust::transform(

--- a/cpp/include/cudf/reduction/detail/segmented_reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/segmented_reduction_functions.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 
@@ -44,7 +44,7 @@ std::unique_ptr<column> segmented_sum(column_view const& col,
                                       data_type const output_dtype,
                                       null_policy null_handling,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -74,7 +74,7 @@ std::unique_ptr<column> segmented_product(column_view const& col,
                                           data_type const output_dtype,
                                           null_policy null_handling,
                                           std::optional<std::reference_wrapper<scalar const>> init,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -103,7 +103,7 @@ std::unique_ptr<column> segmented_min(column_view const& col,
                                       data_type const output_dtype,
                                       null_policy null_handling,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -132,7 +132,7 @@ std::unique_ptr<column> segmented_max(column_view const& col,
                                       data_type const output_dtype,
                                       null_policy null_handling,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -162,7 +162,7 @@ std::unique_ptr<column> segmented_any(column_view const& col,
                                       data_type const output_dtype,
                                       null_policy null_handling,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -192,7 +192,7 @@ std::unique_ptr<column> segmented_all(column_view const& col,
                                       data_type const output_dtype,
                                       null_policy null_handling,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -220,7 +220,7 @@ std::unique_ptr<column> segmented_mean(column_view const& col,
                                        device_span<size_type const> offsets,
                                        data_type const output_dtype,
                                        null_policy null_handling,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -248,7 +248,7 @@ std::unique_ptr<column> segmented_sum_of_squares(column_view const& col,
                                                  device_span<size_type const> offsets,
                                                  data_type const output_dtype,
                                                  null_policy null_handling,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -279,7 +279,7 @@ std::unique_ptr<column> segmented_standard_deviation(column_view const& col,
                                                      data_type const output_dtype,
                                                      null_policy null_handling,
                                                      size_type ddof,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -310,7 +310,7 @@ std::unique_ptr<column> segmented_variance(column_view const& col,
                                            data_type const output_dtype,
                                            null_policy null_handling,
                                            size_type ddof,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr);
 
 /**
@@ -338,7 +338,7 @@ std::unique_ptr<column> segmented_variance(column_view const& col,
 std::unique_ptr<column> segmented_nunique(column_view const& col,
                                           device_span<size_type const> offsets,
                                           null_policy null_handling,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 }  // namespace reduction::detail

--- a/cpp/include/cudf/reduction/detail/unique_count.hpp
+++ b/cpp/include/cudf/reduction/detail/unique_count.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,25 +10,25 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 
 /**
- * @copydoc cudf::unique_count(column_view const&, null_policy, nan_policy, rmm::cuda_stream_view)
+ * @copydoc cudf::unique_count(column_view const&, null_policy, nan_policy, cuda::stream_ref)
  */
 cudf::size_type unique_count(column_view const& input,
                              null_policy null_handling,
                              nan_policy nan_handling,
-                             rmm::cuda_stream_view stream);
+                             cuda::stream_ref stream);
 
 /**
- * @copydoc cudf::unique_count(table_view const&, null_equality, rmm::cuda_stream_view)
+ * @copydoc cudf::unique_count(table_view const&, null_equality, cuda::stream_ref)
  */
 cudf::size_type unique_count(table_view const& input,
                              null_equality nulls_equal,
-                             rmm::cuda_stream_view stream);
+                             cuda::stream_ref stream);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/reduction/distinct_count.hpp
+++ b/cpp/include/cudf/reduction/distinct_count.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 /**
  * @file
@@ -47,7 +47,7 @@ namespace CUDF_EXPORT cudf {
 cudf::size_type distinct_count(column_view const& input,
                                null_policy null_handling,
                                nan_policy nan_handling,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Count the distinct rows in a table.
@@ -60,8 +60,8 @@ cudf::size_type distinct_count(column_view const& input,
  * @return number of distinct rows in the table
  */
 cudf::size_type distinct_count(table_view const& input,
-                               null_equality nulls_equal    = null_equality::EQUAL,
-                               rmm::cuda_stream_view stream = cudf::get_default_stream());
+                               null_equality nulls_equal = null_equality::EQUAL,
+                               cuda::stream_ref stream   = cudf::get_default_stream());
 
 /** @} */
 

--- a/cpp/include/cudf/reduction/unique_count.hpp
+++ b/cpp/include/cudf/reduction/unique_count.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 /**
  * @file
@@ -44,7 +44,7 @@ namespace CUDF_EXPORT cudf {
 cudf::size_type unique_count(column_view const& input,
                              null_policy null_handling,
                              nan_policy nan_handling,
-                             rmm::cuda_stream_view stream = cudf::get_default_stream());
+                             cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Count the number of consecutive groups of equivalent rows in a table.
@@ -57,8 +57,8 @@ cudf::size_type unique_count(column_view const& input,
  * @return number of consecutive groups of equivalent rows in the column
  */
 cudf::size_type unique_count(table_view const& input,
-                             null_equality nulls_equal    = null_equality::EQUAL,
-                             rmm::cuda_stream_view stream = cudf::get_default_stream());
+                             null_equality nulls_equal = null_equality::EQUAL,
+                             cuda::stream_ref stream   = cudf::get_default_stream());
 
 /** @} */
 

--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -150,7 +150,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> make_range_windows(
   null_order null_order,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -197,7 +197,7 @@ std::unique_ptr<column> rolling_window(
   size_type following_window,
   size_type min_periods,
   rolling_aggregation const& agg,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -208,7 +208,7 @@ std::unique_ptr<column> rolling_window(
  *            size_type following_window,
  *            size_type min_periods,
  *            rolling_aggregation const& agg,
- *            rmm::cuda_stream_view stream,
+ *            cuda::stream_ref stream,
  *            rmm::device_async_resource_ref mr)
  *
  * @param default_outputs A column of per-row default values to be returned instead
@@ -222,7 +222,7 @@ std::unique_ptr<column> rolling_window(
   size_type following_window,
   size_type min_periods,
   rolling_aggregation const& agg,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -373,7 +373,7 @@ std::unique_ptr<column> grouped_rolling_window(
   size_type following_window,
   size_type min_periods,
   rolling_aggregation const& aggr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -385,7 +385,7 @@ std::unique_ptr<column> grouped_rolling_window(
  *            size_type following_window,
  *            size_type min_periods,
  *            rolling_aggregation const& aggr,
- *            rmm::cuda_stream_view stream,
+ *            cuda::stream_ref stream,
  *            rmm::device_async_resource_ref mr)
  */
 std::unique_ptr<column> grouped_rolling_window(
@@ -395,7 +395,7 @@ std::unique_ptr<column> grouped_rolling_window(
   window_bounds following_window,
   size_type min_periods,
   rolling_aggregation const& aggr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -407,7 +407,7 @@ std::unique_ptr<column> grouped_rolling_window(
  *            size_type following_window,
  *            size_type min_periods,
  *            rolling_aggregation const& aggr,
- *            rmm::cuda_stream_view stream,,
+ *            cuda::stream_ref stream,,
  *            rmm::device_async_resource_ref mr)
  *
  * @param default_outputs A column of per-row default values to be returned instead
@@ -422,7 +422,7 @@ std::unique_ptr<column> grouped_rolling_window(
   size_type following_window,
   size_type min_periods,
   rolling_aggregation const& aggr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -435,7 +435,7 @@ std::unique_ptr<column> grouped_rolling_window(
  *            size_type following_window,
  *            size_type min_periods,
  *            rolling_aggregation const& aggr,
- *            rmm::cuda_stream_view stream,
+ *            cuda::stream_ref stream,
  *            rmm::device_async_resource_ref mr)
  */
 std::unique_ptr<column> grouped_rolling_window(
@@ -446,7 +446,7 @@ std::unique_ptr<column> grouped_rolling_window(
   window_bounds following_window,
   size_type min_periods,
   rolling_aggregation const& aggr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -569,7 +569,7 @@ std::unique_ptr<column> grouped_range_rolling_window(
   range_window_bounds const& following,
   size_type min_periods,
   rolling_aggregation const& aggr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -595,7 +595,7 @@ std::unique_ptr<table> grouped_range_rolling_window(
   range_window_type preceding,
   range_window_type following,
   std::span<rolling_request const> requests,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -628,7 +628,7 @@ std::unique_ptr<table> grouped_range_rolling_window(
   range_window_type preceding,
   range_window_type following,
   host_span<rolling_request const> requests,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -683,7 +683,7 @@ std::unique_ptr<column> rolling_window(
   column_view const& following_window,
   size_type min_periods,
   rolling_aggregation const& agg,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**

--- a/cpp/include/cudf/rolling/range_window_bounds.hpp
+++ b/cpp/include/cudf/rolling/range_window_bounds.hpp
@@ -54,7 +54,7 @@ struct range_window_bounds {
    * @return A bounded window boundary object
    */
   static range_window_bounds get(scalar const& boundary,
-                                 rmm::cuda_stream_view stream = cudf::get_default_stream());
+                                 cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Factory method to construct a window boundary
@@ -65,7 +65,7 @@ struct range_window_bounds {
    * @return  A "current row" window boundary object
    */
   static range_window_bounds current_row(data_type type,
-                                         rmm::cuda_stream_view stream = cudf::get_default_stream());
+                                         cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Whether or not the window is bounded to the current row
@@ -83,7 +83,7 @@ struct range_window_bounds {
    * @return  An unbounded window boundary object
    */
   static range_window_bounds unbounded(data_type type,
-                                       rmm::cuda_stream_view stream = cudf::get_default_stream());
+                                       cuda::stream_ref stream = cudf::get_default_stream());
 
   /**
    * @brief Whether or not the window is unbounded
@@ -109,7 +109,7 @@ struct range_window_bounds {
 
   range_window_bounds(extent_type extent_,
                       std::unique_ptr<scalar> range_scalar_,
-                      rmm::cuda_stream_view = cudf::get_default_stream());
+                      cuda::stream_ref = cudf::get_default_stream());
 };
 
 /** @} */  // end of group

--- a/cpp/include/cudf/sorting.hpp
+++ b/cpp/include/cudf/sorting.hpp
@@ -45,7 +45,7 @@ std::unique_ptr<column> sorted_order(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -60,7 +60,7 @@ std::unique_ptr<column> stable_sorted_order(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -83,7 +83,7 @@ std::unique_ptr<column> stable_sorted_order(
 bool is_sorted(cudf::table_view const& table,
                std::vector<order> const& column_order,
                std::vector<null_order> const& null_precedence,
-               rmm::cuda_stream_view stream = cudf::get_default_stream());
+               cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Performs a lexicographic sort of the rows of a table
@@ -104,7 +104,7 @@ std::unique_ptr<table> sort(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -116,7 +116,7 @@ std::unique_ptr<table> stable_sort(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -146,7 +146,7 @@ std::unique_ptr<table> sort_by_key(
   table_view const& keys,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -159,7 +159,7 @@ std::unique_ptr<table> stable_sort_by_key(
   table_view const& keys,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -226,7 +226,7 @@ std::unique_ptr<column> rank(
   null_policy null_handling,
   null_order null_precedence,
   bool percentage,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -281,7 +281,7 @@ std::unique_ptr<column> segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -294,7 +294,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -350,7 +350,7 @@ std::unique_ptr<table> segmented_sort_by_key(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -364,7 +364,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
+  cuda::stream_ref stream                        = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr              = cudf::get_current_device_resource_ref());
 
 /**
@@ -387,7 +387,7 @@ std::unique_ptr<column> top_k(
   column_view const& col,
   size_type k,
   order topk_order                  = order::DESCENDING,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -410,7 +410,7 @@ std::unique_ptr<column> top_k_order(
   column_view const& col,
   size_type k,
   order topk_order                  = order::DESCENDING,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -457,7 +457,7 @@ std::unique_ptr<column> segmented_top_k(
   column_view const& segment_offsets,
   size_type k,
   order topk_order                  = order::DESCENDING,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -504,7 +504,7 @@ std::unique_ptr<column> segmented_top_k_order(
   column_view const& segment_offsets,
   size_type k,
   order topk_order                  = order::DESCENDING,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/transform.hpp
+++ b/cpp/include/cudf/transform.hpp
@@ -74,7 +74,7 @@ struct transform_output {
   null_aware is_null_aware          = null_aware::NO,
   std::optional<size_type> row_size = std::nullopt,
   output_nullability null_policy    = output_nullability::PRESERVE,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -127,7 +127,7 @@ std::unique_ptr<table> transform(
   std::span<transform_output const> outputs,
   std::vector<std::unique_ptr<column>>&& string_offsets,
   std::optional<size_type> row_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -157,7 +157,7 @@ std::unique_ptr<table> transform(
   std::span<transform_output const> outputs,
   std::vector<std::unique_ptr<column>>&& string_offsets,
   std::optional<size_type> row_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -215,7 +215,7 @@ std::unique_ptr<table> transform_lto(
   std::span<transform_output const> outputs,
   std::vector<std::unique_ptr<column>>&& string_offsets,
   std::optional<size_type> row_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -234,7 +234,7 @@ std::unique_ptr<table> transform_lto(
  */
 [[deprecated]] std::pair<std::unique_ptr<rmm::device_buffer>, size_type> nans_to_nulls(
   column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -250,7 +250,7 @@ std::unique_ptr<table> transform_lto(
  */
 std::unique_ptr<column> column_nans_to_nulls(
   column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -274,7 +274,7 @@ std::unique_ptr<column> column_nans_to_nulls(
 std::unique_ptr<column> compute_column(
   table_view const& table,
   ast::expression const& expr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -299,7 +299,7 @@ std::unique_ptr<column> compute_column(
 std::unique_ptr<column> compute_column_jit(
   table_view const& table,
   ast::expression const& expr,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -320,7 +320,7 @@ std::unique_ptr<column> compute_column_jit(
  */
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
   column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -350,7 +350,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
  */
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
   cudf::table_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -384,7 +384,7 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(
   column_view const& input,
   column_view const& categories,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -413,7 +413,7 @@ std::unique_ptr<column> mask_to_bools(
   bitmask_type const* bitmask,
   size_type begin_bit,
   size_type end_bit,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -444,7 +444,7 @@ std::unique_ptr<column> mask_to_bools(
  */
 std::unique_ptr<column> row_bit_count(
   table_view const& t,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -469,7 +469,7 @@ std::unique_ptr<column> row_bit_count(
 std::unique_ptr<column> segmented_row_bit_count(
   table_view const& t,
   size_type segment_length,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/unary.hpp
+++ b/cpp/include/cudf/unary.hpp
@@ -71,7 +71,7 @@ enum class unary_operator : int32_t {
 std::unique_ptr<cudf::column> unary_operation(
   cudf::column_view const& input,
   cudf::unary_operator op,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -87,7 +87,7 @@ std::unique_ptr<cudf::column> unary_operation(
  */
 std::unique_ptr<cudf::column> is_null(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -103,7 +103,7 @@ std::unique_ptr<cudf::column> is_null(
  */
 std::unique_ptr<cudf::column> is_valid(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -122,7 +122,7 @@ std::unique_ptr<cudf::column> is_valid(
 std::unique_ptr<column> cast(
   column_view const& input,
   data_type out_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -150,7 +150,7 @@ bool is_supported_cast(data_type from, data_type to) noexcept;
  */
 std::unique_ptr<column> is_nan(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -169,7 +169,7 @@ std::unique_ptr<column> is_nan(
  */
 std::unique_ptr<column> is_not_nan(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /** @} */  // end of group

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2018-2019 BlazingDB, Inc.
  * SPDX-FileCopyrightText: Copyright 2018 Christian Noboa Mardini <christian@blazingdb.com>
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /*
@@ -39,9 +39,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/optional>
+#include <cuda/stream_ref>
 
 #include <string>
 
@@ -59,7 +58,7 @@ bool is_supported_operation(data_type out, data_type lhs, data_type rhs, binary_
 std::pair<rmm::device_buffer, size_type> scalar_col_valid_mask_and(
   column_view const& col,
   scalar const& s,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (col.is_empty()) return std::pair(rmm::device_buffer{0, stream, mr}, 0);
@@ -141,7 +140,7 @@ void binary_operation(mutable_column_view& out,
                       column_view const& lhs,
                       column_view const& rhs,
                       std::string const& ptx,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   std::string const output_type_name = cudf::type_to_name(out.type());
 
@@ -204,7 +203,7 @@ std::unique_ptr<column> binary_operation(LhsType const& lhs,
                                          RhsType const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   if constexpr (std::is_same_v<LhsType, column_view> and std::is_same_v<RhsType, column_view>)
@@ -265,7 +264,7 @@ std::unique_ptr<column> make_fixed_width_column_for_output(scalar const& lhs,
                                                            column_view const& rhs,
                                                            binary_operator op,
                                                            data_type output_type,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   if (binops::is_null_dependent(op)) {
@@ -292,7 +291,7 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
                                                            scalar const& rhs,
                                                            binary_operator op,
                                                            data_type output_type,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   if (binops::is_null_dependent(op)) {
@@ -319,7 +318,7 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
                                                            column_view const& rhs,
                                                            binary_operator op,
                                                            data_type output_type,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   if (binops::is_null_dependent(op)) {
@@ -335,7 +334,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   return binops::compiled::binary_operation<scalar, column_view>(
@@ -345,7 +344,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   return binops::compiled::binary_operation<column_view, scalar>(
@@ -355,7 +354,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   return binops::compiled::binary_operation<column_view, column_view>(
@@ -366,7 +365,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          std::string const& ptx,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   // Check for datatype
@@ -420,7 +419,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -430,7 +429,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -440,7 +439,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -451,7 +450,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          std::string const& ptx,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/binaryop/compiled/ATan2.cu
+++ b/cpp/src/binaryop/compiled/ATan2.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::ATan2>(mutable_column_view&,
                                           column_view const&,
                                           bool is_lhs_scalar,
                                           bool is_rhs_scalar,
-                                          rmm::cuda_stream_view);
+                                          cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Add.cu
+++ b/cpp/src/binaryop/compiled/Add.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Add>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/BitwiseAnd.cu
+++ b/cpp/src/binaryop/compiled/BitwiseAnd.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::BitwiseAnd>(mutable_column_view&,
                                                column_view const&,
                                                bool is_lhs_scalar,
                                                bool is_rhs_scalar,
-                                               rmm::cuda_stream_view);
+                                               cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/BitwiseOr.cu
+++ b/cpp/src/binaryop/compiled/BitwiseOr.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::BitwiseOr>(mutable_column_view&,
                                               column_view const&,
                                               bool is_lhs_scalar,
                                               bool is_rhs_scalar,
-                                              rmm::cuda_stream_view);
+                                              cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/BitwiseXor.cu
+++ b/cpp/src/binaryop/compiled/BitwiseXor.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::BitwiseXor>(mutable_column_view&,
                                                column_view const&,
                                                bool is_lhs_scalar,
                                                bool is_rhs_scalar,
-                                               rmm::cuda_stream_view);
+                                               cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Div.cu
+++ b/cpp/src/binaryop/compiled/Div.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Div>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/FloorDiv.cu
+++ b/cpp/src/binaryop/compiled/FloorDiv.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::FloorDiv>(mutable_column_view&,
                                              column_view const&,
                                              bool is_lhs_scalar,
                                              bool is_rhs_scalar,
-                                             rmm::cuda_stream_view);
+                                             cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Greater.cu
+++ b/cpp/src/binaryop/compiled/Greater.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Greater>(mutable_column_view&,
                                             column_view const&,
                                             bool is_lhs_scalar,
                                             bool is_rhs_scalar,
-                                            rmm::cuda_stream_view);
+                                            cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/GreaterEqual.cu
+++ b/cpp/src/binaryop/compiled/GreaterEqual.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::GreaterEqual>(mutable_column_view&,
                                                  column_view const&,
                                                  bool is_lhs_scalar,
                                                  bool is_rhs_scalar,
-                                                 rmm::cuda_stream_view);
+                                                 cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/IntPow.cu
+++ b/cpp/src/binaryop/compiled/IntPow.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::IntPow>(mutable_column_view&,
                                            column_view const&,
                                            bool is_lhs_scalar,
                                            bool is_rhs_scalar,
-                                           rmm::cuda_stream_view);
+                                           cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Less.cu
+++ b/cpp/src/binaryop/compiled/Less.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Less>(mutable_column_view&,
                                          column_view const&,
                                          bool is_lhs_scalar,
                                          bool is_rhs_scalar,
-                                         rmm::cuda_stream_view);
+                                         cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/LessEqual.cu
+++ b/cpp/src/binaryop/compiled/LessEqual.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::LessEqual>(mutable_column_view&,
                                               column_view const&,
                                               bool is_lhs_scalar,
                                               bool is_rhs_scalar,
-                                              rmm::cuda_stream_view);
+                                              cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/LogBase.cu
+++ b/cpp/src/binaryop/compiled/LogBase.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::LogBase>(mutable_column_view&,
                                             column_view const&,
                                             bool is_lhs_scalar,
                                             bool is_rhs_scalar,
-                                            rmm::cuda_stream_view);
+                                            cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/LogicalAnd.cu
+++ b/cpp/src/binaryop/compiled/LogicalAnd.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::LogicalAnd>(mutable_column_view&,
                                                column_view const&,
                                                bool is_lhs_scalar,
                                                bool is_rhs_scalar,
-                                               rmm::cuda_stream_view);
+                                               cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/LogicalOr.cu
+++ b/cpp/src/binaryop/compiled/LogicalOr.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::LogicalOr>(mutable_column_view&,
                                               column_view const&,
                                               bool is_lhs_scalar,
                                               bool is_rhs_scalar,
-                                              rmm::cuda_stream_view);
+                                              cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Mod.cu
+++ b/cpp/src/binaryop/compiled/Mod.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Mod>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Mul.cu
+++ b/cpp/src/binaryop/compiled/Mul.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Mul>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/NullEquals.cu
+++ b/cpp/src/binaryop/compiled/NullEquals.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullEquals>(mutable_column_view&,
                                                column_view const&,
                                                bool is_lhs_scalar,
                                                bool is_rhs_scalar,
-                                               rmm::cuda_stream_view);
+                                               cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/NullLogicalAnd.cu
+++ b/cpp/src/binaryop/compiled/NullLogicalAnd.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullLogicalAnd>(mutable_column_view&,
                                                    column_view const&,
                                                    bool is_lhs_scalar,
                                                    bool is_rhs_scalar,
-                                                   rmm::cuda_stream_view);
+                                                   cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/NullLogicalOr.cu
+++ b/cpp/src/binaryop/compiled/NullLogicalOr.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullLogicalOr>(mutable_column_view&,
                                                   column_view const&,
                                                   bool is_lhs_scalar,
                                                   bool is_rhs_scalar,
-                                                  rmm::cuda_stream_view);
+                                                  cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/NullMax.cu
+++ b/cpp/src/binaryop/compiled/NullMax.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullMax>(mutable_column_view&,
                                             column_view const&,
                                             bool is_lhs_scalar,
                                             bool is_rhs_scalar,
-                                            rmm::cuda_stream_view);
+                                            cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/NullMin.cu
+++ b/cpp/src/binaryop/compiled/NullMin.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullMin>(mutable_column_view&,
                                             column_view const&,
                                             bool is_lhs_scalar,
                                             bool is_rhs_scalar,
-                                            rmm::cuda_stream_view);
+                                            cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/NullNotEquals.cu
+++ b/cpp/src/binaryop/compiled/NullNotEquals.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::NullNotEquals>(mutable_column_view&,
                                                   column_view const&,
                                                   bool is_lhs_scalar,
                                                   bool is_rhs_scalar,
-                                                  rmm::cuda_stream_view);
+                                                  cuda::stream_ref);
 }  // namespace cudf::binops::compiled

--- a/cpp/src/binaryop/compiled/PMod.cu
+++ b/cpp/src/binaryop/compiled/PMod.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::PMod>(mutable_column_view&,
                                          column_view const&,
                                          bool is_lhs_scalar,
                                          bool is_rhs_scalar,
-                                         rmm::cuda_stream_view);
+                                         cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Pow.cu
+++ b/cpp/src/binaryop/compiled/Pow.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Pow>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/PyMod.cu
+++ b/cpp/src/binaryop/compiled/PyMod.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::PyMod>(mutable_column_view&,
                                           column_view const&,
                                           bool is_lhs_scalar,
                                           bool is_rhs_scalar,
-                                          rmm::cuda_stream_view);
+                                          cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/ShiftLeft.cu
+++ b/cpp/src/binaryop/compiled/ShiftLeft.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::ShiftLeft>(mutable_column_view&,
                                               column_view const&,
                                               bool is_lhs_scalar,
                                               bool is_rhs_scalar,
-                                              rmm::cuda_stream_view);
+                                              cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/ShiftRight.cu
+++ b/cpp/src/binaryop/compiled/ShiftRight.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::ShiftRight>(mutable_column_view&,
                                                column_view const&,
                                                bool is_lhs_scalar,
                                                bool is_rhs_scalar,
-                                               rmm::cuda_stream_view);
+                                               cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/ShiftRightUnsigned.cu
+++ b/cpp/src/binaryop/compiled/ShiftRightUnsigned.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::ShiftRightUnsigned>(mutable_column_view&,
                                                        column_view const&,
                                                        bool is_lhs_scalar,
                                                        bool is_rhs_scalar,
-                                                       rmm::cuda_stream_view);
+                                                       cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/Sub.cu
+++ b/cpp/src/binaryop/compiled/Sub.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::Sub>(mutable_column_view&,
                                         column_view const&,
                                         bool is_lhs_scalar,
                                         bool is_rhs_scalar,
-                                        rmm::cuda_stream_view);
+                                        cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/TrueDiv.cu
+++ b/cpp/src/binaryop/compiled/TrueDiv.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,5 +11,5 @@ template void apply_binary_op<ops::TrueDiv>(mutable_column_view&,
                                             column_view const&,
                                             bool is_lhs_scalar,
                                             bool is_rhs_scalar,
-                                            rmm::cuda_stream_view);
+                                            cuda::stream_ref);
 }

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,12 +16,12 @@
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -39,7 +39,7 @@ struct scalar_as_column_view {
   using return_type = typename std::pair<column_view, std::unique_ptr<column>>;
   template <typename T, CUDF_ENABLE_IF(is_fixed_width<T>())>
   return_type operator()(scalar const& s,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
   {
     auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
@@ -60,7 +60,7 @@ struct scalar_as_column_view {
     return std::pair{col_v, std::move(aux_col)};
   }
   template <typename T, CUDF_ENABLE_IF(!is_fixed_width<T>())>
-  return_type operator()(scalar const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+  return_type operator()(scalar const&, cuda::stream_ref, rmm::device_async_resource_ref)
   {
     CUDF_FAIL("Unsupported type");
   }
@@ -68,7 +68,7 @@ struct scalar_as_column_view {
 // specialization for cudf::string_view
 template <>
 scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::string_view>(
-  scalar const& s, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  scalar const& s, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   using T                  = cudf::string_view;
   auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
@@ -106,7 +106,7 @@ scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::strin
 // specializing for struct column
 template <>
 scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::struct_view>(
-  scalar const& s, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  scalar const& s, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto col = make_column_from_scalar(s, 1, stream, mr);
   return std::pair{col->view(), std::move(col)};
@@ -123,7 +123,7 @@ scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::struc
  */
 auto scalar_to_column_view(
   scalar const& scal,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   return type_dispatcher(scal.type(), scalar_as_column_view{}, scal, stream, mr);
@@ -200,7 +200,7 @@ struct null_considering_binop {
   void populate_out_col(LhsViewT const& lhsv,
                         RhsViewT const& rhsv,
                         cudf::size_type col_size,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         CompareFunc cfunc,
                         OutT* out_col) const
   {
@@ -222,7 +222,7 @@ struct null_considering_binop {
                                      binary_operator op,
                                      data_type output_type,
                                      cudf::size_type col_size,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     // Create device views for inputs
@@ -269,7 +269,7 @@ std::unique_ptr<column> string_null_min_max(scalar const& lhs,
                                             column_view const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   // hard-coded to only work with cudf::string_view so we don't explode compile times
@@ -286,7 +286,7 @@ std::unique_ptr<column> string_null_min_max(column_view const& lhs,
                                             scalar const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   // hard-coded to only work with cudf::string_view so we don't explode compile times
@@ -303,7 +303,7 @@ std::unique_ptr<column> string_null_min_max(column_view const& lhs,
                                             column_view const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   // hard-coded to only work with cudf::string_view so we don't explode compile times
@@ -325,7 +325,7 @@ void operator_dispatcher(mutable_column_view& out,
                          bool is_lhs_scalar,
                          bool is_rhs_scalar,
                          binary_operator op,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   // clang-format off
 switch (op) {
@@ -377,7 +377,7 @@ void binary_operation(mutable_column_view& out,
                       column_view const& lhs,
                       column_view const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   operator_dispatcher(out, lhs, rhs, false, false, op, stream);
 }
@@ -386,7 +386,7 @@ void binary_operation(mutable_column_view& out,
                       scalar const& lhs,
                       column_view const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   auto [lhsv, aux] = scalar_to_column_view(lhs, stream);
   operator_dispatcher(out, lhsv, rhs, true, false, op, stream);
@@ -396,7 +396,7 @@ void binary_operation(mutable_column_view& out,
                       column_view const& lhs,
                       scalar const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   auto [rhsv, aux] = scalar_to_column_view(rhs, stream);
   operator_dispatcher(out, lhs, rhsv, false, true, op, stream);
@@ -409,7 +409,7 @@ void apply_sorting_struct_binary_op(mutable_column_view& out,
                                     bool is_lhs_scalar,
                                     bool is_rhs_scalar,
                                     binary_operator op,
-                                    rmm::cuda_stream_view stream)
+                                    cuda::stream_ref stream)
 {
   CUDF_EXPECTS(lhs.type().id() == type_id::STRUCT && rhs.type().id() == type_id::STRUCT,
                "Both columns must be struct columns");

--- a/cpp/src/binaryop/compiled/binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/binary_ops.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,11 +14,11 @@
 #include <cudf/fixed_point/conv.hpp>
 #include <cudf/unary.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace binops {
@@ -244,7 +244,7 @@ void apply_binary_op(mutable_column_view& out,
                      column_view const& rhs,
                      bool is_lhs_scalar,
                      bool is_rhs_scalar,
-                     rmm::cuda_stream_view stream)
+                     cuda::stream_ref stream)
 {
   auto common_dtype = get_common_type(out.type(), lhs.type(), rhs.type());
 

--- a/cpp/src/binaryop/compiled/binary_ops.hpp
+++ b/cpp/src/binaryop/compiled/binary_ops.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 
@@ -26,21 +26,21 @@ std::unique_ptr<column> string_null_min_max(scalar const& lhs,
                                             column_view const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 std::unique_ptr<column> string_null_min_max(column_view const& lhs,
                                             scalar const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 std::unique_ptr<column> string_null_min_max(column_view const& lhs,
                                             column_view const& rhs,
                                             binary_operator op,
                                             data_type output_type,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 /**
@@ -66,7 +66,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
@@ -92,7 +92,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
@@ -117,24 +117,24 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
                                          binary_operator op,
                                          data_type output_type,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 void binary_operation(mutable_column_view& out,
                       scalar const& lhs,
                       column_view const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream);
+                      cuda::stream_ref stream);
 void binary_operation(mutable_column_view& out,
                       column_view const& lhs,
                       scalar const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream);
+                      cuda::stream_ref stream);
 void binary_operation(mutable_column_view& out,
                       column_view const& lhs,
                       column_view const& rhs,
                       binary_operator op,
-                      rmm::cuda_stream_view stream);
+                      cuda::stream_ref stream);
 
 // Defined in util.cpp
 /**
@@ -178,7 +178,7 @@ void apply_binary_op(mutable_column_view& out,
                      column_view const& rhs,
                      bool is_lhs_scalar,
                      bool is_rhs_scalar,
-                     rmm::cuda_stream_view stream);
+                     cuda::stream_ref stream);
 /**
  * @brief Deploys single type or double type dispatcher that runs equality operation on each element
  * of @p lhs and @p rhs columns.
@@ -202,7 +202,7 @@ void dispatch_equality_op(mutable_column_view& out,
                           bool is_lhs_scalar,
                           bool is_rhs_scalar,
                           binary_operator op,
-                          rmm::cuda_stream_view stream);
+                          cuda::stream_ref stream);
 }  // namespace compiled
 }  // namespace binops
 }  // namespace cudf

--- a/cpp/src/binaryop/compiled/equality_ops.cu
+++ b/cpp/src/binaryop/compiled/equality_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@ void dispatch_equality_op(mutable_column_view& out,
                           bool is_lhs_scalar,
                           bool is_rhs_scalar,
                           binary_operator op,
-                          rmm::cuda_stream_view stream)
+                          cuda::stream_ref stream)
 {
   CUDF_EXPECTS(op == binary_operator::EQUAL || op == binary_operator::NOT_EQUAL,
                "Unsupported operator for these types",

--- a/cpp/src/binaryop/compiled/struct_binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/struct_binary_ops.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,10 +15,10 @@
 #include <cudf/detail/row_operator/equality.cuh>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf::binops::compiled::detail {
@@ -62,7 +62,7 @@ void apply_struct_binary_op(mutable_column_view& out,
                             bool is_lhs_scalar,
                             bool is_rhs_scalar,
                             PhysicalElementComparator comparator,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   auto const compare_orders = std::vector<order>(
     lhs.size(),
@@ -137,7 +137,7 @@ void apply_struct_equality_op(mutable_column_view& out,
                               bool is_rhs_scalar,
                               binary_operator op,
                               PhysicalEqualityComparator comparator,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   CUDF_EXPECTS(op == binary_operator::EQUAL || op == binary_operator::NOT_EQUAL ||
                  op == binary_operator::NULL_EQUALS || op == binary_operator::NULL_NOT_EQUALS,

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -66,7 +66,7 @@ std::unique_ptr<column> replace_indices(column_view const& input,
 
 /**
  * @copydoc cudf::dictionary::detail::replace_nulls(cudf::column_view const&,cudf::column_view
- * const& cuda::stream_ref, rmm::device_async_resource_ref)
+ * const&, cuda::stream_ref, rmm::device_async_resource_ref)
  */
 std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
                                       dictionary_column_view const& replacement,

--- a/cpp/src/groupby/common/m2_var_std.cu
+++ b/cpp/src/groupby/common/m2_var_std.cu
@@ -12,12 +12,12 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/cmath>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/tabulate.h>
 
 namespace cudf::groupby::detail {
@@ -44,7 +44,7 @@ struct m2_functor {
                 SumType const* sum,
                 CountType const* count,
                 size_type size,
-                rmm::cuda_stream_view stream) const noexcept
+                cuda::stream_ref stream) const noexcept
   {
     thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      target,
@@ -64,7 +64,7 @@ struct m2_functor {
                   column_view const& sum_sqr,
                   column_view const& sum,
                   column_view const& count,
-                  rmm::cuda_stream_view stream) const noexcept  //
+                  cuda::stream_ref stream) const noexcept  //
     requires(is_m2_supported<Source>())
   {
     using Target     = cudf::detail::target_type_t<Source, aggregation::M2>;
@@ -89,7 +89,7 @@ std::unique_ptr<column> compute_m2(data_type source_type,
                                    column_view const& sum_sqr,
                                    column_view const& sum,
                                    column_view const& count,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   auto output = make_numeric_column(cudf::detail::target_type(source_type, aggregation::M2),
@@ -123,7 +123,7 @@ void check_input_types(column_view const& m2, column_view const& count)
 template <typename TargetType, typename TransformFunc>
 std::unique_ptr<column> compute_variance_std(TransformFunc&& transform_fn,
                                              size_type size,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   auto output = make_numeric_column(
@@ -152,7 +152,7 @@ std::unique_ptr<column> compute_variance_std(TransformFunc&& transform_fn,
 std::unique_ptr<column> compute_variance(column_view const& m2,
                                          column_view const& count,
                                          size_type ddof,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   check_input_types(m2, count);
@@ -171,7 +171,7 @@ std::unique_ptr<column> compute_variance(column_view const& m2,
 std::unique_ptr<column> compute_std(column_view const& m2,
                                     column_view const& count,
                                     size_type ddof,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   check_input_types(m2, count);

--- a/cpp/src/groupby/common/m2_var_std.hpp
+++ b/cpp/src/groupby/common/m2_var_std.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,8 +8,9 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf::groupby::detail {
 
@@ -17,19 +18,19 @@ std::unique_ptr<column> compute_m2(data_type source_type,
                                    column_view const& sum_sqr,
                                    column_view const& sum,
                                    column_view const& count,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 std::unique_ptr<column> compute_variance(column_view const& m2,
                                          column_view const& count,
                                          size_type ddof,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 std::unique_ptr<column> compute_std(column_view const& m2,
                                     column_view const& count,
                                     size_type ddof,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::groupby::detail

--- a/cpp/src/groupby/common/utils.cpp
+++ b/cpp/src/groupby/common/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 namespace cudf::groupby::detail {
 
 std::pair<rmm::device_buffer, bitmask_type const*> compute_row_bitmask(table_view const& keys,
-                                                                       rmm::cuda_stream_view stream)
+                                                                       cuda::stream_ref stream)
 {
   auto const mr = cudf::get_current_device_resource_ref();
   if (keys.num_columns() == 0 || !cudf::has_nulls(keys)) {

--- a/cpp/src/groupby/common/utils.hpp
+++ b/cpp/src/groupby/common/utils.hpp
@@ -13,8 +13,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <span>
@@ -26,7 +27,7 @@ namespace cudf::groupby::detail {
 template <typename RequestType>
 inline std::vector<aggregation_result> extract_results(std::span<RequestType const> requests,
                                                        cudf::detail::result_cache& cache,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   std::vector<aggregation_result> results(requests.size());
@@ -58,8 +59,8 @@ inline std::vector<aggregation_result> extract_results(std::span<RequestType con
  *
  * @return Pair of {buffer, raw_pointer} where pointer is null if no nulls exist.
  */
-std::pair<rmm::device_buffer, bitmask_type const*> compute_row_bitmask(
-  table_view const& keys, rmm::cuda_stream_view stream);
+std::pair<rmm::device_buffer, bitmask_type const*> compute_row_bitmask(table_view const& keys,
+                                                                       cuda::stream_ref stream);
 
 /// Whether the given aggregation kind is supported by hash-based groupby.
 constexpr bool is_hash_aggregation(aggregation::Kind k)

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -27,9 +27,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -53,7 +52,7 @@ groupby::groupby(table_view const& keys,
 // Select hash vs. sort groupby implementation
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::dispatch_aggregation(
   std::span<aggregation_request const> requests,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // If sort groupby has been called once on this groupby object, then
@@ -88,7 +87,7 @@ namespace {
 struct empty_column_constructor {
   column_view values;
   aggregation const& agg;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   template <typename ValuesType, aggregation::Kind k>
@@ -155,7 +154,7 @@ struct empty_column_constructor {
 /// Make an empty table with appropriate types for requested aggs
 template <typename RequestType>
 auto empty_results(std::span<RequestType const> requests,
-                   rmm::cuda_stream_view stream,
+                   cuda::stream_ref stream,
                    rmm::device_async_resource_ref mr)
 {
   std::vector<aggregation_result> empty_results;
@@ -219,7 +218,7 @@ void verify_valid_requests(std::span<RequestType const> requests)
 // Compute aggregation requests
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggregate(
   std::span<aggregation_request const> requests,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -239,7 +238,7 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggr
 // Compute scan requests
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::scan(
   std::span<scan_request const> requests,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -259,7 +258,7 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::scan
 }
 
 groupby::groups groupby::get_groups(table_view values,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -285,7 +284,7 @@ groupby::groups groupby::get_groups(table_view values,
 std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::replace_nulls(
   table_view const& values,
   std::span<cudf::replace_policy const> replace_policies,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -329,7 +328,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::shift(
   table_view const& values,
   std::span<size_type const> offsets,
   std::vector<std::reference_wrapper<scalar const>> const& fill_values,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@ compute_global_memory_aggs<global_set_t>(bitmask_type const* row_bitmask,
                                          host_span<aggregation::Kind const> h_agg_kinds,
                                          device_span<aggregation::Kind const> d_agg_kinds,
                                          std::span<int8_t const> is_agg_intermediate,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,10 +12,10 @@
 #include <cudf/detail/gather.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
 
@@ -41,7 +41,7 @@ template <typename SetRef>
 rmm::device_uvector<size_type> compute_matching_keys(bitmask_type const* row_bitmask,
                                                      SetRef set_ref,
                                                      size_type num_rows,
-                                                     rmm::cuda_stream_view stream)
+                                                     cuda::stream_ref stream)
 {
   // Mapping from each row in the input key/value into the indices of the key.
   rmm::device_uvector<size_type> key_indices(num_rows, stream);
@@ -78,7 +78,7 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_aggs_d
   host_span<aggregation::Kind const> h_agg_kinds,
   device_span<aggregation::Kind const> d_agg_kinds,
   std::span<int8_t const> is_agg_intermediate,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const num_rows                = values.num_rows();
@@ -127,7 +127,7 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_aggs_s
   host_span<aggregation::Kind const> h_agg_kinds,
   device_span<aggregation::Kind const> d_agg_kinds,
   std::span<int8_t const> is_agg_intermediate,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const num_rows = values.num_rows();
@@ -164,7 +164,7 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_global
   host_span<aggregation::Kind const> h_agg_kinds,
   device_span<aggregation::Kind const> d_agg_kinds,
   std::span<int8_t const> is_agg_intermediate,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return h_agg_kinds.size() > GROUPBY_DENSE_OUTPUT_THRESHOLD

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,8 +9,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <memory>
@@ -26,6 +27,6 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_global
   host_span<aggregation::Kind const> h_agg_kinds,
   device_span<aggregation::Kind const> d_agg_kinds,
   std::span<int8_t const> is_agg_intermediate,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_global_memory_aggs_null.cu
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs_null.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@ compute_global_memory_aggs<nullable_global_set_t>(bitmask_type const* row_bitmas
                                                   host_span<aggregation::Kind const> h_agg_kinds,
                                                   device_span<aggregation::Kind const> d_agg_kinds,
                                                   std::span<int8_t const> is_agg_intermediate,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_groupby.cu
+++ b/cpp/src/groupby/hash/compute_groupby.cu
@@ -17,13 +17,13 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/tabulate.h>
 
 namespace cudf::groupby::detail::hash {
@@ -54,7 +54,7 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
                                        Equal const& d_row_equal,
                                        Hash const& d_row_hash,
                                        cudf::detail::result_cache* cache,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto const num_keys = keys.num_rows();
@@ -99,7 +99,7 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
                      cuco::thread_scope_device,
                      cuco::storage<GROUPBY_BUCKET_SIZE>{},
                      rmm::mr::polymorphic_allocator<char>{},
-                     stream.value()};
+                     stream.get()};
 
   auto const gather_keys = [&](auto const& gather_map) {
     return cudf::detail::gather(keys,
@@ -122,7 +122,7 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
 
     rmm::device_uvector<size_type> unique_key_indices(
       num_keys, stream, cudf::get_current_device_resource_ref());
-    auto const keys_end       = set.retrieve_all(unique_key_indices.begin(), stream.value());
+    auto const keys_end       = set.retrieve_all(unique_key_indices.begin(), stream.get());
     auto const key_gather_map = device_span<size_type const>{
       unique_key_indices.data(),
       static_cast<std::size_t>(cuda::std::distance(unique_key_indices.begin(), keys_end))};
@@ -161,7 +161,7 @@ template std::unique_ptr<table> compute_groupby<row_comparator_t, row_hash_t>(
   row_comparator_t const& d_row_equal,
   row_hash_t const& d_row_hash,
   cudf::detail::result_cache* cache,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template std::unique_ptr<table> compute_groupby<nullable_row_comparator_t, row_hash_t>(
@@ -171,6 +171,6 @@ template std::unique_ptr<table> compute_groupby<nullable_row_comparator_t, row_h
   nullable_row_comparator_t const& d_row_equal,
   row_hash_t const& d_row_hash,
   cudf::detail::result_cache* cache,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_groupby.hpp
+++ b/cpp/src/groupby/hash/compute_groupby.hpp
@@ -10,8 +10,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -47,6 +48,6 @@ std::unique_ptr<cudf::table> compute_groupby(table_view const& keys,
                                              Equal const& d_row_equal,
                                              Hash const& d_row_hash,
                                              cudf::detail::result_cache* cache,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_mapping_indices.cu
+++ b/cpp/src/groupby/hash/compute_mapping_indices.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,5 +18,5 @@ template void compute_mapping_indices<hash_set_ref_t<cuco::insert_and_find_tag>>
   size_type* global_mapping_index,
   size_type* block_cardinality,
   cuda::std::atomic_flag* needs_global_memory_fallback,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_mapping_indices.cuh
+++ b/cpp/src/groupby/hash/compute_mapping_indices.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,11 +12,10 @@
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cooperative_groups.h>
 #include <cuco/static_set_ref.cuh>
 #include <cuda/std/atomic>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 
@@ -169,9 +168,9 @@ void compute_mapping_indices(size_type grid_size,
                              size_type* global_mapping_indices,
                              size_type* block_cardinality,
                              cuda::std::atomic_flag* needs_global_memory_fallback,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
-  mapping_indices_kernel<<<grid_size, GROUPBY_BLOCK_SIZE, 0, stream>>>(
+  mapping_indices_kernel<<<grid_size, GROUPBY_BLOCK_SIZE, 0, stream.get()>>>(
     num_rows,
     global_set,
     row_bitmask,

--- a/cpp/src/groupby/hash/compute_mapping_indices.hpp
+++ b/cpp/src/groupby/hash/compute_mapping_indices.hpp
@@ -1,14 +1,13 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/atomic>
+#include <cuda/stream_ref>
 
 namespace cudf::groupby::detail::hash {
 
@@ -28,5 +27,5 @@ void compute_mapping_indices(size_type grid_size,
                              size_type* global_mapping_index,
                              size_type* block_cardinality,
                              cuda::std::atomic_flag* needs_global_memory_fallback,
-                             rmm::cuda_stream_view stream);
+                             cuda::stream_ref stream);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_mapping_indices_null.cu
+++ b/cpp/src/groupby/hash/compute_mapping_indices_null.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,5 +19,5 @@ template void compute_mapping_indices<nullable_hash_set_ref_t<cuco::insert_and_f
   size_type* global_mapping_index,
   size_type* block_cardinality,
   cuda::std::atomic_flag* needs_global_memory_fallback,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
@@ -21,13 +21,12 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cooperative_groups.h>
 #include <cuda/std/algorithm>
 #include <cuda/std/cstddef>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -384,7 +383,7 @@ void compute_shared_memory_aggs(cudf::size_type grid_size,
                                 cudf::table_device_view input_values,
                                 cudf::mutable_table_device_view output_values,
                                 cudf::aggregation::Kind const* d_agg_kinds,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   // For each aggregation, need one offset determining where the aggregation is
   // performed, another indicating the validity of the aggregation
@@ -393,17 +392,19 @@ void compute_shared_memory_aggs(cudf::size_type grid_size,
   CUDF_EXPECTS(available_shmem_size > offsets_size * 2,
                "No enough space for shared memory aggregations");
   auto const shmem_agg_size = available_shmem_size - offsets_size * 2;
-  single_pass_shmem_aggs_kernel<<<grid_size, GROUPBY_BLOCK_SIZE, available_shmem_size, stream>>>(
-    num_input_rows,
-    row_bitmask,
-    local_mapping_index,
-    global_mapping_index,
-    block_cardinality,
-    input_values,
-    output_values,
-    d_agg_kinds,
-    shmem_agg_size,
-    offsets_size);
+  single_pass_shmem_aggs_kernel<<<grid_size,
+                                  GROUPBY_BLOCK_SIZE,
+                                  available_shmem_size,
+                                  stream.get()>>>(num_input_rows,
+                                                  row_bitmask,
+                                                  local_mapping_index,
+                                                  global_mapping_index,
+                                                  block_cardinality,
+                                                  input_values,
+                                                  output_values,
+                                                  d_agg_kinds,
+                                                  shmem_agg_size,
+                                                  offsets_size);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
@@ -8,7 +8,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstdint>
 
@@ -37,5 +37,5 @@ void compute_shared_memory_aggs(size_type grid_size,
                                 table_device_view input_values,
                                 mutable_table_device_view output_values,
                                 aggregation::Kind const* d_agg_kinds,
-                                rmm::cuda_stream_view stream);
+                                cuda::stream_ref stream);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cu
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cu
@@ -42,7 +42,7 @@ template std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_agg
   bitmask_type const* row_bitmask,
   std::span<aggregation_request const> requests,
   cudf::detail::result_cache* cache,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
@@ -116,7 +116,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
                                              needs_global_memory_fallback.data(),
                                              sizeof(cuda::std::atomic_flag),
                                              stream));
-    stream.wait();
+    stream.sync();
     return h_needs_fallback.test(cuda::std::memory_order_relaxed);
   }();
   if (needs_fallback) { return run_aggs_by_global_mem_kernel(); }

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
@@ -18,12 +18,12 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/table_device_view.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 namespace cudf::groupby::detail::hash {
@@ -34,7 +34,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
   bitmask_type const* row_bitmask,
   std::span<aggregation_request const> requests,
   cudf::detail::result_cache* cache,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Collect the single-pass aggregations that can be processed in this function.
@@ -95,7 +95,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
   // Flag indicating whether a global memory aggregation fallback is required or not.
   rmm::device_scalar<cuda::std::atomic_flag> needs_global_memory_fallback(stream);
   CUDF_CUDA_TRY(cudaMemsetAsync(
-    needs_global_memory_fallback.data(), 0, sizeof(cuda::std::atomic_flag), stream.value()));
+    needs_global_memory_fallback.data(), 0, sizeof(cuda::std::atomic_flag), stream.get()));
 
   auto set_ref_insert = global_set.ref(cuco::op::insert_and_find);
   compute_mapping_indices(grid_size,
@@ -116,7 +116,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
                                              needs_global_memory_fallback.data(),
                                              sizeof(cuda::std::atomic_flag),
                                              stream));
-    stream.synchronize();
+    stream.wait();
     return h_needs_fallback.test(cuda::std::memory_order_relaxed);
   }();
   if (needs_fallback) { return run_aggs_by_global_mem_kernel(); }

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.hpp
@@ -9,8 +9,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf::groupby::detail::hash {
 
@@ -40,7 +41,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
   bitmask_type const* row_bitmask,
   std::span<aggregation_request const> requests,
   cudf::detail::result_cache* cache,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_single_pass_aggs_null.cu
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs_null.cu
@@ -12,6 +12,6 @@ compute_single_pass_aggs<nullable_global_set_t>(nullable_global_set_t& global_se
                                                 bitmask_type const* row_bitmask,
                                                 std::span<aggregation_request const> requests,
                                                 cudf::detail::result_cache* cache,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/extract_single_pass_aggs.cpp
+++ b/cpp/src/groupby/hash/extract_single_pass_aggs.cpp
@@ -113,8 +113,7 @@ std::tuple<table_view,
            std::vector<std::unique_ptr<aggregation>>,
            std::vector<int8_t>,
            bool>
-extract_single_pass_aggs(std::span<aggregation_request const> requests,
-                         rmm::cuda_stream_view stream)
+extract_single_pass_aggs(std::span<aggregation_request const> requests, cuda::stream_ref stream)
 {
   auto agg_kinds = cudf::detail::make_empty_host_vector<aggregation::Kind>(requests.size(), stream);
   std::vector<column_view> columns;

--- a/cpp/src/groupby/hash/extract_single_pass_aggs.hpp
+++ b/cpp/src/groupby/hash/extract_single_pass_aggs.hpp
@@ -42,8 +42,7 @@ std::tuple<table_view,
            std::vector<std::unique_ptr<aggregation>>,
            std::vector<int8_t>,
            bool>
-extract_single_pass_aggs(std::span<aggregation_request const> requests,
-                         rmm::cuda_stream_view stream);
+extract_single_pass_aggs(std::span<aggregation_request const> requests, cuda::stream_ref stream);
 
 /**
  * @brief Get simple aggregations from groupby aggregation

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -21,7 +21,7 @@
 #include <cudf/utilities/traits.cuh>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -35,7 +35,7 @@ std::unique_ptr<table> dispatch_groupby(table_view const& keys,
                                         cudf::detail::result_cache* cache,
                                         bool const keys_have_nulls,
                                         null_policy const include_null_keys,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto const null_keys_are_equal  = null_equality::EQUAL;
@@ -134,7 +134,7 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby(
   table_view const& keys,
   std::span<aggregation_request const> requests,
   null_policy include_null_keys,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   cudf::detail::result_cache cache(requests.size());

--- a/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
+++ b/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,14 +17,14 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf::groupby::detail::hash {
 
 hash_compound_agg_finalizer::hash_compound_agg_finalizer(column_view const& col,
                                                          cudf::detail::result_cache* cache,
                                                          bitmask_type const* d_row_bitmask,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
   : col{col},
     input_type{is_dictionary(col.type()) ? dictionary_column_view(col).keys().type() : col.type()},

--- a/cpp/src/groupby/hash/hash_compound_agg_finalizer.hpp
+++ b/cpp/src/groupby/hash/hash_compound_agg_finalizer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -19,13 +19,13 @@ struct hash_compound_agg_finalizer {
   data_type const input_type;
   cudf::detail::result_cache* const cache;
   bitmask_type const* const d_row_bitmask;
-  rmm::cuda_stream_view const stream;
+  cuda::stream_ref const stream;
   rmm::device_async_resource_ref const mr;
 
   hash_compound_agg_finalizer(column_view const& col,
                               cudf::detail::result_cache* cache,
                               bitmask_type const* d_row_bitmask,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
   // Default case: no-op

--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -17,12 +17,12 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 
@@ -48,11 +48,11 @@ namespace {
  */
 struct result_column_creator {
   size_type output_size;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   explicit result_column_creator(size_type output_size_,
-                                 rmm::cuda_stream_view stream_,
+                                 cuda::stream_ref stream_,
                                  rmm::device_async_resource_ref mr_)
     : output_size{output_size_}, stream{stream_}, mr{mr_}
   {
@@ -116,7 +116,7 @@ std::unique_ptr<table> create_results_table(size_type output_size,
                                             table_view const& values,
                                             host_span<aggregation::Kind const> agg_kinds,
                                             std::span<int8_t const> is_agg_intermediate,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.num_columns() == static_cast<size_type>(agg_kinds.size()),
@@ -139,11 +139,11 @@ std::unique_ptr<table> create_results_table(size_type output_size,
 template <typename SetType>
 rmm::device_uvector<size_type> extract_populated_keys(SetType const& key_set,
                                                       size_type num_total_keys,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<size_type> unique_key_indices(num_total_keys, stream, mr);
-  auto const keys_end = key_set.retrieve_all(unique_key_indices.begin(), stream.value());
+  auto const keys_end = key_set.retrieve_all(unique_key_indices.begin(), stream.get());
   unique_key_indices.resize(std::distance(unique_key_indices.begin(), keys_end), stream);
   return unique_key_indices;
 }
@@ -151,19 +151,19 @@ rmm::device_uvector<size_type> extract_populated_keys(SetType const& key_set,
 template rmm::device_uvector<size_type> extract_populated_keys<global_set_t>(
   global_set_t const& key_set,
   size_type num_total_keys,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template rmm::device_uvector<size_type> extract_populated_keys<nullable_global_set_t>(
   nullable_global_set_t const& key_set,
   size_type num_total_keys,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 rmm::device_uvector<size_type> compute_key_transform_map(
   size_type num_total_keys,
   device_span<size_type const> unique_key_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Map from old key indices (index of the keys in the original input keys table) to new key
@@ -181,7 +181,7 @@ rmm::device_uvector<size_type> compute_key_transform_map(
 
 rmm::device_uvector<size_type> compute_target_indices(device_span<size_type const> input,
                                                       device_span<size_type const> transform_map,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<size_type> target_indices(input.size(), stream, mr);
@@ -199,7 +199,7 @@ void finalize_output(table_view const& values,
                      std::vector<std::unique_ptr<aggregation>> const& aggregations,
                      std::unique_ptr<table>& agg_results,
                      cudf::detail::result_cache* cache,
-                     rmm::cuda_stream_view stream)
+                     cuda::stream_ref stream)
 {
   auto result_cols       = agg_results->release();
   auto const null_counts = [&]() -> std::vector<size_type> {

--- a/cpp/src/groupby/hash/output_utils.hpp
+++ b/cpp/src/groupby/hash/output_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,8 +12,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <memory>
@@ -42,7 +43,7 @@ std::unique_ptr<table> create_results_table(size_type output_size,
                                             table_view const& values,
                                             host_span<aggregation::Kind const> agg_kinds,
                                             std::span<int8_t const> is_agg_intermediate,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
 /**
@@ -59,7 +60,7 @@ std::unique_ptr<table> create_results_table(size_type output_size,
 template <typename SetType>
 rmm::device_uvector<size_type> extract_populated_keys(SetType const& key_set,
                                                       size_type num_total_keys,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -78,7 +79,7 @@ rmm::device_uvector<size_type> extract_populated_keys(SetType const& key_set,
 rmm::device_uvector<size_type> compute_key_transform_map(
   size_type num_total_keys,
   device_span<size_type const> unique_key_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -96,7 +97,7 @@ rmm::device_uvector<size_type> compute_key_transform_map(
  */
 rmm::device_uvector<size_type> compute_target_indices(device_span<size_type const> input,
                                                       device_span<size_type const> transform_map,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -113,6 +114,6 @@ void finalize_output(table_view const& values,
                      std::vector<std::unique_ptr<aggregation>> const& aggregations,
                      std::unique_ptr<table>& agg_results,
                      cudf::detail::result_cache* cache,
-                     rmm::cuda_stream_view stream);
+                     cuda::stream_ref stream);
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -26,7 +26,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <unordered_map>
@@ -47,7 +47,7 @@ namespace {
  */
 auto column_view_with_common_nulls(column_view const& column_0,
                                    column_view const& column_1,
-                                   rmm::cuda_stream_view stream)
+                                   cuda::stream_ref stream)
 {
   auto [new_nullmask, null_count] = cudf::bitmask_and(
     table_view{{column_0, column_1}}, stream, cudf::get_current_device_resource_ref());
@@ -878,7 +878,7 @@ void aggregate_result_functor::operator()<aggregation::HOST_UDF>(aggregation con
 // Sort-based groupby
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::sort_aggregate(
   std::span<aggregation_request const> requests,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // We're going to start by creating a cache of results so that aggs that

--- a/cpp/src/groupby/sort/functors.hpp
+++ b/cpp/src/groupby/sort/functors.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -31,7 +31,7 @@ struct store_result_functor {
   store_result_functor(column_view const& values,
                        sort::sort_groupby_helper& helper,
                        cudf::detail::result_cache& cache,
-                       rmm::cuda_stream_view stream,
+                       cuda::stream_ref stream,
                        rmm::device_async_resource_ref mr,
                        sorted keys_are_sorted = sorted::NO)
     : helper(helper),
@@ -88,7 +88,7 @@ struct store_result_functor {
   cudf::detail::result_cache& cache;  ///< cache of results to store into
   column_view const& values;          ///< Column of values to group and aggregate
 
-  rmm::cuda_stream_view stream;       ///< CUDA stream on which to execute kernels
+  cuda::stream_ref stream;            ///< CUDA stream on which to execute kernels
   rmm::device_async_resource_ref mr;  ///< Memory resource to allocate space for results
 
   sorted keys_are_sorted;                  ///< Whether the keys are sorted

--- a/cpp/src/groupby/sort/group_argmax.cu
+++ b/cpp/src/groupby/sort/group_argmax.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,8 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream_ref>
 #include <thrust/gather.h>
 
 namespace cudf {
@@ -20,7 +19,7 @@ std::unique_ptr<column> group_argmax(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
                                      column_view const& key_sort_order,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   auto dispatch_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_argmin.cu
+++ b/cpp/src/groupby/sort/group_argmin.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,9 +9,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/gather.h>
 
 namespace cudf {
@@ -21,7 +21,7 @@ std::unique_ptr<column> group_argmin(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
                                      column_view const& key_sort_order,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   auto dispatch_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_bitwise.cu
+++ b/cpp/src/groupby/sort/group_bitwise.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,11 +14,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 
 namespace cudf::groupby::detail {
 
@@ -30,7 +30,7 @@ struct bitwise_group_reduction_functor {
                                      column_view const& values,
                                      device_span<size_type const> group_labels,
                                      size_type num_groups,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
 
   {
@@ -93,7 +93,7 @@ std::unique_ptr<column> group_bitwise(bitwise_op bit_op,
                                       column_view const& values,
                                       device_span<size_type const> group_labels,
                                       size_type num_groups,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   return cudf::type_dispatcher(values.type(),

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -12,9 +12,8 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
@@ -39,7 +38,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   column_view const& values,
   column_view const& offsets,
   size_type num_groups,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto values_device_view = column_device_view::create(values, stream);
@@ -80,7 +79,7 @@ std::unique_ptr<column> group_collect(column_view const& values,
                                       cudf::device_span<size_type const> group_offsets,
                                       size_type num_groups,
                                       null_policy null_handling,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   auto [child_column,

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -16,11 +16,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 #include <type_traits>
@@ -107,7 +107,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
                                          column_view const& mean_1,
                                          size_type min_periods,
                                          size_type ddof,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   using result_type = id_to_type<type_id::FLOAT64>;
@@ -169,7 +169,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
 std::unique_ptr<column> group_correlation(column_view const& covariance,
                                           column_view const& stddev_0,
                                           column_view const& stddev_1,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   using result_type = id_to_type<type_id::FLOAT64>;

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,11 +11,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/adjacent_difference.h>
 #include <thrust/iterator/transform_iterator.h>
 
@@ -25,7 +25,7 @@ namespace detail {
 std::unique_ptr<column> group_count_valid(column_view const& values,
                                           cudf::device_span<size_type const> group_labels,
                                           size_type num_groups,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_groups >= 0, "number of groups cannot be negative");
@@ -70,7 +70,7 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
 
 std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group_offsets,
                                         size_type num_groups,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_groups >= 0, "number of groups cannot be negative");

--- a/cpp/src/groupby/sort/group_count_scan.cu
+++ b/cpp/src/groupby/sort/group_count_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,10 +12,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 
 namespace cudf {
@@ -24,7 +24,7 @@ namespace detail {
 std::unique_ptr<column> count_scan(column_view const& values,
                                    null_policy nulls,
                                    cudf::device_span<size_type const> group_labels,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   std::unique_ptr<column> result = make_fixed_width_column(

--- a/cpp/src/groupby/sort/group_histogram.cu
+++ b/cpp/src/groupby/sort/group_histogram.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ std::unique_ptr<column> build_histogram(column_view const& values,
                                         cudf::device_span<size_type const> group_labels,
                                         std::optional<column_view> const& partial_counts,
                                         size_type num_groups,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(static_cast<size_t>(values.size()) == group_labels.size(),
@@ -77,7 +77,7 @@ std::unique_ptr<column> build_histogram(column_view const& values,
 std::unique_ptr<column> group_histogram(column_view const& values,
                                         cudf::device_span<size_type const> group_labels,
                                         size_type num_groups,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   // Empty group should be handled before reaching here.
@@ -89,7 +89,7 @@ std::unique_ptr<column> group_histogram(column_view const& values,
 std::unique_ptr<column> group_merge_histogram(column_view const& values,
                                               cudf::device_span<size_type const> group_offsets,
                                               size_type num_groups,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   // Empty group should be handled before reaching here.

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,11 +15,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -52,7 +52,7 @@ void compute_m2_fn(column_device_view const& values,
                    cudf::device_span<size_type const> group_labels,
                    ResultType const* d_means,
                    ResultType* d_result,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
 {
   auto m2_fn = m2_transform<ResultType, decltype(values_iter)>{
     values, values_iter, d_means, group_labels.data()};
@@ -81,7 +81,7 @@ struct m2_functor {
   std::unique_ptr<column> operator()(column_view const& values,
                                      column_view const& group_means,
                                      cudf::device_span<size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<T>)
   {
@@ -122,7 +122,7 @@ struct m2_functor {
 std::unique_ptr<column> group_m2(column_view const& values,
                                  column_view const& group_means,
                                  cudf::device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_max.cu
+++ b/cpp/src/groupby/sort/group_max.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> group_max(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_max_scan.cu
+++ b/cpp/src/groupby/sort/group_max_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> max_scan(column_view const& values,
                                  size_type num_groups,
                                  cudf::device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(values.type(),

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,9 +8,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/gather.h>
 
 namespace cudf {
@@ -19,7 +19,7 @@ namespace detail {
 std::unique_ptr<column> group_merge_lists(column_view const& values,
                                           cudf::device_span<size_type const> group_offsets,
                                           size_type num_groups,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.type().id() == type_id::LIST,

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -8,11 +8,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -75,7 +75,7 @@ template <typename count_type>
 std::unique_ptr<column> merge_m2(column_view const& values,
                                  device_span<size_type const> group_offsets,
                                  size_type num_groups,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   auto result_counts = make_numeric_column(
@@ -119,7 +119,7 @@ std::unique_ptr<column> merge_m2(column_view const& values,
 std::unique_ptr<column> group_merge_m2(column_view const& values,
                                        device_span<size_type const> group_offsets,
                                        size_type num_groups,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.type().id() == type_id::STRUCT,

--- a/cpp/src/groupby/sort/group_min.cu
+++ b/cpp/src/groupby/sort/group_min.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> group_min(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_min_scan.cu
+++ b/cpp/src/groupby/sort/group_min_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> min_scan(column_view const& values,
                                  size_type num_groups,
                                  cudf::device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(values.type(),

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,11 +15,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/scatter.h>
@@ -36,7 +36,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
                                           size_type num_groups,
                                           size_type n,
                                           null_policy null_handling,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(static_cast<size_t>(values.size()) == group_labels.size(),

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,10 +11,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 namespace cudf {
@@ -66,7 +66,7 @@ std::unique_ptr<column> group_nunique(column_view const& values,
                                       size_type const num_groups,
                                       cudf::device_span<size_type const> group_offsets,
                                       null_policy null_handling,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_groups >= 0, "number of groups cannot be negative");

--- a/cpp/src/groupby/sort/group_product.cu
+++ b/cpp/src/groupby/sort/group_product.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -17,7 +17,7 @@ namespace detail {
 std::unique_ptr<column> group_product(column_view const& values,
                                       size_type num_groups,
                                       cudf::device_span<size_type const> group_labels,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_product_scan.cu
+++ b/cpp/src/groupby/sort/group_product_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> product_scan(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(values.type(),

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,11 +17,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
@@ -79,7 +79,7 @@ struct quantiles_functor {
                                      size_type const num_groups,
                                      device_span<double const> quantile,
                                      interpolation interpolation,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<T>)
   {
@@ -152,7 +152,7 @@ std::unique_ptr<column> group_quantiles(column_view const& values,
                                         size_type const num_groups,
                                         std::vector<double> const& quantiles,
                                         interpolation interp,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto dv_quantiles = cudf::detail::make_device_uvector_async(

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
@@ -23,6 +22,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
@@ -90,7 +90,7 @@ std::unique_ptr<column> rank_generator(column_view const& grouped_values,
                                        value_resolver resolver,
                                        scan_operator scan_op,
                                        bool has_nulls,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto const grouped_values_view = table_view{{grouped_values}};
@@ -146,7 +146,7 @@ std::unique_ptr<column> min_rank_scan(column_view const& grouped_values,
                                       column_view const& value_order,
                                       device_span<size_type const> group_labels,
                                       device_span<size_type const> group_offsets,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   return rank_generator<true>(
@@ -167,7 +167,7 @@ std::unique_ptr<column> max_rank_scan(column_view const& grouped_values,
                                       column_view const& value_order,
                                       device_span<size_type const> group_labels,
                                       device_span<size_type const> group_offsets,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   return rank_generator<false>(
@@ -188,7 +188,7 @@ std::unique_ptr<column> first_rank_scan(column_view const& grouped_values,
                                         column_view const&,
                                         device_span<size_type const> group_labels,
                                         device_span<size_type const> group_offsets,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto ranks = make_fixed_width_column(
@@ -210,7 +210,7 @@ std::unique_ptr<column> average_rank_scan(column_view const& grouped_values,
                                           column_view const& value_order,
                                           device_span<size_type const> group_labels,
                                           device_span<size_type const> group_offsets,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   auto max_rank = max_rank_scan(grouped_values,
@@ -243,7 +243,7 @@ std::unique_ptr<column> dense_rank_scan(column_view const& grouped_values,
                                         column_view const& value_order,
                                         device_span<size_type const> group_labels,
                                         device_span<size_type const> group_offsets,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   return rank_generator<true>(
@@ -264,7 +264,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
                                                  column_view const& count,
                                                  device_span<size_type const> group_labels,
                                                  device_span<size_type const> group_offsets,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(percentage != rank_percentage::NONE, "Percentage cannot be NONE");

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -41,7 +41,7 @@ namespace detail {
 std::unique_ptr<column> group_sum(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -61,7 +61,7 @@ std::unique_ptr<column> group_sum(column_view const& values,
   column_view const& values,
   size_type num_groups,
   cudf::device_span<size_type const> group_labels,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -84,7 +84,7 @@ std::unique_ptr<column> group_sum(column_view const& values,
 std::unique_ptr<column> group_product(column_view const& values,
                                       size_type num_groups,
                                       cudf::device_span<size_type const> group_labels,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -107,7 +107,7 @@ std::unique_ptr<column> group_product(column_view const& values,
 std::unique_ptr<column> group_min(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -130,7 +130,7 @@ std::unique_ptr<column> group_min(column_view const& values,
 std::unique_ptr<column> group_max(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -155,7 +155,7 @@ std::unique_ptr<column> group_argmax(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
                                      column_view const& key_sort_order,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -180,7 +180,7 @@ std::unique_ptr<column> group_argmin(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
                                      column_view const& key_sort_order,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -204,7 +204,7 @@ std::unique_ptr<column> group_argmin(column_view const& values,
 std::unique_ptr<column> group_count_valid(column_view const& values,
                                           cudf::device_span<size_type const> group_labels,
                                           size_type num_groups,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -224,7 +224,7 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
  */
 std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group_offsets,
                                         size_type num_groups,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 /**
  * @brief Internal API to compute histogram for each group in @p values.
@@ -251,7 +251,7 @@ std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group
 std::unique_ptr<column> group_histogram(column_view const& values,
                                         cudf::device_span<size_type const> group_labels,
                                         size_type num_groups,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -275,7 +275,7 @@ std::unique_ptr<column> group_histogram(column_view const& values,
 std::unique_ptr<column> group_m2(column_view const& values,
                                  column_view const& group_means,
                                  cudf::device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -305,7 +305,7 @@ std::unique_ptr<column> group_var(column_view const& values,
                                   column_view const& group_sizes,
                                   cudf::device_span<size_type const> group_labels,
                                   size_type ddof,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr);
 
 /**
@@ -336,7 +336,7 @@ std::unique_ptr<column> group_quantiles(column_view const& values,
                                         size_type const num_groups,
                                         std::vector<double> const& quantiles,
                                         interpolation interp,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -368,7 +368,7 @@ std::unique_ptr<column> group_nunique(column_view const& values,
                                       size_type const num_groups,
                                       cudf::device_span<size_type const> group_offsets,
                                       null_policy null_handling,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -403,7 +403,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
                                           size_type num_groups,
                                           size_type n,
                                           null_policy null_handling,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 /**
  * @brief Internal API to collect grouped values into a lists column
@@ -428,7 +428,7 @@ std::unique_ptr<column> group_collect(column_view const& values,
                                       cudf::device_span<size_type const> group_offsets,
                                       size_type num_groups,
                                       null_policy null_handling,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -451,7 +451,7 @@ std::unique_ptr<column> group_collect(column_view const& values,
 std::unique_ptr<column> group_merge_lists(column_view const& values,
                                           cudf::device_span<size_type const> group_offsets,
                                           size_type num_groups,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -477,7 +477,7 @@ std::unique_ptr<column> group_merge_lists(column_view const& values,
 std::unique_ptr<column> group_merge_m2(column_view const& values,
                                        cudf::device_span<size_type const> group_offsets,
                                        size_type num_groups,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -504,7 +504,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
 std::unique_ptr<column> group_merge_histogram(column_view const& values,
                                               cudf::device_span<size_type const> group_offsets,
                                               size_type num_groups,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr);
 
 /**
@@ -531,7 +531,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
                                          column_view const& mean_1,
                                          size_type min_periods,
                                          size_type ddof,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
@@ -546,7 +546,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
 std::unique_ptr<column> group_correlation(column_view const& covariance,
                                           column_view const& stddev_0,
                                           column_view const& stddev_1,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -563,7 +563,7 @@ std::unique_ptr<column> group_bitwise(bitwise_op bit_op,
                                       column_view const& grouped_values,
                                       device_span<size_type const> group_labels,
                                       size_type num_groups,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -580,7 +580,7 @@ std::unique_ptr<column> group_top_k(size_type k,
                                     order topk_order,
                                     column_view const& values,
                                     device_span<size_type const> group_offsets,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr);
 }  // namespace detail
 }  // namespace groupby

--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/column/column_device_view.cuh>
@@ -26,7 +26,7 @@ namespace detail {
 std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_value,
                                             device_span<size_type const> group_labels,
                                             cudf::replace_policy replace_policy,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   cudf::size_type size = grouped_value.size();

--- a/cpp/src/groupby/sort/group_scan.hpp
+++ b/cpp/src/groupby/sort/group_scan.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -29,7 +29,7 @@ namespace detail {
 std::unique_ptr<column> sum_scan(column_view const& values,
                                  size_type num_groups,
                                  device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -46,7 +46,7 @@ std::unique_ptr<column> sum_scan(column_view const& values,
 std::unique_ptr<column> product_scan(column_view const& values,
                                      size_type num_groups,
                                      device_span<size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 /**
@@ -61,7 +61,7 @@ std::unique_ptr<column> product_scan(column_view const& values,
 std::unique_ptr<column> min_scan(column_view const& values,
                                  size_type num_groups,
                                  device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -76,7 +76,7 @@ std::unique_ptr<column> min_scan(column_view const& values,
 std::unique_ptr<column> max_scan(column_view const& values,
                                  size_type num_groups,
                                  device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
 /**
@@ -92,7 +92,7 @@ std::unique_ptr<column> max_scan(column_view const& values,
 std::unique_ptr<column> count_scan(column_view const& values,
                                    null_policy nulls,
                                    device_span<size_type const> group_labels,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -111,7 +111,7 @@ std::unique_ptr<column> min_rank_scan(column_view const& grouped_values,
                                       column_view const& value_order,
                                       device_span<size_type const> group_labels,
                                       device_span<size_type const> group_offsets,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -121,14 +121,14 @@ std::unique_ptr<column> min_rank_scan(column_view const& grouped_values,
  *                                      column_view const& value_order,
  *                                      device_span<size_type const> group_labels,
  *                                      device_span<size_type const> group_offsets,
- *                                      rmm::cuda_stream_view stream,
+ *                                      cuda::stream_ref stream,
  *                                      rmm::device_async_resource_ref mr)
  */
 std::unique_ptr<column> max_rank_scan(column_view const& grouped_values,
                                       column_view const& value_order,
                                       device_span<size_type const> group_labels,
                                       device_span<size_type const> group_offsets,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr);
 
 /**
@@ -138,14 +138,14 @@ std::unique_ptr<column> max_rank_scan(column_view const& grouped_values,
  *                                      column_view const& value_order,
  *                                      device_span<size_type const> group_labels,
  *                                      device_span<size_type const> group_offsets,
- *                                      rmm::cuda_stream_view stream,
+ *                                      cuda::stream_ref stream,
  *                                      rmm::device_async_resource_ref mr)
  */
 std::unique_ptr<column> first_rank_scan(column_view const& grouped_values,
                                         column_view const& value_order,
                                         device_span<size_type const> group_labels,
                                         device_span<size_type const> group_offsets,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -155,14 +155,14 @@ std::unique_ptr<column> first_rank_scan(column_view const& grouped_values,
  *                                      column_view const& value_order,
  *                                      device_span<size_type const> group_labels,
  *                                      device_span<size_type const> group_offsets,
- *                                      rmm::cuda_stream_view stream,
+ *                                      cuda::stream_ref stream,
  *                                      rmm::device_async_resource_ref mr)
  */
 std::unique_ptr<column> average_rank_scan(column_view const& grouped_values,
                                           column_view const& value_order,
                                           device_span<size_type const> group_labels,
                                           device_span<size_type const> group_offsets,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr);
 
 /**
@@ -180,7 +180,7 @@ std::unique_ptr<column> dense_rank_scan(column_view const& grouped_values,
                                         column_view const& value_order,
                                         device_span<size_type const> group_labels,
                                         device_span<size_type const> group_offsets,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr);
 
 /**
@@ -203,7 +203,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
                                                  column_view const& count,
                                                  device_span<size_type const> group_labels,
                                                  device_span<size_type const> group_offsets,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,12 +22,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 
@@ -50,7 +50,7 @@ struct group_scan_dispatcher {
   std::unique_ptr<column> operator()(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<cudf::size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return group_scan_functor<K, T>::invoke(values, num_groups, group_labels, stream, mr);
@@ -79,7 +79,7 @@ struct group_scan_functor<K, T, std::enable_if_t<is_group_scan_supported<K, T>()
   static std::unique_ptr<column> invoke(column_view const& values,
                                         size_type num_groups,
                                         cudf::device_span<cudf::size_type const> group_labels,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     using DeviceType       = device_storage_type_t<T>;
@@ -139,7 +139,7 @@ struct group_scan_functor<K,
   static std::unique_ptr<column> invoke(column_view const& values,
                                         size_type num_groups,
                                         cudf::device_span<cudf::size_type const> group_labels,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     using OpType = cudf::detail::corresponding_operator_t<K>;
@@ -186,7 +186,7 @@ struct group_scan_functor<K,
   static std::unique_ptr<column> invoke(column_view const& values,
                                         size_type num_groups,
                                         cudf::device_span<cudf::size_type const> group_labels,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     if (values.is_empty()) { return cudf::empty_like(values); }

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,11 +19,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/reduce.h>
 
 namespace cudf {
@@ -105,7 +105,7 @@ struct group_reduction_dispatcher {
   std::unique_ptr<column> operator()(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<cudf::size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return group_reduction_functor<K, T>::invoke(values, num_groups, group_labels, stream, mr);
@@ -138,7 +138,7 @@ struct group_reduction_functor<
   static std::unique_ptr<column> invoke(column_view const& values,
                                         size_type num_groups,
                                         cudf::device_span<cudf::size_type const> group_labels,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     using SourceDType = device_storage_type_t<T>;
@@ -207,7 +207,7 @@ struct group_reduction_functor<
   static std::unique_ptr<column> invoke(column_view const& values,
                                         size_type num_groups,
                                         cudf::device_span<cudf::size_type const> group_labels,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     // This is be expected to be size_type.

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,11 +17,11 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
@@ -65,7 +65,7 @@ void reduce_by_key_fn(column_device_view const& values,
                       size_type const* d_group_sizes,
                       size_type ddof,
                       ResultType* d_result,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   auto var_fn = var_transform<ResultType, decltype(values_iter)>{
     values, values_iter, d_means, d_group_sizes, group_labels.data(), ddof};
@@ -96,7 +96,7 @@ struct var_functor {
                                      column_view const& group_sizes,
                                      cudf::device_span<size_type const> group_labels,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<T>)
   {
@@ -169,7 +169,7 @@ std::unique_ptr<column> group_var(column_view const& values,
                                   column_view const& group_sizes,
                                   cudf::device_span<size_type const> group_labels,
                                   size_type ddof,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_sum.cu
+++ b/cpp/src/groupby/sort/group_sum.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -17,7 +17,7 @@ namespace detail {
 std::unique_ptr<column> group_sum(column_view const& values,
                                   size_type num_groups,
                                   cudf::device_span<size_type const> group_labels,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto values_type = cudf::is_dictionary(values.type())

--- a/cpp/src/groupby/sort/group_sum_overflow.cu
+++ b/cpp/src/groupby/sort/group_sum_overflow.cu
@@ -17,13 +17,13 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/reduce.h>
 
 #include <memory>
@@ -49,7 +49,7 @@ struct group_sum_overflow_fn {
   std::unique_ptr<column> operator()(column_view const& values,
                                      size_type num_groups,
                                      cudf::device_span<size_type const> group_labels,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     using DeviceType = cudf::device_storage_type_t<Source>;
@@ -117,7 +117,7 @@ struct group_sum_overflow_fn {
 std::unique_ptr<column> group_sum_overflow(column_view const& values,
                                            size_type num_groups,
                                            cudf::device_span<size_type const> group_labels,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return cudf::type_dispatcher(

--- a/cpp/src/groupby/sort/group_sum_scan.cu
+++ b/cpp/src/groupby/sort/group_sum_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace groupby {
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<column> sum_scan(column_view const& values,
                                  size_type num_groups,
                                  cudf::device_span<size_type const> group_labels,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(values.type(),

--- a/cpp/src/groupby/sort/group_topk.cu
+++ b/cpp/src/groupby/sort/group_topk.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -21,7 +21,7 @@ std::unique_ptr<column> group_top_k(size_type k,
                                     order topk_order,
                                     column_view const& values,
                                     cudf::device_span<size_type const> group_offsets,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   return cudf::detail::segmented_top_k(values, group_offsets, k, topk_order, stream, mr);

--- a/cpp/src/groupby/sort/scan.cpp
+++ b/cpp/src/groupby/sort/scan.cpp
@@ -24,7 +24,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -213,7 +213,7 @@ void scan_result_functor::operator()<aggregation::RANK>(aggregation const& agg)
 // Sort-based groupby
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::sort_scan(
   std::span<scan_request const> requests,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // We're going to start by creating a cache of results so that aggs that

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -20,10 +20,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 #include <algorithm>
@@ -54,7 +54,7 @@ sort_groupby_helper::sort_groupby_helper(table_view const& keys,
   }
 };
 
-size_type sort_groupby_helper::num_keys(rmm::cuda_stream_view stream)
+size_type sort_groupby_helper::num_keys(cuda::stream_ref stream)
 {
   if (_num_keys > -1) return _num_keys;
 
@@ -70,7 +70,7 @@ size_type sort_groupby_helper::num_keys(rmm::cuda_stream_view stream)
   return _num_keys;
 }
 
-column_view sort_groupby_helper::key_sort_order(rmm::cuda_stream_view stream)
+column_view sort_groupby_helper::key_sort_order(cuda::stream_ref stream)
 {
   auto sliced_key_sorted_order = [stream, this]() {
     return cudf::detail::slice(this->_key_sorted_order->view(), 0, this->num_keys(stream), stream);
@@ -117,8 +117,7 @@ column_view sort_groupby_helper::key_sort_order(rmm::cuda_stream_view stream)
   return sliced_key_sorted_order();
 }
 
-sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(
-  rmm::cuda_stream_view stream)
+sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(cuda::stream_ref stream)
 {
   if (_group_offsets) return *_group_offsets;
 
@@ -142,8 +141,7 @@ sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(
   return *_group_offsets;
 }
 
-sort_groupby_helper::index_vector const& sort_groupby_helper::group_labels(
-  rmm::cuda_stream_view stream)
+sort_groupby_helper::index_vector const& sort_groupby_helper::group_labels(cuda::stream_ref stream)
 {
   if (_group_labels) return *_group_labels;
 
@@ -161,7 +159,7 @@ sort_groupby_helper::index_vector const& sort_groupby_helper::group_labels(
   return *_group_labels;
 }
 
-column_view sort_groupby_helper::unsorted_keys_labels(rmm::cuda_stream_view stream)
+column_view sort_groupby_helper::unsorted_keys_labels(cuda::stream_ref stream)
 {
   if (_unsorted_keys_labels) return _unsorted_keys_labels->view();
 
@@ -191,7 +189,7 @@ column_view sort_groupby_helper::unsorted_keys_labels(rmm::cuda_stream_view stre
   return _unsorted_keys_labels->view();
 }
 
-column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view stream)
+column_view sort_groupby_helper::keys_bitmask_column(cuda::stream_ref stream)
 {
   if (_keys_bitmask_column) return _keys_bitmask_column->view();
 
@@ -211,7 +209,7 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
 }
 
 sort_groupby_helper::column_ptr sort_groupby_helper::sorted_values(
-  column_view const& values, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& values, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   column_ptr values_sort_order =
     cudf::detail::stable_sorted_order(table_view({unsorted_keys_labels(stream), values}),
@@ -235,7 +233,7 @@ sort_groupby_helper::column_ptr sort_groupby_helper::sorted_values(
 }
 
 sort_groupby_helper::column_ptr sort_groupby_helper::grouped_values(
-  column_view const& values, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& values, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto gather_map = key_sort_order(stream);
 
@@ -249,7 +247,7 @@ sort_groupby_helper::column_ptr sort_groupby_helper::grouped_values(
   return std::move(grouped_values_table->release()[0]);
 }
 
-std::unique_ptr<table> sort_groupby_helper::unique_keys(rmm::cuda_stream_view stream,
+std::unique_ptr<table> sort_groupby_helper::unique_keys(cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   auto const num_unique_keys = num_groups(stream);
@@ -269,7 +267,7 @@ std::unique_ptr<table> sort_groupby_helper::unique_keys(rmm::cuda_stream_view st
                               mr);
 }
 
-std::unique_ptr<table> sort_groupby_helper::sorted_keys(rmm::cuda_stream_view stream,
+std::unique_ptr<table> sort_groupby_helper::sorted_keys(cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   return cudf::detail::gather(_keys,

--- a/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
+++ b/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
@@ -14,13 +14,13 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf::groupby::detail::sort {
@@ -29,14 +29,14 @@ size_type compute_nested_group_offsets(table_view const& keys,
                                        size_type const* sorted_order,
                                        size_type size,
                                        rmm::device_uvector<size_type>& group_offsets,
-                                       rmm::cuda_stream_view stream);
+                                       cuda::stream_ref stream);
 
 template <bool HasNested>
 size_type compute_group_offsets(table_view const& keys,
                                 size_type const* sorted_order,
                                 size_type size,
                                 rmm::device_uvector<size_type>& group_offsets,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   auto const comparator  = cudf::detail::row::equality::self_comparator{keys, stream};
   auto const d_key_equal = comparator.equal_to<HasNested>(

--- a/cpp/src/groupby/sort/sort_helper_nested.cu
+++ b/cpp/src/groupby/sort/sort_helper_nested.cu
@@ -11,7 +11,7 @@ size_type compute_nested_group_offsets(table_view const& keys,
                                        size_type const* sorted_order,
                                        size_type size,
                                        rmm::device_uvector<size_type>& group_offsets,
-                                       rmm::cuda_stream_view stream)
+                                       cuda::stream_ref stream)
 {
   return compute_group_offsets<true>(keys, sorted_order, size, group_offsets, stream);
 }

--- a/cpp/src/groupby/streaming_groupby.cpp
+++ b/cpp/src/groupby/streaming_groupby.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -18,20 +18,20 @@
 
 namespace cudf::groupby {
 
-void streaming_groupby::aggregate(table_view const& data, rmm::cuda_stream_view stream)
+void streaming_groupby::aggregate(table_view const& data, cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   do_aggregate(data, stream);
 }
 
-void streaming_groupby::merge(streaming_groupby const& other, rmm::cuda_stream_view stream)
+void streaming_groupby::merge(streaming_groupby const& other, cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   do_merge(other, stream);
 }
 
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> streaming_groupby::finalize(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
   return do_finalize(stream, mr);

--- a/cpp/src/groupby/streaming_groupby/aggregate.cu
+++ b/cpp/src/groupby/streaming_groupby/aggregate.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,10 +10,10 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 #include <limits>
@@ -21,7 +21,7 @@
 
 namespace cudf::groupby {
 
-void streaming_groupby::impl::do_aggregate(table_view const& data, rmm::cuda_stream_view stream)
+void streaming_groupby::impl::do_aggregate(table_view const& data, cuda::stream_ref stream)
 {
   CUDF_EXPECTS(!_invalidated,
                "streaming_groupby is in an invalidated state from a prior failure; "

--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -19,12 +19,12 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/std/functional>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <vector>
@@ -220,7 +220,7 @@ auto build_cross_comparators(
   std::vector<std::shared_ptr<cudf::detail::row::equality::preprocessed_table>> const&
     preprocessed_batches,
   cudf::nullate::DYNAMIC has_null,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   using eq_t = cudf::detail::row::equality::device_row_comparator<
     has_nested_columns,
@@ -309,8 +309,8 @@ struct streaming_groupby::impl {
        null_policy null_handling,
        cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
-  void initialize(table_view const& data, rmm::cuda_stream_view stream);
-  void create_key_set(rmm::cuda_stream_view stream);
+  void initialize(table_view const& data, cuda::stream_ref stream);
+  void create_key_set(cuda::stream_ref stream);
   void update_nullable_state(table_view const& batch_keys);
 
   struct batch_insert_result {
@@ -319,15 +319,14 @@ struct streaming_groupby::impl {
     rmm::device_buffer bitmask_buffer;
   };
 
-  batch_insert_result probe_and_insert(table_view const& batch_keys, rmm::cuda_stream_view stream);
+  batch_insert_result probe_and_insert(table_view const& batch_keys, cuda::stream_ref stream);
 
   /*
    * Template implementation of probe_and_insert, split by has_nested.
    * Defined in insert.cuh, instantiated in insert.cu and insert_nested.cu.
    */
   template <bool has_nested>
-  batch_insert_result probe_and_insert_impl(table_view const& batch_keys,
-                                            rmm::cuda_stream_view stream);
+  batch_insert_result probe_and_insert_impl(table_view const& batch_keys, cuda::stream_ref stream);
 
   /*
    * Two helpers split off probe_and_insert_impl for compile-time parallelism.
@@ -348,7 +347,7 @@ struct streaming_groupby::impl {
     size_type* target_indices,
     size_type* slot_offsets,
     size_type* batch_local_indices,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
   template <bool has_nested>
   size_type probe_and_insert_subsequent(
@@ -360,19 +359,19 @@ struct streaming_groupby::impl {
     size_type* target_indices,
     size_type* slot_offsets,
     size_type* batch_local_indices,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
-  void do_aggregate(table_view const& data, rmm::cuda_stream_view stream);
+  void do_aggregate(table_view const& data, cuda::stream_ref stream);
 
-  [[nodiscard]] std::unique_ptr<table> gather_agg_results(rmm::cuda_stream_view stream,
+  [[nodiscard]] std::unique_ptr<table> gather_agg_results(cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr) const;
   [[nodiscard]] std::unique_ptr<table> gather_distinct_keys(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const;
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
   [[nodiscard]] std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> do_finalize(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const;
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
-  void do_merge(impl const& other, rmm::cuda_stream_view stream);
+  void do_merge(impl const& other, cuda::stream_ref stream);
 };
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/impl.cu
+++ b/cpp/src/groupby/streaming_groupby/impl.cu
@@ -23,8 +23,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <memory>
@@ -104,7 +105,7 @@ streaming_groupby::impl::impl(host_span<size_type const> key_indices,
   }
 }
 
-void streaming_groupby::impl::initialize(table_view const& data, rmm::cuda_stream_view stream)
+void streaming_groupby::impl::initialize(table_view const& data, cuda::stream_ref stream)
 {
   auto const mr = cudf::get_current_device_resource_ref();
 
@@ -211,7 +212,7 @@ void streaming_groupby::impl::initialize(table_view const& data, rmm::cuda_strea
   _initialized = true;
 }
 
-void streaming_groupby::impl::create_key_set(rmm::cuda_stream_view stream)
+void streaming_groupby::impl::create_key_set(cuda::stream_ref stream)
 {
   _key_set = std::make_unique<streaming_set_t>(
     cuco::extent<int64_t>{static_cast<int64_t>(_max_distinct_keys)},
@@ -222,7 +223,7 @@ void streaming_groupby::impl::create_key_set(rmm::cuda_stream_view stream)
     cuco::thread_scope_device,
     cuco::storage<detail::hash::GROUPBY_BUCKET_SIZE>{},
     rmm::mr::polymorphic_allocator<char>{_mr},
-    stream.value());
+    stream.get());
 }
 
 void streaming_groupby::impl::update_nullable_state(table_view const& batch_keys)
@@ -237,7 +238,7 @@ void streaming_groupby::impl::update_nullable_state(table_view const& batch_keys
 }
 
 std::unique_ptr<table> streaming_groupby::impl::gather_agg_results(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   // The results we care about are dense in `[0, _distinct_keys)` and can be extracted by
   // slice+copy.
@@ -247,7 +248,7 @@ std::unique_ptr<table> streaming_groupby::impl::gather_agg_results(
 }
 
 std::unique_ptr<table> streaming_groupby::impl::gather_distinct_keys(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   if (_compacted_batches.empty()) {
     return std::make_unique<table>(_empty_key_schema->view(), stream, mr);
@@ -264,7 +265,7 @@ std::unique_ptr<table> streaming_groupby::impl::gather_distinct_keys(
 }
 
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>>
-streaming_groupby::impl::do_finalize(rmm::cuda_stream_view stream,
+streaming_groupby::impl::do_finalize(cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
 {
   CUDF_EXPECTS(_initialized, "Cannot finalize streaming_groupby with no accumulated data.");
@@ -333,7 +334,7 @@ streaming_groupby::impl::do_finalize(rmm::cuda_stream_view stream,
 }
 
 streaming_groupby::impl::batch_insert_result streaming_groupby::impl::probe_and_insert(
-  table_view const& batch_keys, rmm::cuda_stream_view stream)
+  table_view const& batch_keys, cuda::stream_ref stream)
 {
   if (_has_nested_keys) {
     return probe_and_insert_impl<true>(batch_keys, stream);
@@ -361,18 +362,18 @@ streaming_groupby& streaming_groupby::operator=(streaming_groupby&&) noexcept = 
 
 // Private member functions defined here (requires full impl definition).
 // The public API wrappers in streaming_groupby.cpp call these.
-void streaming_groupby::do_aggregate(table_view const& data, rmm::cuda_stream_view stream)
+void streaming_groupby::do_aggregate(table_view const& data, cuda::stream_ref stream)
 {
   _impl->do_aggregate(data, stream);
 }
 
-void streaming_groupby::do_merge(streaming_groupby const& other, rmm::cuda_stream_view stream)
+void streaming_groupby::do_merge(streaming_groupby const& other, cuda::stream_ref stream)
 {
   _impl->do_merge(*other._impl, stream);
 }
 
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> streaming_groupby::do_finalize(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->do_finalize(stream, mr);
 }

--- a/cpp/src/groupby/streaming_groupby/insert.cu
+++ b/cpp/src/groupby/streaming_groupby/insert.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,6 @@ namespace cudf::groupby {
 
 template streaming_groupby::impl::batch_insert_result
 streaming_groupby::impl::probe_and_insert_impl<false>(table_view const& batch_keys,
-                                                      rmm::cuda_stream_view stream);
+                                                      cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/insert.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,11 +13,11 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
 
@@ -27,7 +27,7 @@ namespace cudf::groupby {
 
 template <bool has_nested>
 streaming_groupby::impl::batch_insert_result streaming_groupby::impl::probe_and_insert_impl(
-  table_view const& batch_keys, rmm::cuda_stream_view stream)
+  table_view const& batch_keys, cuda::stream_ref stream)
 {
   auto const batch_size = batch_keys.num_rows();
   auto const temp_mr    = cudf::get_current_device_resource_ref();

--- a/cpp/src/groupby/streaming_groupby/insert_first.cu
+++ b/cpp/src/groupby/streaming_groupby/insert_first.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,6 @@ template size_type streaming_groupby::impl::probe_and_insert_first_batch<false>(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/insert_first.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert_first.cuh
@@ -11,11 +11,11 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 
 #include <cstddef>
@@ -50,7 +50,7 @@ size_type streaming_groupby::impl::probe_and_insert_first_batch(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const temp_mr        = cudf::get_current_device_resource_ref();
   auto const batch_self_cmp = cudf::detail::row::equality::self_comparator{preprocessed_batch};

--- a/cpp/src/groupby/streaming_groupby/insert_first_nested.cu
+++ b/cpp/src/groupby/streaming_groupby/insert_first_nested.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,6 @@ template size_type streaming_groupby::impl::probe_and_insert_first_batch<true>(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/insert_nested.cu
+++ b/cpp/src/groupby/streaming_groupby/insert_nested.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,6 @@ namespace cudf::groupby {
 
 template streaming_groupby::impl::batch_insert_result
 streaming_groupby::impl::probe_and_insert_impl<true>(table_view const& batch_keys,
-                                                     rmm::cuda_stream_view stream);
+                                                     cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/insert_subsequent.cu
+++ b/cpp/src/groupby/streaming_groupby/insert_subsequent.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,6 @@ template size_type streaming_groupby::impl::probe_and_insert_subsequent<false>(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/insert_subsequent.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert_subsequent.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,10 +9,10 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 
 namespace cudf::groupby {
@@ -27,7 +27,7 @@ size_type streaming_groupby::impl::probe_and_insert_subsequent(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const temp_mr        = cudf::get_current_device_resource_ref();
   auto const batch_self_cmp = cudf::detail::row::equality::self_comparator{preprocessed_batch};

--- a/cpp/src/groupby/streaming_groupby/insert_subsequent_nested.cu
+++ b/cpp/src/groupby/streaming_groupby/insert_subsequent_nested.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,6 @@ template size_type streaming_groupby::impl::probe_and_insert_subsequent<true>(
   size_type* target_indices,
   size_type* slot_offsets,
   size_type* batch_local_indices,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/merge.cu
+++ b/cpp/src/groupby/streaming_groupby/merge.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,10 +12,10 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 #include <string>
@@ -88,7 +88,7 @@ struct merge_single_pass_aggs_fn {
 
 }  // namespace
 
-void streaming_groupby::impl::do_merge(impl const& other, rmm::cuda_stream_view stream)
+void streaming_groupby::impl::do_merge(impl const& other, cuda::stream_ref stream)
 {
   CUDF_EXPECTS(!_invalidated,
                "streaming_groupby is in an invalidated state from a prior failure; "

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,7 +20,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 #include <vector>
@@ -37,7 +37,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
   ast::expression const& binary_predicate,
   join_kind join_type,
   std::optional<std::size_t> output_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (right.num_rows() == 0) {
@@ -79,12 +79,12 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
     cudf::detail::device_scalar<std::size_t> size(0, stream, mr);
     if (has_nulls) {
       compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, true>
-        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
           *left_table, *right_table, join_type, parser.device_expression_data, false, size.data());
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
       compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, false>
-        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
           *left_table, *right_table, join_type, parser.device_expression_data, false, size.data());
       CUDF_CUDA_TRY(cudaGetLastError());
     }
@@ -100,7 +100,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
 
   if (has_nulls) {
     conditional_join_anti_semi<DEFAULT_JOIN_BLOCK_SIZE, DEFAULT_CACHE_SIZE, true>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         join_type,
@@ -111,7 +111,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     conditional_join_anti_semi<DEFAULT_JOIN_BLOCK_SIZE, DEFAULT_CACHE_SIZE, false>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         join_type,
@@ -131,7 +131,7 @@ conditional_join(table_view const& left,
                  ast::expression const& binary_predicate,
                  join_kind join_type,
                  std::optional<std::size_t> output_size,
-                 rmm::cuda_stream_view stream,
+                 cuda::stream_ref stream,
                  rmm::device_async_resource_ref mr)
 {
   // We can immediately filter out cases where the right table is empty. In
@@ -201,7 +201,7 @@ conditional_join(table_view const& left,
     cudf::detail::device_scalar<std::size_t> size(0, stream, mr);
     if (has_nulls) {
       compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, true>
-        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
           *left_table,
           *right_table,
           kernel_join_type,
@@ -211,7 +211,7 @@ conditional_join(table_view const& left,
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
       compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, false>
-        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+        <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
           *left_table,
           *right_table,
           kernel_join_type,
@@ -245,7 +245,7 @@ conditional_join(table_view const& left,
 
   if (has_nulls) {
     conditional_join<DEFAULT_JOIN_BLOCK_SIZE, DEFAULT_CACHE_SIZE, true>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         kernel_join_type,
@@ -258,7 +258,7 @@ conditional_join(table_view const& left,
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     conditional_join<DEFAULT_JOIN_BLOCK_SIZE, DEFAULT_CACHE_SIZE, false>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         kernel_join_type,
@@ -286,7 +286,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
                                                  table_view const& right,
                                                  ast::expression const& binary_predicate,
                                                  join_kind join_type,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   // Until we add logic to handle the number of non-matches in the right table,
@@ -354,7 +354,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
   // find what the size of the output will be.
   if (has_nulls) {
     compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, true>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         join_type,
@@ -364,7 +364,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     compute_conditional_join_output_size<DEFAULT_JOIN_BLOCK_SIZE, false>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         *left_table,
         *right_table,
         join_type,
@@ -384,7 +384,7 @@ conditional_inner_join(table_view const& left,
                        table_view const& right,
                        ast::expression const& binary_predicate,
                        std::optional<std::size_t> output_size,
-                       rmm::cuda_stream_view stream,
+                       cuda::stream_ref stream,
                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -398,7 +398,7 @@ conditional_left_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
                       std::optional<std::size_t> output_size,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -411,7 +411,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 conditional_full_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -424,7 +424,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
   table_view const& right,
   ast::expression const& binary_predicate,
   std::optional<std::size_t> output_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -437,7 +437,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
   table_view const& right,
   ast::expression const& binary_predicate,
   std::optional<std::size_t> output_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -448,7 +448,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
 std::size_t conditional_inner_join_size(table_view const& left,
                                         table_view const& right,
                                         ast::expression const& binary_predicate,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -459,7 +459,7 @@ std::size_t conditional_inner_join_size(table_view const& left,
 std::size_t conditional_left_join_size(table_view const& left,
                                        table_view const& right,
                                        ast::expression const& binary_predicate,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -470,7 +470,7 @@ std::size_t conditional_left_join_size(table_view const& left,
 std::size_t conditional_left_semi_join_size(table_view const& left,
                                             table_view const& right,
                                             ast::expression const& binary_predicate,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -481,7 +481,7 @@ std::size_t conditional_left_semi_join_size(table_view const& left,
 std::size_t conditional_left_anti_join_size(table_view const& left,
                                             table_view const& right,
                                             ast::expression const& binary_predicate,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/conditional_join.hpp
+++ b/cpp/src/join/conditional_join.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 
@@ -40,7 +40,7 @@ conditional_join(table_view const& left,
                  ast::expression const& binary_predicate,
                  join_kind JoinKind,
                  std::optional<std::size_t> output_size,
-                 rmm::cuda_stream_view stream,
+                 cuda::stream_ref stream,
                  rmm::device_async_resource_ref mr);
 
 /**
@@ -61,7 +61,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
                                                  table_view const& right,
                                                  ast::expression const& binary_predicate,
                                                  join_kind JoinKind,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -17,7 +17,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <limits>
@@ -33,7 +33,7 @@ namespace detail {
  */
 std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
                                         cudf::table_view const& right,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   // If left or right table has no rows, return an empty table with all columns
@@ -72,7 +72,7 @@ std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
 
 std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
                                         cudf::table_view const& right,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/direct_join.cu
+++ b/cpp/src/join/direct_join.cu
@@ -12,13 +12,13 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cub/device/device_for.cuh>
 #include <cub/device/device_transform.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <memory>
@@ -71,7 +71,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 direct_inner_join(column_view const& left_keys,
                   column_view const& right_keys,
                   std::size_t capacity,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -94,11 +94,11 @@ direct_inner_join(column_view const& left_keys,
   auto lookup =
     rmm::device_uvector<size_type>(capacity, stream, cudf::get_current_device_resource_ref());
   CUDF_CUDA_TRY(
-    cub::DeviceTransform::Fill(lookup.begin(), lookup.size(), JoinNoMatch, stream.value()));
+    cub::DeviceTransform::Fill(lookup.begin(), lookup.size(), JoinNoMatch, stream.get()));
   CUDF_CUDA_TRY(
     cub::DeviceFor::Bulk(right_keys.size(),
                          scatter_right_index{lookup.data(), right_keys.begin<std::uint32_t>()},
-                         stream.value()));
+                         stream.get()));
 
   // Probe: a single pass emitting the (left index, matched right index) pairs
   auto left_indices =
@@ -130,7 +130,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 direct_inner_join(column_view const& left_keys,
                   column_view const& right_keys,
                   std::size_t capacity,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -18,7 +18,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 #include <rmm/resource_ref.hpp>
@@ -29,6 +28,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 #include <thrust/sequence.h>
 
@@ -119,14 +119,14 @@ void find_matches_in_hash_table(HashTableType const& hash_table,
                                 Hasher hasher,
                                 cudf::null_equality nulls_equal,
                                 FoundIterator found_begin,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   auto const left_table_num_rows = left.num_rows();
   // If `idx` is within the range `[0, left_table_num_rows)` and `found_indices[idx]` is not
   // equal to `cudf::JoinNoMatch`, then `idx` has a match in the hash set.
   if (nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(left))) {
     hash_table.find_async(
-      iter, iter + left_table_num_rows, d_equal, hasher, found_begin, stream.value());
+      iter, iter + left_table_num_rows, d_equal, hasher, found_begin, stream.get());
   } else {
     auto stencil = cuda::counting_iterator<size_type>{0};
     auto const row_bitmask =
@@ -134,14 +134,8 @@ void find_matches_in_hash_table(HashTableType const& hash_table,
     auto const pred =
       cudf::detail::row_is_valid{reinterpret_cast<bitmask_type const*>(row_bitmask.data())};
 
-    hash_table.find_if_async(iter,
-                             iter + left_table_num_rows,
-                             stencil,
-                             pred,
-                             d_equal,
-                             hasher,
-                             found_begin,
-                             stream.value());
+    hash_table.find_if_async(
+      iter, iter + left_table_num_rows, stencil, pred, d_equal, hasher, found_begin, stream.get());
   }
 }
 
@@ -149,7 +143,7 @@ void find_matches_in_hash_table(HashTableType const& hash_table,
 
 distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        cudf::null_equality compare_nulls,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : distinct_hash_join{right, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream, std::move(mr)}
 {
@@ -158,7 +152,7 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
 distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        cudf::null_equality compare_nulls,
                                        double load_factor,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _has_nested_columns{cudf::has_nested_columns(right)},
     _nulls_equal{compare_nulls},
@@ -173,7 +167,7 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                 cuco::thread_scope_device,
                 cuco_storage_type{},
                 rmm::mr::polymorphic_allocator<char>{std::move(mr)},
-                stream.value()}
+                stream.get()}
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(0 != this->_right.num_columns(), "Hash join right table is empty");
@@ -183,7 +177,7 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
 
   auto const build_hash_table = [&](auto iter) {
     if (this->_nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(right))) {
-      this->_hash_table.insert_async(iter, iter + right_table_num_rows, stream.value());
+      this->_hash_table.insert_async(iter, iter + right_table_num_rows, stream.get());
     } else {
       auto stencil = cuda::counting_iterator<size_type>{0};
       auto const row_bitmask =
@@ -193,7 +187,7 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
 
       // insert valid rows
       this->_hash_table.insert_if_async(
-        iter, iter + right_table_num_rows, stencil, pred, stream.value());
+        iter, iter + right_table_num_rows, stencil, pred, stream.get());
     }
   };
 
@@ -219,7 +213,7 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 distinct_hash_join::inner_join(cudf::table_view const& left,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"distinct_hash_join::inner_join"};
@@ -315,9 +309,7 @@ distinct_hash_join::inner_join(cudf::table_view const& left,
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"distinct_hash_join::left_join"};
 
@@ -402,7 +394,7 @@ distinct_hash_join::~distinct_hash_join() = default;
 distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        null_equality compare_nulls,
                                        double load_factor,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<impl_type>(right, compare_nulls, load_factor, stream, std::move(mr))}
 {
@@ -411,16 +403,14 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 distinct_hash_join::inner_join(cudf::table_view const& left,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr) const
 {
   return _impl->inner_join(left, stream, mr);
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->left_join(left, stream, mr);
 }

--- a/cpp/src/join/filter_join_indices/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices.cu
@@ -28,7 +28,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -39,6 +38,7 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
 
@@ -58,7 +58,7 @@ filter_join_indices(cudf::table_view const& left,
                     ast::expression const& predicate,
                     join_kind join_kind,
                     std::optional<std::size_t> output_size,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr)
 {
   // Validate inputs
@@ -218,7 +218,7 @@ filter_join_indices(cudf::table_view const& left,
                                    {},
                                    {},
                                    {},
-                                   stream.value()};
+                                   stream.get()};
 
     auto predicate_func = [predicate_results_ptr] __device__(std::size_t idx) -> bool {
       return static_cast<bool>(predicate_results_ptr[idx]);
@@ -228,7 +228,7 @@ filter_join_indices(cudf::table_view const& left,
                                        left_ptr + left_indices.size(),
                                        cuda::counting_iterator<std::size_t>{0},
                                        predicate_func,
-                                       stream.value());
+                                       stream.get());
 
     auto const num_invalid = left.num_rows() - num_filter_passing;
 
@@ -248,14 +248,14 @@ filter_join_indices(cudf::table_view const& left,
                              predicate_it,
                              d_num_valid.data(),
                              left_indices.size(),
-                             stream.value());
+                             stream.get());
       rmm::device_buffer temp_storage(temp_storage_bytes, stream);
       cub::DeviceReduce::Sum(temp_storage.data(),
                              temp_storage_bytes,
                              predicate_it,
                              d_num_valid.data(),
                              left_indices.size(),
-                             stream.value());
+                             stream.get());
       return d_num_valid.value(stream);
     }();
     auto const result_size = num_valid + num_invalid;
@@ -299,7 +299,7 @@ filter_join_indices(cudf::table_view const& left,
           stream);
       }
       cub::DeviceTransform::Fill(
-        filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.value());
+        filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.get());
     }
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
@@ -379,7 +379,7 @@ filter_join_indices_output_size(cudf::table_view const& left,
                                 cudf::device_span<size_type const> right_indices,
                                 ast::expression const& predicate,
                                 join_kind join_kind,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   // Validate inputs (same constraints as filter_join_indices)
@@ -471,7 +471,7 @@ filter_join_indices(cudf::table_view const& left,
                     ast::expression const& predicate,
                     cudf::join_kind join_kind,
                     std::optional<std::size_t> output_size,
-                    rmm::cuda_stream_view stream,
+                    cuda::stream_ref stream,
                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -486,7 +486,7 @@ filter_join_indices_output_size(cudf::table_view const& left,
                                 cudf::device_span<size_type const> right_indices,
                                 ast::expression const& predicate,
                                 cudf::join_kind join_kind,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
@@ -22,7 +22,6 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -31,6 +30,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 
 #include <jit/cache.hpp>
 #include <jit/helpers.hpp>
@@ -92,7 +92,7 @@ kernel build_join_filter_kernel(std::string const& predicate_code,
                                 bool is_ptx,
                                 bool has_user_data,
                                 bool is_null_aware,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -134,7 +134,7 @@ void launch_join_filter_kernel(kernel const& kernel,
                                std::span<transform_input const> inputs,
                                bool* predicate_results,
                                std::optional<void*> user_data,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -181,7 +181,7 @@ apply_join_semantics(cudf::table_view const& left,
                      cudf::device_span<size_type const> right_indices,
                      rmm::device_uvector<bool> const& predicate_results,
                      join_kind join_kind,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      rmm::device_async_resource_ref mr)
 {
   auto make_empty_result = [&]() {
@@ -246,7 +246,7 @@ apply_join_semantics(cudf::table_view const& left,
                                    {},
                                    {},
                                    {},
-                                   stream.value()};
+                                   stream.get()};
 
     auto predicate_func = [predicate_results_ptr] __device__(std::size_t idx) -> bool {
       return static_cast<bool>(predicate_results_ptr[idx]);
@@ -256,7 +256,7 @@ apply_join_semantics(cudf::table_view const& left,
                                        left_ptr + left_indices.size(),
                                        cuda::counting_iterator<std::size_t>{0},
                                        predicate_func,
-                                       stream.value());
+                                       stream.get());
 
     auto const num_invalid = left.num_rows() - num_filter_passing;
 
@@ -298,7 +298,7 @@ apply_join_semantics(cudf::table_view const& left,
                             stream);
 
       cub::DeviceTransform::Fill(
-        filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.value());
+        filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.get());
     }
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
@@ -380,7 +380,7 @@ filter_join_indices_jit(cudf::table_view const& left,
                         std::string const& predicate_code,
                         join_kind join_kind,
                         bool is_ptx,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -452,7 +452,7 @@ filter_join_indices_jit(cudf::table_view const& left,
                         cudf::device_span<size_type const> right_indices,
                         ast::expression const& predicate,
                         join_kind join_kind,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -518,7 +518,7 @@ filter_join_indices_jit(cudf::table_view const& left,
                         std::string const& predicate_code,
                         cudf::join_kind join_kind,
                         bool is_ptx,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -534,7 +534,7 @@ filter_join_indices_jit(cudf::table_view const& left,
                         cudf::device_span<size_type const> right_indices,
                         cudf::ast::expression const& predicate,
                         cudf::join_kind join_kind,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit_kernel.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,8 +10,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <string>
@@ -47,13 +48,13 @@ filter_join_indices_jit(cudf::table_view const& left,
                         std::string const& predicate_code,
                         join_kind join_kind,
                         bool is_ptx,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr);
 
 /**
  * @copydoc cudf::filter_join_indices_jit(table_view const&, table_view const&,
  *   device_span<size_type const>, device_span<size_type const>,
- *   ast::expression const&, join_kind, rmm::cuda_stream_view,
+ *   ast::expression const&, join_kind, cuda::stream_ref,
  *   rmm::device_async_resource_ref)
  */
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -64,7 +65,7 @@ filter_join_indices_jit(cudf::table_view const& left,
                         cudf::device_span<size_type const> right_indices,
                         ast::expression const& predicate,
                         join_kind join_kind,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel.cuh
@@ -15,7 +15,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
@@ -91,10 +91,10 @@ void launch_filter_gather_map_kernel(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* predicate_results,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   filter_join_indices_kernel<MAX_BLOCK_SIZE, has_nulls, has_complex_type>
-    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.value()>>>(
+    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.get()>>>(
       left_table,
       right_table,
       left_indices,

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel.hpp
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel.hpp
@@ -10,7 +10,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
@@ -50,6 +50,6 @@ void launch_filter_gather_map_kernel(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* output_flags,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel_complex.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel_complex.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,5 +16,5 @@ template void launch_filter_gather_map_kernel<false, true>(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* output_flags,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel_null_complex.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel_null_complex.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,5 +16,5 @@ template void launch_filter_gather_map_kernel<true, true>(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* output_flags,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel_null_primitive.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel_null_primitive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,5 +16,5 @@ template void launch_filter_gather_map_kernel<true, false>(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* output_flags,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel_primitive.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel_primitive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,5 +16,5 @@ template void launch_filter_gather_map_kernel<false, false>(
   cudf::detail::grid_1d const& config,
   std::size_t shmem_per_block,
   bool* output_flags,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
@@ -16,9 +16,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/atomic>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
@@ -108,10 +107,10 @@ void launch_filter_output_size_kernel(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   filter_join_indices_output_size_kernel<has_nulls, has_complex_type>
-    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.value()>>>(
+    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.get()>>>(
       left_table,
       right_table,
       left_indices,

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.hpp
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.hpp
@@ -13,7 +13,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
@@ -57,6 +57,6 @@ void launch_filter_output_size_kernel(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_complex.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_complex.cu
@@ -17,5 +17,5 @@ template void launch_filter_output_size_kernel<false, true>(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_null_complex.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_null_complex.cu
@@ -17,5 +17,5 @@ template void launch_filter_output_size_kernel<true, true>(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_null_primitive.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_null_primitive.cu
@@ -17,5 +17,5 @@ template void launch_filter_output_size_kernel<true, false>(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_primitive.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel_primitive.cu
@@ -17,5 +17,5 @@ template void launch_filter_output_size_kernel<false, false>(
   std::size_t shmem_per_block,
   cudf::join_kind join_kind,
   cudf::size_type* output_counts,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/join/filtered_join/filtered_join.cu
+++ b/cpp/src/join/filtered_join/filtered_join.cu
@@ -17,7 +17,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -26,6 +25,7 @@
 
 #include <cuco/extent.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 #include <thrust/sequence.h>
 
@@ -40,7 +40,7 @@ namespace detail {
  * @brief Returns a validity mask for rows without nulls at any nested level, or null when unused.
  */
 std::pair<rmm::device_buffer, bitmask_type const*> make_filtered_join_row_bitmask(
-  table_view const& input, null_equality nulls_equal, rmm::cuda_stream_view stream)
+  table_view const& input, null_equality nulls_equal, cuda::stream_ref stream)
 {
   if (nulls_equal == null_equality::EQUAL || !has_nested_nulls(input)) {
     return std::pair(rmm::device_buffer{0, stream}, nullptr);
@@ -98,13 +98,13 @@ std::size_t filtered_join::compute_bucket_storage_size(cudf::size_type num_rows,
 filtered_join::filtered_join(cudf::table_view const& right,
                              cudf::null_equality compare_nulls,
                              double load_factor,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _right_mode{select_row_operator_mode(right)},
     _bucket_storage{cuco::extent<std::size_t>{compute_bucket_storage_size(
                       right.num_rows(), checked_load_factor(load_factor), _right_mode)},
                     rmm::mr::polymorphic_allocator<char>{std::move(mr)},
-                    stream.value()},
+                    stream.get()},
     _right{right},
     _nulls_equal{compare_nulls},
     _preprocessed_right{cudf::detail::row::equality::preprocessed_table::create(_right, stream)}
@@ -124,7 +124,7 @@ filtered_join::filtered_join(cudf::table_view const& right,
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> filtered_join::semi_anti_join(
   cudf::table_view const& left,
   join_kind kind,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   cudf::scoped_range range{"filtered_join::semi_anti_join"};
@@ -156,7 +156,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> filtered_join::semi_anti_j
 }
 
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> filtered_join::semi_join(
-  cudf::table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   // Early return for empty right or left table
   if (_right.num_rows() == 0 || left.num_rows() == 0) {
@@ -167,7 +167,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> filtered_join::semi_join(
 }
 
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> filtered_join::anti_join(
-  cudf::table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   // Early return for empty left table
   if (left.num_rows() == 0) {
@@ -192,7 +192,7 @@ filtered_join::~filtered_join() = default;
 filtered_join::filtered_join(cudf::table_view const& build,
                              null_equality compare_nulls,
                              double load_factor,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<cudf::detail::filtered_join>(
       build, compare_nulls, load_factor, stream, std::move(mr))}
@@ -201,7 +201,7 @@ filtered_join::filtered_join(cudf::table_view const& build,
 
 filtered_join::filtered_join(cudf::table_view const& build,
                              null_equality compare_nulls,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : filtered_join(
       build, compare_nulls, cudf::detail::CUCO_DESIRED_LOAD_FACTOR, stream, std::move(mr))
@@ -209,17 +209,13 @@ filtered_join::filtered_join(cudf::table_view const& build,
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> filtered_join::semi_join(
-  cudf::table_view const& probe,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& probe, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->semi_join(probe, stream, mr);
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> filtered_join::anti_join(
-  cudf::table_view const& probe,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& probe, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->anti_join(probe, stream, mr);
 }

--- a/cpp/src/join/filtered_join/filtered_join_common.cuh
+++ b/cpp/src/join/filtered_join/filtered_join_common.cuh
@@ -13,11 +13,11 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <cuco/detail/open_addressing/kernels.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cstdint>
@@ -38,7 +38,7 @@ struct precomputed_hash {
 };
 
 std::pair<rmm::device_buffer, bitmask_type const*> make_filtered_join_row_bitmask(
-  table_view const& input, null_equality nulls_equal, rmm::cuda_stream_view stream);
+  table_view const& input, null_equality nulls_equal, cuda::stream_ref stream);
 
 class filtered_join_row_is_valid {
  public:
@@ -56,7 +56,7 @@ class filtered_join_row_is_valid {
 template <int32_t CGSize, typename Iterator, typename Ref>
 void filtered_join::insert_right_table(Iterator right_iter,
                                        Ref const& insert_ref,
-                                       rmm::cuda_stream_view stream)
+                                       cuda::stream_ref stream)
 {
   cudf::scoped_range range{"filtered_join::insert_right_table"};
   // Insert valid rows from the right table into the hash table.
@@ -64,7 +64,7 @@ void filtered_join::insert_right_table(Iterator right_iter,
   auto const bitmask_buffer_and_ptr = make_filtered_join_row_bitmask(_right, _nulls_equal, stream);
   if (bitmask_buffer_and_ptr.second != nullptr) {
     cuco::detail::open_addressing_ns::insert_if_n<CGSize, cuco::detail::default_block_size()>
-      <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
         right_iter,
         _right.num_rows(),
         cuda::counting_iterator<size_type>{0},
@@ -72,7 +72,7 @@ void filtered_join::insert_right_table(Iterator right_iter,
         insert_ref);
   } else {
     cuco::detail::open_addressing_ns::insert_if_n<CGSize, cuco::detail::default_block_size()>
-      <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
         right_iter,
         _right.num_rows(),
         cuda::constant_iterator<bool>{true},
@@ -87,14 +87,14 @@ void filtered_join::query_right_table(cudf::table_view const& left,
                                       Iterator left_iter,
                                       Ref query_ref,
                                       cudf::device_span<bool> contains_map,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   cudf::scoped_range range{"filtered_join::query_right_table"};
   auto const grid_size              = cuco::detail::grid_size(left.num_rows(), CGSize);
   auto const bitmask_buffer_and_ptr = make_filtered_join_row_bitmask(left, _nulls_equal, stream);
   if (bitmask_buffer_and_ptr.second != nullptr) {
     cuco::detail::open_addressing_ns::contains_if_n<CGSize, cuco::detail::default_block_size()>
-      <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
         left_iter,
         left.num_rows(),
         cuda::counting_iterator<size_type>{0},
@@ -103,7 +103,7 @@ void filtered_join::query_right_table(cudf::table_view const& left,
         query_ref);
   } else {
     cuco::detail::open_addressing_ns::contains_if_n<CGSize, cuco::detail::default_block_size()>
-      <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
         left_iter,
         left.num_rows(),
         cuda::constant_iterator<bool>{true},

--- a/cpp/src/join/filtered_join/filtered_join_flat.cu
+++ b/cpp/src/join/filtered_join/filtered_join_flat.cu
@@ -15,17 +15,16 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
+#include <cuda/stream_ref>
 
 #include <memory>
 
 namespace cudf::detail {
 
-void filtered_join::insert_right_table_flat(rmm::cuda_stream_view stream)
+void filtered_join::insert_right_table_flat(cuda::stream_ref stream)
 {
   auto const comparator =
     cudf::detail::row::equality::self_comparator{_preprocessed_right}.equal_to<false>(
@@ -49,7 +48,7 @@ void filtered_join::query_right_table_flat(
   cudf::table_view const& left,
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::device_span<bool> contains_map,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const comparator =
     cudf::detail::row::equality::two_table_comparator{_preprocessed_right, preprocessed_left}

--- a/cpp/src/join/filtered_join/filtered_join_nested.cu
+++ b/cpp/src/join/filtered_join/filtered_join_nested.cu
@@ -13,15 +13,14 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
-void filtered_join::insert_right_table_nested(rmm::cuda_stream_view stream)
+void filtered_join::insert_right_table_nested(cuda::stream_ref stream)
 {
   auto const comparator =
     cudf::detail::row::equality::self_comparator{_preprocessed_right}.equal_to<true>(

--- a/cpp/src/join/filtered_join/filtered_join_nested_query.cu
+++ b/cpp/src/join/filtered_join/filtered_join_nested_query.cu
@@ -16,11 +16,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -30,7 +29,7 @@ void filtered_join::query_right_table_nested(
   cudf::table_view const& left,
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::device_span<bool> contains_map,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const comparator =
     cudf::detail::row::equality::two_table_comparator{_preprocessed_right, preprocessed_left}

--- a/cpp/src/join/filtered_join/filtered_join_primitive.cu
+++ b/cpp/src/join/filtered_join/filtered_join_primitive.cu
@@ -15,11 +15,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -33,7 +32,7 @@ using primitive_row_hasher =
 
 }  // namespace
 
-void filtered_join::insert_right_table_primitive(rmm::cuda_stream_view stream)
+void filtered_join::insert_right_table_primitive(cuda::stream_ref stream)
 {
   auto const comparator = primitive_row_comparator{
     nullate::DYNAMIC{true}, _preprocessed_right, _preprocessed_right, _nulls_equal};
@@ -53,7 +52,7 @@ void filtered_join::query_right_table_primitive(
   cudf::table_view const& left,
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::device_span<bool> contains_map,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const comparator = primitive_row_comparator{
     nullate::DYNAMIC{true}, _preprocessed_right, preprocessed_left, _nulls_equal};

--- a/cpp/src/join/hash_join/common.cuh
+++ b/cpp/src/join/hash_join/common.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,9 +11,10 @@
 #include <cudf/join/join.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -35,7 +36,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
   null_equality compare_nulls,
   join_kind join,
   table_view const& left,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/finalize_partitioned_full_join.cpp
+++ b/cpp/src/join/hash_join/finalize_partitioned_full_join.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,8 +12,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 
@@ -24,7 +25,7 @@ hash_join::finalize_partitioned_full_join(
   cudf::host_span<cudf::device_span<size_type const> const> right_partials,
   size_type left_table_num_rows,
   size_type right_table_num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/hash_join/full_join_match_context.cpp
+++ b/cpp/src/join/hash_join/full_join_match_context.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,17 +12,13 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::full_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::full_join_match_context"};
   return cudf::join_match_context{left, make_match_counts(join_kind::FULL_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::full_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const;
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/full_join_retrieve.cu
+++ b/cpp/src/join/hash_join/full_join_retrieve.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::full_join(cudf::table_view const& left,
                              std::optional<std::size_t> output_size,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr) const
 {
   return this->template join_retrieve<join_kind::FULL_JOIN>(left, output_size, stream, mr);
@@ -22,7 +22,7 @@ template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::full_join(cudf::table_view const& left,
                                        std::optional<std::size_t> output_size,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/full_join_size.cu
+++ b/cpp/src/join/hash_join/full_join_size.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,15 +9,13 @@ namespace cudf::detail {
 
 template <typename Hasher>
 std::size_t hash_join<Hasher>::full_join_size(cudf::table_view const& left,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr) const
 {
   return this->template join_size<join_kind::FULL_JOIN>(left, stream, mr);
 }
 
 template std::size_t hash_join<hash_join_hasher>::full_join_size(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const;
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/full_join_size_impl.cu
+++ b/cpp/src/join/hash_join/full_join_size_impl.cu
@@ -24,7 +24,7 @@ namespace {
 std::size_t compute_left_join_complement_size(cudf::device_span<size_type const> right_indices,
                                               size_type left_table_row_count,
                                               size_type right_table_row_count,
-                                              rmm::cuda_stream_view stream)
+                                              cuda::stream_ref stream)
 {
   if (left_table_row_count == 0) { return right_table_row_count; }
 
@@ -59,7 +59,7 @@ std::size_t get_full_join_size(
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   std::size_t join_size = compute_join_output_size<join_kind::LEFT_JOIN>(right_table,

--- a/cpp/src/join/hash_join/hash_join.cu
+++ b/cpp/src/join/hash_join/hash_join.cu
@@ -66,7 +66,7 @@ void build_hash_join(
   bool has_nested_nulls,
   null_equality nulls_equal,
   [[maybe_unused]] bitmask_type const* bitmask,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   CUDF_EXPECTS(0 != right.num_columns(), "Selected right dataset is empty", std::invalid_argument);
   CUDF_EXPECTS(0 != right.num_rows(), "Right side table has no rows", std::invalid_argument);
@@ -75,12 +75,12 @@ void build_hash_join(
     auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
 
     if (nulls_equal == cudf::null_equality::EQUAL or not nullable(right)) {
-      hash_table.insert(iter, iter + right.num_rows(), stream.value());
+      hash_table.insert(iter, iter + right.num_rows(), stream.get());
     } else {
       auto const stencil = cuda::counting_iterator<size_type>{0};
       auto const pred    = row_is_valid{bitmask};
 
-      hash_table.insert_if(iter, iter + right.num_rows(), stencil, pred, stream.value());
+      hash_table.insert_if(iter, iter + right.num_rows(), stencil, pred, stream.get());
     }
   };
 
@@ -103,7 +103,7 @@ template <typename Hasher>
 hash_join<Hasher>::hash_join(cudf::table_view const& right,
                              bool has_nulls,
                              cudf::null_equality compare_nulls,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : hash_join{right, has_nulls, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream, std::move(mr)}
 {
@@ -114,7 +114,7 @@ hash_join<Hasher>::hash_join(cudf::table_view const& right,
                              bool has_nulls,
                              cudf::null_equality compare_nulls,
                              double load_factor,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _has_nulls(has_nulls),
     _is_empty{right.num_rows() == 0},
@@ -128,7 +128,7 @@ hash_join<Hasher>::hash_join(cudf::table_view const& right,
       {},
       {},
       rmm::mr::polymorphic_allocator<char>{std::move(mr)},
-      stream.value()}})},
+      stream.get()}})},
     _right{right},
     _preprocessed_right{cudf::detail::row::equality::preprocessed_table::create(_right, stream)}
 {
@@ -151,7 +151,7 @@ template hash_join<hash_join_hasher>::hash_join(
   cudf::table_view const& right,
   bool has_nulls,
   cudf::null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
 template hash_join<hash_join_hasher>::hash_join(
@@ -159,7 +159,7 @@ template hash_join<hash_join_hasher>::hash_join(
   bool has_nulls,
   cudf::null_equality compare_nulls,
   double load_factor,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
 template <typename Hasher>
@@ -175,7 +175,7 @@ hash_join::~hash_join() = default;
 
 hash_join::hash_join(cudf::table_view const& right,
                      null_equality compare_nulls,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : hash_join(right,
               nullable_join::YES,
@@ -190,7 +190,7 @@ hash_join::hash_join(cudf::table_view const& right,
                      nullable_join has_nulls,
                      null_equality compare_nulls,
                      double load_factor,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<impl_type const>(
       right, has_nulls == nullable_join::YES, compare_nulls, load_factor, stream, std::move(mr))}
@@ -201,7 +201,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::inner_join(cudf::table_view const& left,
                       std::optional<std::size_t> output_size,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr) const
 {
   return _impl->inner_join(left, output_size, stream, mr);
@@ -211,7 +211,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::left_join(cudf::table_view const& left,
                      std::optional<std::size_t> output_size,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      rmm::device_async_resource_ref mr) const
 {
   return _impl->left_join(left, output_size, stream, mr);
@@ -221,48 +221,44 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::full_join(cudf::table_view const& left,
                      std::optional<std::size_t> output_size,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      rmm::device_async_resource_ref mr) const
 {
   return _impl->full_join(left, output_size, stream, mr);
 }
 
-std::size_t hash_join::inner_join_size(cudf::table_view const& left,
-                                       rmm::cuda_stream_view stream) const
+std::size_t hash_join::inner_join_size(cudf::table_view const& left, cuda::stream_ref stream) const
 {
   return _impl->inner_join_size(left, stream);
 }
 
-std::size_t hash_join::left_join_size(cudf::table_view const& left,
-                                      rmm::cuda_stream_view stream) const
+std::size_t hash_join::left_join_size(cudf::table_view const& left, cuda::stream_ref stream) const
 {
   return _impl->left_join_size(left, stream);
 }
 
 std::size_t hash_join::full_join_size(cudf::table_view const& left,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr) const
 {
   return _impl->full_join_size(left, stream, mr);
 }
 
 cudf::join_match_context hash_join::inner_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->inner_join_match_context(left, stream, mr);
 }
 
 cudf::join_match_context hash_join::left_join_match_context(cudf::table_view const& left,
-                                                            rmm::cuda_stream_view stream,
+                                                            cuda::stream_ref stream,
                                                             rmm::device_async_resource_ref mr) const
 {
   return _impl->left_join_match_context(left, stream, mr);
 }
 
 cudf::join_match_context hash_join::full_join_match_context(cudf::table_view const& left,
-                                                            rmm::cuda_stream_view stream,
+                                                            cuda::stream_ref stream,
                                                             rmm::device_async_resource_ref mr) const
 {
   return _impl->full_join_match_context(left, stream, mr);
@@ -271,7 +267,7 @@ cudf::join_match_context hash_join::full_join_match_context(cudf::table_view con
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::partitioned_inner_join(cudf::join_partition_context const& context,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
@@ -281,7 +277,7 @@ hash_join::partitioned_inner_join(cudf::join_partition_context const& context,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::partitioned_left_join(cudf::join_partition_context const& context,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
@@ -291,7 +287,7 @@ hash_join::partitioned_left_join(cudf::join_partition_context const& context,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join::partitioned_full_join(cudf::join_partition_context const& context,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/hash_join/inner_join_match_context.cpp
+++ b/cpp/src/join/hash_join/inner_join_match_context.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,17 +12,13 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::inner_join_match_context"};
   return cudf::join_match_context{left, make_match_counts(join_kind::INNER_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::inner_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const;
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/inner_join_retrieve.cu
+++ b/cpp/src/join/hash_join/inner_join_retrieve.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::inner_join(cudf::table_view const& left,
                               std::optional<std::size_t> output_size,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr) const
 {
   return this->template join_retrieve<join_kind::INNER_JOIN>(left, output_size, stream, mr);
@@ -22,7 +22,7 @@ template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::inner_join(cudf::table_view const& left,
                                         std::optional<std::size_t> output_size,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/inner_join_size.cu
+++ b/cpp/src/join/hash_join/inner_join_size.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,12 +9,12 @@ namespace cudf::detail {
 
 template <typename Hasher>
 std::size_t hash_join<Hasher>::inner_join_size(cudf::table_view const& left,
-                                               rmm::cuda_stream_view stream) const
+                                               cuda::stream_ref stream) const
 {
   return this->template join_size<join_kind::INNER_JOIN>(left, stream);
 }
 
-template std::size_t hash_join<hash_join_hasher>::inner_join_size(
-  cudf::table_view const& left, rmm::cuda_stream_view stream) const;
+template std::size_t hash_join<hash_join_hasher>::inner_join_size(cudf::table_view const& left,
+                                                                  cuda::stream_ref stream) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/left_join_match_context.cpp
+++ b/cpp/src/join/hash_join/left_join_match_context.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,17 +12,13 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::left_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::left_join_match_context"};
   return cudf::join_match_context{left, make_match_counts(join_kind::LEFT_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::left_join_match_context(
-  cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const;
+  cudf::table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/left_join_retrieve.cu
+++ b/cpp/src/join/hash_join/left_join_retrieve.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::left_join(cudf::table_view const& left,
                              std::optional<std::size_t> output_size,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr) const
 {
   return this->template join_retrieve<join_kind::LEFT_JOIN>(left, output_size, stream, mr);
@@ -22,7 +22,7 @@ template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::left_join(cudf::table_view const& left,
                                        std::optional<std::size_t> output_size,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/left_join_size.cu
+++ b/cpp/src/join/hash_join/left_join_size.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,12 +9,12 @@ namespace cudf::detail {
 
 template <typename Hasher>
 std::size_t hash_join<Hasher>::left_join_size(cudf::table_view const& left,
-                                              rmm::cuda_stream_view stream) const
+                                              cuda::stream_ref stream) const
 {
   return this->template join_size<join_kind::LEFT_JOIN>(left, stream);
 }
 
-template std::size_t hash_join<hash_join_hasher>::left_join_size(
-  cudf::table_view const& left, rmm::cuda_stream_view stream) const;
+template std::size_t hash_join<hash_join_hasher>::left_join_size(cudf::table_view const& left,
+                                                                 cuda::stream_ref stream) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/match_context.cu
+++ b/cpp/src/join/hash_join/match_context.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -28,7 +28,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
   null_equality compare_nulls,
   join_kind join,
   table_view const& left,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto match_counts = std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
@@ -80,7 +80,7 @@ template <typename Hasher>
 std::unique_ptr<rmm::device_uvector<size_type>> hash_join<Hasher>::make_match_counts(
   join_kind join,
   cudf::table_view const& left,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr) const
 {
   return make_join_match_counts(_right,
@@ -98,7 +98,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> hash_join<Hasher>::make_match_co
 template std::unique_ptr<rmm::device_uvector<size_type>>
 hash_join<hash_join_hasher>::make_match_counts(join_kind,
                                                cudf::table_view const&,
-                                               rmm::cuda_stream_view,
+                                               cuda::stream_ref,
                                                rmm::device_async_resource_ref) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_count.cu
+++ b/cpp/src/join/hash_join/partitioned_count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,16 +8,13 @@
 
 namespace cudf::detail {
 
-template void launch_partitioned_count<false, primitive_count_ref_t>(probe_key_type const*,
-                                                                     thread_index_type,
-                                                                     size_type*,
-                                                                     primitive_count_ref_t,
-                                                                     rmm::cuda_stream_view);
+template void launch_partitioned_count<false, primitive_count_ref_t>(
+  probe_key_type const*, thread_index_type, size_type*, primitive_count_ref_t, cuda::stream_ref);
 
 template void launch_partitioned_count<false, nested_count_ref_t>(
-  probe_key_type const*, thread_index_type, size_type*, nested_count_ref_t, rmm::cuda_stream_view);
+  probe_key_type const*, thread_index_type, size_type*, nested_count_ref_t, cuda::stream_ref);
 
 template void launch_partitioned_count<false, flat_count_ref_t>(
-  probe_key_type const*, thread_index_type, size_type*, flat_count_ref_t, rmm::cuda_stream_view);
+  probe_key_type const*, thread_index_type, size_type*, flat_count_ref_t, cuda::stream_ref);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_count_kernels.cuh
+++ b/cpp/src/join/hash_join/partitioned_count_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,10 +9,9 @@
 
 #include <cudf/detail/utilities/grid_1d.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
@@ -80,7 +79,7 @@ void launch_partitioned_count(probe_key_type const* keys,
                               thread_index_type n,
                               size_type* output,
                               Ref ref,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   if (n == 0) { return; }
 
@@ -88,7 +87,7 @@ void launch_partitioned_count(probe_key_type const* keys,
     grid_1d{static_cast<thread_index_type>(n * DEFAULT_JOIN_CG_SIZE), DEFAULT_JOIN_BLOCK_SIZE};
 
   partitioned_count_kernel<IsOuter>
-    <<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(keys, n, output, ref);
+    <<<config.num_blocks, config.num_threads_per_block, 0, stream.get()>>>(keys, n, output, ref);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 

--- a/cpp/src/join/hash_join/partitioned_count_kernels.hpp
+++ b/cpp/src/join/hash_join/partitioned_count_kernels.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include "kernels_common.cuh"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 
@@ -17,6 +17,6 @@ void launch_partitioned_count(probe_key_type const* keys,
                               thread_index_type n,
                               size_type* output,
                               Ref ref,
-                              rmm::cuda_stream_view stream);
+                              cuda::stream_ref stream);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_count_outer.cu
+++ b/cpp/src/join/hash_join/partitioned_count_outer.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,16 +8,13 @@
 
 namespace cudf::detail {
 
-template void launch_partitioned_count<true, primitive_count_ref_t>(probe_key_type const*,
-                                                                    thread_index_type,
-                                                                    size_type*,
-                                                                    primitive_count_ref_t,
-                                                                    rmm::cuda_stream_view);
+template void launch_partitioned_count<true, primitive_count_ref_t>(
+  probe_key_type const*, thread_index_type, size_type*, primitive_count_ref_t, cuda::stream_ref);
 
 template void launch_partitioned_count<true, nested_count_ref_t>(
-  probe_key_type const*, thread_index_type, size_type*, nested_count_ref_t, rmm::cuda_stream_view);
+  probe_key_type const*, thread_index_type, size_type*, nested_count_ref_t, cuda::stream_ref);
 
 template void launch_partitioned_count<true, flat_count_ref_t>(
-  probe_key_type const*, thread_index_type, size_type*, flat_count_ref_t, rmm::cuda_stream_view);
+  probe_key_type const*, thread_index_type, size_type*, flat_count_ref_t, cuda::stream_ref);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_full_join.cu
+++ b/cpp/src/join/hash_join/partitioned_full_join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@ template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::partitioned_full_join(cudf::join_partition_context const& context,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr) const
 {
   return this->partitioned_join_retrieve(join_kind::FULL_JOIN, context, stream, mr);
@@ -20,7 +20,7 @@ hash_join<Hasher>::partitioned_full_join(cudf::join_partition_context const& con
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::partitioned_full_join(cudf::join_partition_context const& context,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_inner_join.cu
+++ b/cpp/src/join/hash_join/partitioned_inner_join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@ template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::partitioned_inner_join(cudf::join_partition_context const& context,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr) const
 {
   return this->partitioned_join_retrieve(join_kind::INNER_JOIN, context, stream, mr);
@@ -20,7 +20,7 @@ hash_join<Hasher>::partitioned_inner_join(cudf::join_partition_context const& co
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::partitioned_inner_join(cudf::join_partition_context const& context,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_join_retrieve.cu
+++ b/cpp/src/join/hash_join/partitioned_join_retrieve.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -33,7 +33,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 make_trivial_outer_indices(size_type left_start_idx,
                            size_type partition_size,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr)
 {
   auto left_indices  = std::make_unique<rmm::device_uvector<size_type>>(partition_size, stream, mr);
@@ -57,7 +57,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::partitioned_join_retrieve(join_kind join,
                                              cudf::join_partition_context const& context,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
@@ -158,7 +158,7 @@ template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::partitioned_join_retrieve(join_kind,
                                                        cudf::join_partition_context const&,
-                                                       rmm::cuda_stream_view,
+                                                       cuda::stream_ref,
                                                        rmm::device_async_resource_ref) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_left_join.cu
+++ b/cpp/src/join/hash_join/partitioned_left_join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@ template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::partitioned_left_join(cudf::join_partition_context const& context,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr) const
 {
   return this->partitioned_join_retrieve(join_kind::LEFT_JOIN, context, stream, mr);
@@ -20,7 +20,7 @@ hash_join<Hasher>::partitioned_left_join(cudf::join_partition_context const& con
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<hash_join_hasher>::partitioned_left_join(cudf::join_partition_context const& context,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_retrieve.cu
+++ b/cpp/src/join/hash_join/partitioned_retrieve.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@ launch_partitioned_retrieve<false, primitive_count_ref_t>(probe_key_type const*,
                                                           size_type const*,
                                                           primitive_count_ref_t,
                                                           size_type,
-                                                          rmm::cuda_stream_view,
+                                                          cuda::stream_ref,
                                                           rmm::device_async_resource_ref);
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -25,7 +25,7 @@ launch_partitioned_retrieve<false, nested_count_ref_t>(probe_key_type const*,
                                                        size_type const*,
                                                        nested_count_ref_t,
                                                        size_type,
-                                                       rmm::cuda_stream_view,
+                                                       cuda::stream_ref,
                                                        rmm::device_async_resource_ref);
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -35,7 +35,7 @@ launch_partitioned_retrieve<false, flat_count_ref_t>(probe_key_type const*,
                                                      size_type const*,
                                                      flat_count_ref_t,
                                                      size_type,
-                                                     rmm::cuda_stream_view,
+                                                     cuda::stream_ref,
                                                      rmm::device_async_resource_ref);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_retrieve_kernels.cuh
+++ b/cpp/src/join/hash_join/partitioned_retrieve_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,6 @@
 #include <cudf/join/join.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -21,6 +20,7 @@
 #include <cuda/atomic>
 #include <cuda/std/bit>
 #include <cuda/std/cstdint>
+#include <cuda/stream_ref>
 #include <thrust/reduce.h>
 
 namespace cudf::detail {
@@ -218,7 +218,7 @@ launch_partitioned_retrieve(probe_key_type const* keys,
                             size_type const* match_counts,
                             Ref ref,
                             size_type left_offset,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr)
 {
   if (n == 0) {
@@ -248,7 +248,7 @@ launch_partitioned_retrieve(probe_key_type const* keys,
   auto constexpr tiles_in_block = DEFAULT_JOIN_BLOCK_SIZE / Ref::cg_size;
   auto const num_blocks = static_cast<unsigned int>((n + tiles_in_block - 1) / tiles_in_block);
 
-  partitioned_retrieve_kernel<IsOuter><<<num_blocks, DEFAULT_JOIN_BLOCK_SIZE, 0, stream.value()>>>(
+  partitioned_retrieve_kernel<IsOuter><<<num_blocks, DEFAULT_JOIN_BLOCK_SIZE, 0, stream.get()>>>(
     keys, n, left_offset, left_indices->data(), right_indices->data(), output_counter.data(), ref);
   CUDF_CUDA_TRY(cudaGetLastError());
 

--- a/cpp/src/join/hash_join/partitioned_retrieve_kernels.hpp
+++ b/cpp/src/join/hash_join/partitioned_retrieve_kernels.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,8 +9,9 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -35,7 +36,7 @@ launch_partitioned_retrieve(probe_key_type const* keys,
                             size_type const* match_counts,
                             Ref ref,
                             size_type left_offset,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/partitioned_retrieve_outer.cu
+++ b/cpp/src/join/hash_join/partitioned_retrieve_outer.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@ launch_partitioned_retrieve<true, primitive_count_ref_t>(probe_key_type const*,
                                                          size_type const*,
                                                          primitive_count_ref_t,
                                                          size_type,
-                                                         rmm::cuda_stream_view,
+                                                         cuda::stream_ref,
                                                          rmm::device_async_resource_ref);
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -25,7 +25,7 @@ launch_partitioned_retrieve<true, nested_count_ref_t>(probe_key_type const*,
                                                       size_type const*,
                                                       nested_count_ref_t,
                                                       size_type,
-                                                      rmm::cuda_stream_view,
+                                                      cuda::stream_ref,
                                                       rmm::device_async_resource_ref);
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -35,7 +35,7 @@ launch_partitioned_retrieve<true, flat_count_ref_t>(probe_key_type const*,
                                                     size_type const*,
                                                     flat_count_ref_t,
                                                     size_type,
-                                                    rmm::cuda_stream_view,
+                                                    cuda::stream_ref,
                                                     rmm::device_async_resource_ref);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/retrieve_impl.cuh
+++ b/cpp/src/join/hash_join/retrieve_impl.cuh
@@ -37,7 +37,7 @@ probe_join_hash_table(
   bool has_nulls,
   null_equality compare_nulls,
   std::optional<std::size_t> output_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   static_assert(Join == join_kind::INNER_JOIN || Join == join_kind::LEFT_JOIN ||
@@ -81,7 +81,7 @@ probe_join_hash_table(
                           hash_table.hash_function(),
                           out_probe_begin,
                           out_build_begin,
-                          stream.value());
+                          stream.get());
     } else {
       [[maybe_unused]] auto out_probe_end = hash_table
                                               .retrieve_outer(iter,
@@ -90,7 +90,7 @@ probe_join_hash_table(
                                                               hash_table.hash_function(),
                                                               out_probe_begin,
                                                               out_build_begin,
-                                                              stream.value())
+                                                              stream.get())
                                               .first;
 
       if constexpr (Join == join_kind::FULL_JOIN) {
@@ -122,7 +122,7 @@ void retrieve_left_join_build_indices(
   bool has_nulls,
   null_equality compare_nulls,
   RightOutputIterator out_build_begin,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const left_table_num_rows = left_table.num_rows();
 
@@ -134,7 +134,7 @@ void retrieve_left_join_build_indices(
                               hash_table.hash_function(),
                               cuda::make_discard_iterator(),
                               out_build_begin,
-                              stream.value());
+                              stream.get());
   };
 
   dispatch_join_comparator(right_table,
@@ -152,7 +152,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::join_retrieve(cudf::table_view const& left,
                                  std::optional<std::size_t> output_size,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/hash_join/size_impl.cuh
+++ b/cpp/src/join/hash_join/size_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -20,7 +20,7 @@ std::size_t get_full_join_size(
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template <join_kind Join>
@@ -32,7 +32,7 @@ std::size_t compute_join_output_size(
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   cudf::null_equality nulls_equal,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   static_assert(Join == join_kind::INNER_JOIN || Join == join_kind::LEFT_JOIN);
 
@@ -53,10 +53,10 @@ std::size_t compute_join_output_size(
       auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
       if constexpr (Join == join_kind::LEFT_JOIN) {
         return hash_table.count_outer(
-          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.value());
+          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.get());
       } else {
         return hash_table.count(
-          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.value());
+          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.get());
       }
     });
 }
@@ -64,7 +64,7 @@ std::size_t compute_join_output_size(
 template <typename Hasher>
 template <join_kind Join>
 std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
-                                         rmm::cuda_stream_view stream) const
+                                         cuda::stream_ref stream) const
 {
   static_assert(Join == join_kind::INNER_JOIN || Join == join_kind::LEFT_JOIN);
 
@@ -96,7 +96,7 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
 template <typename Hasher>
 template <join_kind Join>
 std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr) const
 {
   static_assert(Join == join_kind::FULL_JOIN);

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "join_common_utils.hpp"
@@ -15,9 +15,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -29,7 +30,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 inner_join(table_view const& left_input,
            table_view const& right_input,
            null_equality compare_nulls,
-           rmm::cuda_stream_view stream,
+           cuda::stream_ref stream,
            rmm::device_async_resource_ref mr)
 {
   // Make sure any dictionary columns have matched key sets.
@@ -64,7 +65,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 left_join(table_view const& left_input,
           table_view const& right_input,
           null_equality compare_nulls,
-          rmm::cuda_stream_view stream,
+          cuda::stream_ref stream,
           rmm::device_async_resource_ref mr)
 {
   // Make sure any dictionary columns have matched key sets.
@@ -89,7 +90,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 full_join(table_view const& left_input,
           table_view const& right_input,
           null_equality compare_nulls,
-          rmm::cuda_stream_view stream,
+          cuda::stream_ref stream,
           rmm::device_async_resource_ref mr)
 {
   // Make sure any dictionary columns have matched key sets.
@@ -116,7 +117,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 inner_join(table_view const& left,
            table_view const& right,
            null_equality compare_nulls,
-           rmm::cuda_stream_view stream,
+           cuda::stream_ref stream,
            rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -128,7 +129,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 left_join(table_view const& left,
           table_view const& right,
           null_equality compare_nulls,
-          rmm::cuda_stream_view stream,
+          cuda::stream_ref stream,
           rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -140,7 +141,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 full_join(table_view const& left,
           table_view const& right,
           null_equality compare_nulls,
-          rmm::cuda_stream_view stream,
+          cuda::stream_ref stream,
           rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/join_common_utils.cuh
+++ b/cpp/src/join/join_common_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 #include <cudf/detail/row_operator/hashing.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 

--- a/cpp/src/join/join_common_utils.hpp
+++ b/cpp/src/join/join_common_utils.hpp
@@ -9,9 +9,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -48,7 +49,7 @@ using VectorPair = std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
  * @return Join output indices vector pair
  */
 VectorPair get_trivial_left_join_indices(table_view const& left,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 /**
@@ -73,7 +74,7 @@ VectorPair get_trivial_left_join_indices(table_view const& left,
 VectorPair finalize_full_join(VectorPair&& indices,
                               size_type left_table_num_rows,
                               size_type right_table_num_rows,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr);
 
 /**
@@ -100,7 +101,7 @@ VectorPair finalize_full_join(
   cudf::host_span<cudf::device_span<size_type const> const> right_partials,
   size_type left_table_num_rows,
   size_type right_table_num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::detail

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
@@ -23,6 +22,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/uninitialized_fill.h>
@@ -43,7 +43,7 @@ double checked_load_factor(double load_factor)
 }
 
 VectorPair get_trivial_left_join_indices(table_view const& left,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   auto left_indices = std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
@@ -86,7 +86,7 @@ struct to_no_match_pair {
 VectorPair finalize_full_join(VectorPair&& indices,
                               size_type left_table_num_rows,
                               size_type right_table_num_rows,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   auto [left_out, right_out] = std::move(indices);
@@ -161,7 +161,7 @@ VectorPair finalize_full_join(
   cudf::host_span<cudf::device_span<size_type const> const> right_partials,
   size_type left_table_num_rows,
   size_type right_table_num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(left_partials.size() == right_partials.size(),

--- a/cpp/src/join/key_remapping.cu
+++ b/cpp/src/join/key_remapping.cu
@@ -23,7 +23,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -33,6 +32,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/atomic>
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/reduce.h>
@@ -240,7 +240,7 @@ class key_remap_table_interface {
 
   virtual std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe(
     cudf::table_view const& left_keys,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const = 0;
 
   virtual bool has_metrics() const                        = 0;
@@ -279,7 +279,7 @@ class key_remap_table : public key_remap_table_interface {
     RowHasher const& row_hasher,
     cudf::null_equality compare_nulls,
     bool compute_metrics,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr)
     : _right_has_nested_columns{cudf::has_nested_columns(right)},
       _compare_nulls{compare_nulls},
@@ -294,7 +294,7 @@ class key_remap_table : public key_remap_table_interface {
                   cuco::thread_scope_device,
                   cuco_storage_type{},
                   rmm::mr::polymorphic_allocator<char>{std::move(mr)},
-                  stream.value()},
+                  stream.get()},
       _has_metrics{compute_metrics},
       _distinct_count{0},
       _max_duplicate_count{0}
@@ -337,7 +337,7 @@ class key_remap_table : public key_remap_table_interface {
   void compute_metrics_atomic(cudf::size_type right_num_rows,
                               KeyIter key_iter,
                               cudf::bitmask_type const* bitmask_ptr,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
   {
     rmm::device_uvector<cudf::size_type> counts(right_num_rows, stream);
     thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -352,7 +352,7 @@ class key_remap_table : public key_remap_table_interface {
 
     cudf::detail::grid_1d grid{right_num_rows, KEY_REMAP_BLOCK_SIZE};
 
-    insert_and_count_kernel<<<grid.num_blocks, KEY_REMAP_BLOCK_SIZE, 0, stream.value()>>>(
+    insert_and_count_kernel<<<grid.num_blocks, KEY_REMAP_BLOCK_SIZE, 0, stream.get()>>>(
       right_num_rows, set_ref, key_iter, counts.data(), d_distinct_count.data(), bitmask_ptr);
     CUDF_CUDA_TRY(cudaGetLastError());
 
@@ -369,7 +369,7 @@ class key_remap_table : public key_remap_table_interface {
  public:
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe(
     cudf::table_view const& left_keys,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const override
   {
     CUDF_FUNC_RANGE();
@@ -450,14 +450,14 @@ class key_remap_table : public key_remap_table_interface {
                     EqualType const& d_equal,
                     cudf::table_view const& left_keys,
                     FoundIterator found_begin,
-                    rmm::cuda_stream_view stream) const
+                    cuda::stream_ref stream) const
   {
     CUDF_FUNC_RANGE();
     auto const left_num_rows = left_keys.num_rows();
 
     if (_compare_nulls == cudf::null_equality::EQUAL or (not cudf::nullable(left_keys))) {
       _hash_table.find_async(
-        iter, iter + left_num_rows, d_equal, key_hasher{}, found_begin, stream.value());
+        iter, iter + left_num_rows, d_equal, key_hasher{}, found_begin, stream.get());
     } else {
       auto stencil = cuda::counting_iterator<cudf::size_type>{0};
       auto const row_bitmask =
@@ -472,7 +472,7 @@ class key_remap_table : public key_remap_table_interface {
                                 d_equal,
                                 key_hasher{},
                                 found_begin,
-                                stream.value());
+                                stream.get());
     }
   }
 
@@ -493,7 +493,7 @@ std::unique_ptr<key_remap_table_interface> create_key_remap_table(
   cudf::table_view const& right,
   cudf::null_equality compare_nulls,
   bool compute_metrics,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cuda::mr::any_resource<cuda::mr::device_accessible> mr)
 {
   CUDF_FUNC_RANGE();
@@ -565,7 +565,7 @@ class key_remapping_impl {
   key_remapping_impl(cudf::table_view const& right,
                      cudf::null_equality compare_nulls,
                      bool compute_metrics,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
     : _right{right},
       _compare_nulls{compare_nulls},
@@ -575,9 +575,7 @@ class key_remapping_impl {
   }
 
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe(
-    cudf::table_view const& keys,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const
+    cudf::table_view const& keys, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(keys.num_columns() == _right.num_columns(),
                  "Mismatch in number of columns to be joined on",
@@ -637,7 +635,7 @@ class key_remapping_impl {
 key_remapping::key_remapping(cudf::table_view const& right,
                              null_equality compare_nulls,
                              cudf::compute_metrics metrics,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<detail::key_remapping_impl>(
       right, compare_nulls, static_cast<bool>(metrics), stream, std::move(mr))}
@@ -651,7 +649,7 @@ namespace {
 std::unique_ptr<cudf::column> remap_keys_internal(detail::key_remapping_impl const& impl,
                                                   cudf::table_view const& keys,
                                                   cudf::size_type not_found_sentinel,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr)
 {
   auto indices = impl.probe(keys, stream, mr);
@@ -671,7 +669,7 @@ std::unique_ptr<cudf::column> remap_keys_internal(detail::key_remapping_impl con
 }  // namespace
 
 std::unique_ptr<cudf::column> key_remapping::remap_right_keys(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
   // Use the cached right table from the implementation
@@ -679,9 +677,7 @@ std::unique_ptr<cudf::column> key_remapping::remap_right_keys(
 }
 
 std::unique_ptr<cudf::column> key_remapping::remap_left_keys(
-  cudf::table_view const& keys,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& keys, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
   return remap_keys_internal(*_impl, keys, KEY_REMAP_NOT_FOUND, stream, mr);

--- a/cpp/src/join/mark_join.cu
+++ b/cpp/src/join/mark_join.cu
@@ -39,7 +39,7 @@ namespace detail {
 namespace {
 
 std::pair<rmm::device_buffer, bitmask_type const*> build_row_bitmask(table_view const& input,
-                                                                     rmm::cuda_stream_view stream)
+                                                                     cuda::stream_ref stream)
 {
   auto const nullable_columns = get_nullable_columns(input);
   CUDF_EXPECTS(nullable_columns.size() > 0,
@@ -382,14 +382,14 @@ static std::size_t compute_mark_join_capacity(cudf::table_view tbl, double load_
 
 }  // namespace
 
-void mark_join::clear_marks(rmm::cuda_stream_view stream)
+void mark_join::clear_marks(cuda::stream_ref stream)
 {
   auto const storage_ref = _bucket_storage.ref();
   auto const num_buckets = static_cast<cudf::thread_index_type>(storage_ref.num_buckets());
   if (num_buckets == 0) return;
 
   auto const grid_size = cudf::util::div_rounding_up_unsafe(num_buckets, mark_block_size);
-  clear_marks_kernel<mark_block_size><<<grid_size, mark_block_size, 0, stream.value()>>>(
+  clear_marks_kernel<mark_block_size><<<grid_size, mark_block_size, 0, stream.get()>>>(
     storage_ref, static_cast<slot_type>(masked_empty_sentinel), num_buckets);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
@@ -400,7 +400,7 @@ cudf::size_type mark_join::mark_probe_without_prefilter(storage_ref_type storage
                                                         right_key_type const* right_rows,
                                                         cudf::size_type num_right_rows,
                                                         bitmask_type const* right_row_bitmask,
-                                                        rmm::cuda_stream_view stream)
+                                                        cuda::stream_ref stream)
 {
   cudf::detail::device_scalar<cudf::size_type> d_mark_counter(
     0, stream, cudf::get_current_device_resource_ref());
@@ -413,7 +413,7 @@ cudf::size_type mark_join::mark_probe_without_prefilter(storage_ref_type storage
     CUDF_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, 0));
     grid_size *= num_sms;
 
-    mark_probe_kernel<mark_block_size><<<grid_size, mark_block_size, 0, stream.value()>>>(
+    mark_probe_kernel<mark_block_size><<<grid_size, mark_block_size, 0, stream.get()>>>(
       storage_ref,
       masked_probing_scheme{},
       comparator,
@@ -434,7 +434,7 @@ cudf::size_type mark_join::mark_probe_with_prefilter(storage_ref_type storage_re
                                                      right_key_type const* right_rows,
                                                      cudf::size_type num_right_rows,
                                                      bitmask_type const* right_row_bitmask,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(_bloom_filter != nullptr, "Prefilter-enabled mark_join is missing bloom filter.");
@@ -459,7 +459,7 @@ cudf::size_type mark_join::mark_probe_with_prefilter(storage_ref_type storage_re
   filter_grid_size *= num_sms;
 
   compact_if_kernel<mark_block_size, right_key_type, right_key_type, prefilter_operator_type>
-    <<<filter_grid_size, mark_block_size, 0, stream.value()>>>(
+    <<<filter_grid_size, mark_block_size, 0, stream.get()>>>(
       filtered_right_rows.data(), d_filtered_count.data(), prefilter_op);
   CUDF_CUDA_TRY(cudaGetLastError());
 
@@ -474,7 +474,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::mark_probe_and_
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table> preprocessed_right,
   join_kind kind,
   Comparator comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -486,7 +486,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::mark_probe_and_
                                     right_rows.begin(),
                                     right.num_rows(),
                                     cuda::proclaim_return_type<right_key_type>(key_fn),
-                                    stream.value());
+                                    stream.get());
     return right_rows;
   };
 
@@ -554,22 +554,20 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::mark_probe_and_
     grid_size *= num_sms;
 
     if (kind == join_kind::LEFT_SEMI_JOIN) {
-      mark_retrieve_kernel<mark_block_size, false>
-        <<<grid_size, mark_block_size, 0, stream.value()>>>(
-          storage_ref,
-          static_cast<slot_type>(masked_empty_sentinel),
-          result.data(),
-          d_scan_offset.data(),
-          num_buckets);
+      mark_retrieve_kernel<mark_block_size, false><<<grid_size, mark_block_size, 0, stream.get()>>>(
+        storage_ref,
+        static_cast<slot_type>(masked_empty_sentinel),
+        result.data(),
+        d_scan_offset.data(),
+        num_buckets);
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
-      mark_retrieve_kernel<mark_block_size, true>
-        <<<grid_size, mark_block_size, 0, stream.value()>>>(
-          storage_ref,
-          static_cast<slot_type>(masked_empty_sentinel),
-          result.data(),
-          d_scan_offset.data(),
-          num_buckets);
+      mark_retrieve_kernel<mark_block_size, true><<<grid_size, mark_block_size, 0, stream.get()>>>(
+        storage_ref,
+        static_cast<slot_type>(masked_empty_sentinel),
+        result.data(),
+        d_scan_offset.data(),
+        num_buckets);
       CUDF_CUDA_TRY(cudaGetLastError());
     }
   }
@@ -591,7 +589,7 @@ mark_join::mark_join(cudf::table_view const& left,
                      cudf::null_equality compare_nulls,
                      double load_factor,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _has_nested_columns{cudf::has_nested_columns(left)},
     _left{left},
@@ -601,7 +599,7 @@ mark_join::mark_join(cudf::table_view const& left,
     _bucket_storage{
       cuco::extent<std::size_t>{compute_mark_join_capacity(left, checked_load_factor(load_factor))},
       rmm::mr::polymorphic_allocator<char>{mr},
-      stream.value()}
+      stream.get()}
 {
   cudf::scoped_range range{"mark_join::mark_join"};
   if (_left.num_rows() == 0) return;
@@ -612,7 +610,7 @@ mark_join::mark_join(cudf::table_view const& left,
       cuco::cuda_thread_scope<cuda::thread_scope_device>{},
       bloom_filter_policy_type{},
       bloom_filter_allocator_type{std::move(mr)},
-      stream.value());
+      stream.get());
   }
 
   // Any mismatch in nullate between right and left row operators results in UB. Ideally, nullate
@@ -639,9 +637,9 @@ mark_join::mark_join(cudf::table_view const& left,
                                   hashes.end(),
                                   cuda::counting_iterator{size_type{0}},
                                   row_is_valid{row_bitmask_ptr},
-                                  stream.value());
+                                  stream.get());
     } else {
-      _bloom_filter->add_async(hashes.begin(), hashes.end(), stream.value());
+      _bloom_filter->add_async(hashes.begin(), hashes.end(), stream.get());
     }
   };
 
@@ -651,7 +649,7 @@ mark_join::mark_join(cudf::table_view const& left,
     if (has_null_left_keys) {
       cuco::detail::open_addressing_ns::insert_if_n<masked_probing_scheme::cg_size,
                                                     cuco::detail::default_block_size()>
-        <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+        <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
           left_iter,
           _left.num_rows(),
           cuda::counting_iterator<size_type>{0},
@@ -661,7 +659,7 @@ mark_join::mark_join(cudf::table_view const& left,
     } else {
       cuco::detail::open_addressing_ns::insert_if_n<masked_probing_scheme::cg_size,
                                                     cuco::detail::default_block_size()>
-        <<<grid_size, cuco::detail::default_block_size(), 0, stream.value()>>>(
+        <<<grid_size, cuco::detail::default_block_size(), 0, stream.get()>>>(
           left_iter,
           _left.num_rows(),
           cuda::constant_iterator<bool>{true},
@@ -679,7 +677,7 @@ mark_join::mark_join(cudf::table_view const& left,
         left_hashes.begin(),
         _left.num_rows(),
         cuda::proclaim_return_type<hash_value_type>(masked_hash_value_fn{d_left_hasher}),
-        stream.value());
+        stream.get());
       auto const left_iter = cudf::detail::make_counting_transform_iterator(
         size_type{0}, hash_pair_fn<lhs_index_type>{left_hashes.data()});
       cuco::static_multiset_ref set_ref{masked_empty_sentinel,
@@ -737,7 +735,7 @@ mark_join::mark_join(cudf::table_view const& left,
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::semi_anti_join(
   cudf::table_view const& right,
   join_kind kind,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   clear_marks(stream);
@@ -784,7 +782,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::semi_anti_join(
 }
 
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::semi_join(
-  cudf::table_view const& right, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   if (_left.num_rows() == 0 || right.num_rows() == 0) {
     return std::make_unique<rmm::device_uvector<cudf::size_type>>(0, stream, mr);
@@ -793,7 +791,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::semi_join(
 }
 
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> mark_join::anti_join(
-  cudf::table_view const& right, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   if (_left.num_rows() == 0) {
     return std::make_unique<rmm::device_uvector<cudf::size_type>>(0, stream, mr);
@@ -818,7 +816,7 @@ mark_join::~mark_join() = default;
 mark_join::mark_join(cudf::table_view const& left,
                      cudf::null_equality compare_nulls,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<detail::mark_join>(
       left, compare_nulls, detail::CUCO_DESIRED_LOAD_FACTOR, prefilter, stream, std::move(mr))}
@@ -829,7 +827,7 @@ mark_join::mark_join(cudf::table_view const& left,
                      double load_factor,
                      cudf::null_equality compare_nulls,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<detail::mark_join>(
       left, compare_nulls, load_factor, prefilter, stream, std::move(mr))}
@@ -837,18 +835,14 @@ mark_join::mark_join(cudf::table_view const& left,
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> mark_join::semi_join(
-  cudf::table_view const& right,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"mark_join::semi_join"};
   return _impl->semi_join(right, stream, mr);
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> mark_join::anti_join(
-  cudf::table_view const& right,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+  cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"mark_join::anti_join"};
   return _impl->anti_join(right, stream, mr);

--- a/cpp/src/join/mark_join.cuh
+++ b/cpp/src/join/mark_join.cuh
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
@@ -26,6 +25,7 @@
 #include <cuco/probing_scheme.cuh>
 #include <cuco/types.cuh>
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -183,14 +183,14 @@ class mark_join {
             cudf::null_equality compare_nulls,
             double load_factor,
             cudf::join_prefilter prefilter,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> semi_join(
-    cudf::table_view const& right, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+    cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> anti_join(
-    cudf::table_view const& right, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+    cudf::table_view const& right, cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
  private:
   using primitive_row_hasher =
@@ -212,7 +212,7 @@ class mark_join {
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> semi_anti_join(
     cudf::table_view const& right,
     join_kind kind,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
   template <typename Comparator>
@@ -221,7 +221,7 @@ class mark_join {
                                                right_key_type const* right_rows,
                                                cudf::size_type num_right_rows,
                                                bitmask_type const* right_row_bitmask,
-                                               rmm::cuda_stream_view stream);
+                                               cuda::stream_ref stream);
 
   template <typename Comparator>
   cudf::size_type mark_probe_with_prefilter(storage_ref_type storage_ref,
@@ -229,7 +229,7 @@ class mark_join {
                                             right_key_type const* right_rows,
                                             cudf::size_type num_right_rows,
                                             bitmask_type const* right_row_bitmask,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr);
 
   template <typename Comparator>
@@ -238,10 +238,10 @@ class mark_join {
     std::shared_ptr<cudf::detail::row::equality::preprocessed_table> preprocessed_right,
     join_kind kind,
     Comparator comparator,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
-  void clear_marks(rmm::cuda_stream_view stream);
+  void clear_marks(cuda::stream_ref stream);
 };
 
 }  // namespace cudf::detail

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -17,10 +17,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/uninitialized_fill.h>
 
 #include <memory>
@@ -43,7 +43,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 equality_join_indices(cudf::hash_join const& hash_joiner,
                       table_view const& left_equality,
                       join_kind join_type,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   switch (join_type) {
@@ -66,7 +66,7 @@ mixed_join(table_view const& left_equality,
            null_equality compare_nulls,
            join_kind join_type,
            output_size_data_type const& output_size_data,
-           rmm::cuda_stream_view stream,
+           cuda::stream_ref stream,
            rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS((join_type != join_kind::LEFT_SEMI_JOIN) && (join_type != join_kind::LEFT_ANTI_JOIN),
@@ -133,7 +133,7 @@ compute_mixed_join_output_size(table_view const& left_equality,
                                ast::expression const& binary_predicate,
                                null_equality compare_nulls,
                                join_kind join_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(join_type != join_kind::FULL_JOIN,
@@ -189,7 +189,7 @@ mixed_inner_join(
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
   std::optional<std::pair<std::size_t, device_span<size_type const>>> const output_size_data,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -212,7 +212,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_in
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -236,7 +236,7 @@ mixed_left_join(table_view const& left_equality,
                 ast::expression const& binary_predicate,
                 null_equality compare_nulls,
                 output_size_data_type const output_size_data,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -259,7 +259,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -283,7 +283,7 @@ mixed_full_join(table_view const& left_equality,
                 ast::expression const& binary_predicate,
                 null_equality compare_nulls,
                 output_size_data_type const output_size_data,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/mixed_join_kernels_semi.cu
+++ b/cpp/src/join/mixed_join_kernels_semi.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -73,11 +73,11 @@ void launch_mixed_join_semi(bool has_nulls,
                             cudf::ast::detail::expression_device_view device_expression_data,
                             detail::grid_1d const config,
                             int64_t shmem_size_per_block,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   if (has_nulls) {
     mixed_join_semi<DEFAULT_JOIN_BLOCK_SIZE, true>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         left_table,
         right_table,
         probe,
@@ -89,7 +89,7 @@ void launch_mixed_join_semi(bool has_nulls,
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     mixed_join_semi<DEFAULT_JOIN_BLOCK_SIZE, false>
-      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.value()>>>(
+      <<<config.num_blocks, config.num_threads_per_block, shmem_size_per_block, stream.get()>>>(
         left_table,
         right_table,
         probe,

--- a/cpp/src/join/mixed_join_kernels_semi.cuh
+++ b/cpp/src/join/mixed_join_kernels_semi.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -57,7 +57,7 @@ void launch_mixed_join_semi(bool has_nulls,
                             cudf::ast::detail::expression_device_view device_expression_data,
                             detail::grid_1d const config,
                             int64_t shmem_size_per_block,
-                            rmm::cuda_stream_view stream);
+                            cuda::stream_ref stream);
 
 }  // namespace detail
 

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -22,12 +22,12 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 
 #include <optional>
@@ -43,7 +43,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
   join_kind join_type,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS((join_type != join_kind::INNER_JOIN) and (join_type != join_kind::LEFT_JOIN) and
@@ -148,13 +148,13 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
                         {},
                         {},
                         rmm::mr::polymorphic_allocator<char>{},
-                        {stream.value()}};
+                        {stream.get()}};
 
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
 
   // skip rows that are null here.
   if ((compare_nulls == null_equality::EQUAL) or (not nullable(right))) {
-    row_set.insert_async(iter, iter + right_num_rows, stream.value());
+    row_set.insert_async(iter, iter + right_num_rows, stream.get());
   } else {
     cuda::counting_iterator<cudf::size_type> stencil(0);
     auto const [row_bitmask, _] =
@@ -162,7 +162,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows
-    row_set.insert_if_async(iter, iter + right_num_rows, stencil, pred, stream.value());
+    row_set.insert_if_async(iter, iter + right_num_rows, stencil, pred, stream.get());
   }
 
   detail::grid_1d const config(outer_num_rows * hash_set_type::cg_size, DEFAULT_JOIN_BLOCK_SIZE);
@@ -217,7 +217,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_semi_join(
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -239,7 +239,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_anti_join(
   table_view const& right_conditional,
   ast::expression const& binary_predicate,
   null_equality compare_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -26,7 +26,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -54,11 +53,11 @@ namespace cudf {
 
 namespace {
 
-auto make_cub_env(rmm::cuda_stream_view stream)
+auto make_cub_env(cuda::stream_ref stream)
 {
   auto mr_prop = cuda::std::execution::prop{cuda::mr::get_memory_resource,
                                             cudf::get_current_device_resource_ref()};
-  auto env     = cuda::std::execution::env{cuda::stream_ref{stream.value()}, mr_prop};
+  auto env     = cuda::std::execution::env{cuda::stream_ref{stream.get()}, mr_prop};
   return env;
 }
 
@@ -154,7 +153,7 @@ template <typename SortedOrderIterator, typename Less>
 right_run_index build_right_run_index(SortedOrderIterator sorted_order,
                                       size_type num_rows,
                                       Less less,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   auto temp_mr = cudf::get_current_device_resource_ref();
   auto env     = make_cub_env(stream);
@@ -199,7 +198,7 @@ right_run_index build_right_run_index(SortedOrderIterator sorted_order,
 template <typename SortedOrderIterator>
 right_run_index build_right_run_index(table_view const& table,
                                       SortedOrderIterator sorted_order,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   auto const has_nulls = has_nested_nulls(table);
   std::vector<cudf::order> column_order(table.num_columns(), cudf::order::ASCENDING);
@@ -318,7 +317,7 @@ void batched_copy(InputIts input_iterators,
                   OutputIts output_iterators,
                   SizeIt sizes,
                   size_type num_ranges,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
 {
   CUDF_CUDA_TRY(cub::DeviceCopy::Batched(
     input_iterators, output_iterators, sizes, num_ranges, make_cub_env(stream)));
@@ -348,7 +347,7 @@ class merge {
         device_span<size_type const> unique_smaller_rows,
         device_span<size_type const> smaller_run_offsets,
         table_view const& larger,
-        rmm::cuda_stream_view stream)
+        cuda::stream_ref stream)
     : smaller{smaller},
       larger{larger},
       sorted_smaller_order_begin{sorted_smaller_order_begin},
@@ -362,26 +361,24 @@ class merge {
   }
 
   std::unique_ptr<rmm::device_uvector<size_type>> matches_per_row(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   match_ranges find_match_ranges(compute_match_starts compute_starts,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr);
 
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
-  inner(rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  inner(cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
-  left(rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
+  left(cuda::stream_ref stream, rmm::device_async_resource_ref mr);
 };
 
 template <typename SmallerIterator>
 typename merge<SmallerIterator>::match_ranges merge<SmallerIterator>::find_match_ranges(
-  compute_match_starts compute_starts,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  compute_match_starts compute_starts, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto const has_nulls        = has_nested_nulls(smaller) or has_nested_nulls(larger);
   auto const larger_numrows   = larger.num_rows();
@@ -431,7 +428,7 @@ typename merge<SmallerIterator>::match_ranges merge<SmallerIterator>::find_match
 
 template <typename SmallerIterator>
 std::unique_ptr<rmm::device_uvector<size_type>> merge<SmallerIterator>::matches_per_row(
-  rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   return find_match_ranges(compute_match_starts::NO, stream, mr).counts;
 }
@@ -439,7 +436,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> merge<SmallerIterator>::matches_
 template <typename SmallerIterator>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-merge<SmallerIterator>::inner(rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+merge<SmallerIterator>::inner(cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto temp_mr              = cudf::get_current_device_resource_ref();
   auto const larger_numrows = larger.num_rows();
@@ -492,7 +489,7 @@ merge<SmallerIterator>::inner(rmm::cuda_stream_view stream, rmm::device_async_re
 template <typename SmallerIterator>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-merge<SmallerIterator>::left(rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+merge<SmallerIterator>::left(cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto temp_mr              = cudf::get_current_device_resource_ref();
   auto const larger_numrows = larger.num_rows();
@@ -537,7 +534,7 @@ merge<SmallerIterator>::left(rmm::cuda_stream_view stream, rmm::device_async_res
 
 namespace detail {
 
-void sort_merge_join::preprocessed_table::populate_nonnull_filter(rmm::cuda_stream_view stream)
+void sort_merge_join::preprocessed_table::populate_nonnull_filter(cuda::stream_ref stream)
 {
   auto table   = this->_table_view;
   auto temp_mr = cudf::get_current_device_resource_ref();
@@ -640,7 +637,7 @@ void sort_merge_join::preprocessed_table::populate_nonnull_filter(rmm::cuda_stre
   this->_validity_mask = std::move(validity_mask);
 }
 
-void sort_merge_join::preprocessed_table::apply_nonnull_filter(rmm::cuda_stream_view stream)
+void sort_merge_join::preprocessed_table::apply_nonnull_filter(cuda::stream_ref stream)
 {
   auto temp_mr = cudf::get_current_device_resource_ref();
   // construct bool column to apply mask
@@ -655,13 +652,13 @@ void sort_merge_join::preprocessed_table::apply_nonnull_filter(rmm::cuda_stream_
   _null_processed_table_view = _null_processed_table.value()->view();
 }
 
-void sort_merge_join::preprocessed_table::preprocess_unprocessed_table(rmm::cuda_stream_view stream)
+void sort_merge_join::preprocessed_table::preprocess_unprocessed_table(cuda::stream_ref stream)
 {
   populate_nonnull_filter(stream);
   apply_nonnull_filter(stream);
 }
 
-void sort_merge_join::preprocessed_table::compute_sorted_order(rmm::cuda_stream_view stream)
+void sort_merge_join::preprocessed_table::compute_sorted_order(cuda::stream_ref stream)
 {
   auto temp_mr = cudf::get_current_device_resource_ref();
   std::vector<cudf::order> column_order(_null_processed_table_view.num_columns(),
@@ -673,10 +670,7 @@ void sort_merge_join::preprocessed_table::compute_sorted_order(rmm::cuda_stream_
 }
 
 sort_merge_join::preprocessed_table sort_merge_join::preprocessed_table::create(
-  table_view const& table,
-  null_equality compare_nulls,
-  sorted is_sorted,
-  rmm::cuda_stream_view stream)
+  table_view const& table, null_equality compare_nulls, sorted is_sorted, cuda::stream_ref stream)
 {
   preprocessed_table result;
   result._table_view = table;
@@ -700,7 +694,7 @@ sort_merge_join::preprocessed_table sort_merge_join::preprocessed_table::create(
 sort_merge_join::sort_merge_join(table_view const& right,
                                  sorted is_right_sorted,
                                  null_equality compare_nulls,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
   : preprocessed_right{preprocessed_table::create(right, compare_nulls, is_right_sorted, stream)},
     compare_nulls{compare_nulls}
 {
@@ -724,7 +718,7 @@ sort_merge_join::sort_merge_join(table_view const& right,
 }
 
 rmm::device_uvector<size_type> sort_merge_join::preprocessed_table::map_table_to_unprocessed(
-  rmm::cuda_stream_view stream) const
+  cuda::stream_ref stream) const
 {
   CUDF_EXPECTS(_validity_mask.has_value() && _num_nulls.has_value(), "Mapping is not possible");
   auto temp_mr                  = cudf::get_current_device_resource_ref();
@@ -743,7 +737,7 @@ rmm::device_uvector<size_type> sort_merge_join::preprocessed_table::map_table_to
 void sort_merge_join::postprocess_indices(preprocessed_table const& preprocessed_left,
                                           device_span<size_type> smaller_indices,
                                           device_span<size_type> larger_indices,
-                                          rmm::cuda_stream_view stream) const
+                                          cuda::stream_ref stream) const
 {
   if (compare_nulls == null_equality::UNEQUAL) {
     auto env = make_cub_env(stream);
@@ -775,7 +769,7 @@ template <typename MergeOperation>
 auto sort_merge_join::invoke_merge(table_view right_view,
                                    table_view left_view,
                                    MergeOperation&& op,
-                                   rmm::cuda_stream_view stream) const
+                                   cuda::stream_ref stream) const
 {
   auto const unique_right_rows =
     device_span<size_type const>{right_run_rows->data(), static_cast<std::size_t>(num_right_runs)};
@@ -800,7 +794,7 @@ auto sort_merge_join::invoke_merge(table_view right_view,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::inner_join(table_view const& left,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"sort_merge_join::inner_join"};
@@ -831,7 +825,7 @@ sort_merge_join::inner_join(table_view const& left,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::left_join(table_view const& left,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"sort_merge_join::left_join"};
@@ -906,7 +900,7 @@ sort_merge_join::left_join(table_view const& left,
 }
 
 std::unique_ptr<cudf::join_match_context> sort_merge_join::inner_join_match_context(
-  table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"sort_merge_join::inner_join_match_context"};
   // Sanity checks
@@ -955,7 +949,7 @@ std::unique_ptr<cudf::join_match_context> sort_merge_join::inner_join_match_cont
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::partitioned_inner_join(cudf::join_partition_context const& context,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"sort_merge_join::partitioned_inner_join"};
@@ -1017,7 +1011,7 @@ sort_merge_join::~sort_merge_join() = default;
 sort_merge_join::sort_merge_join(table_view const& right,
                                  sorted is_right_sorted,
                                  null_equality compare_nulls,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
   : _impl{std::make_unique<impl_type>(right, is_right_sorted, compare_nulls, stream)}
 {
 }
@@ -1025,7 +1019,7 @@ sort_merge_join::sort_merge_join(table_view const& right,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::inner_join(table_view const& left,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr) const
 {
   return _impl->inner_join(left, stream, mr);
@@ -1035,7 +1029,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::inner_join(table_view const& left,
                             sorted is_left_sorted,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr) const
 {
   static_cast<void>(is_left_sorted);
@@ -1045,7 +1039,7 @@ sort_merge_join::inner_join(table_view const& left,
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::left_join(table_view const& left,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr) const
 {
   return _impl->left_join(left, stream, mr);
@@ -1055,7 +1049,7 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::left_join(table_view const& left,
                            sorted is_left_sorted,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr) const
 {
   static_cast<void>(is_left_sorted);
@@ -1063,7 +1057,7 @@ sort_merge_join::left_join(table_view const& left,
 }
 
 std::unique_ptr<join_match_context> sort_merge_join::inner_join_match_context(
-  table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
+  table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const
 {
   return _impl->inner_join_match_context(left, stream, mr);
 }
@@ -1071,7 +1065,7 @@ std::unique_ptr<join_match_context> sort_merge_join::inner_join_match_context(
 std::unique_ptr<join_match_context> sort_merge_join::inner_join_match_context(
   table_view const& left,
   sorted is_left_sorted,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr) const
 {
   static_cast<void>(is_left_sorted);
@@ -1081,7 +1075,7 @@ std::unique_ptr<join_match_context> sort_merge_join::inner_join_match_context(
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 sort_merge_join::partitioned_inner_join(cudf::join_partition_context const& context,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr) const
 {
   return _impl->partitioned_inner_join(context, stream, mr);

--- a/cpp/src/join/sort_merge_join.hpp
+++ b/cpp/src/join/sort_merge_join.hpp
@@ -13,9 +13,10 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -52,7 +53,7 @@ class sort_merge_join {
   sort_merge_join(table_view const& right,
                   sorted is_right_sorted,
                   null_equality compare_nulls,
-                  rmm::cuda_stream_view stream);
+                  cuda::stream_ref stream);
 
   /**
    * @brief Returns the row indices for an inner join.
@@ -65,7 +66,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(table_view const& left,
-             rmm::cuda_stream_view stream,
+             cuda::stream_ref stream,
              rmm::device_async_resource_ref mr) const;
 
   /**
@@ -79,7 +80,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(table_view const& left,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             rmm::device_async_resource_ref mr) const;
 
   /**
@@ -91,7 +92,7 @@ class sort_merge_join {
    * @return A unique_ptr to join_match_context
    */
   std::unique_ptr<join_match_context> inner_join_match_context(
-    table_view const& left, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const;
+    table_view const& left, cuda::stream_ref stream, rmm::device_async_resource_ref mr) const;
 
   /**
    * @brief Performs an inner join between a partition of the left table and the right table.
@@ -104,7 +105,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_inner_join(cudf::join_partition_context const& context,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr) const;
 
  private:
@@ -141,7 +142,7 @@ class sort_merge_join {
     static preprocessed_table create(table_view const& table,
                                      null_equality compare_nulls,
                                      sorted is_sorted,
-                                     rmm::cuda_stream_view stream);
+                                     cuda::stream_ref stream);
 
     /**
      * @brief Mark rows in unprocessed table with nulls at root or child levels by populating the
@@ -149,28 +150,28 @@ class sort_merge_join {
      *
      * @param stream CUDA stream used for device memory operations and kernel launches
      */
-    void populate_nonnull_filter(rmm::cuda_stream_view stream);
+    void populate_nonnull_filter(cuda::stream_ref stream);
 
     /**
      * @brief Apply _validity_mask to the _table_view to create a null-free table
      *
      * @param stream CUDA stream used for device memory operations and kernel launches
      */
-    void apply_nonnull_filter(rmm::cuda_stream_view stream);
+    void apply_nonnull_filter(cuda::stream_ref stream);
 
     /**
      * @brief Pre-process the unprocessed table when null equality is set to unequal
      *
      * @param stream CUDA stream used for device memory operations and kernel launches
      */
-    void preprocess_unprocessed_table(rmm::cuda_stream_view stream);
+    void preprocess_unprocessed_table(cuda::stream_ref stream);
 
     /**
      * @brief Compute sorted ordering of the processed table
      *
      * @param stream CUDA stream used for device memory operations and kernel launches
      */
-    void compute_sorted_order(rmm::cuda_stream_view stream);
+    void compute_sorted_order(cuda::stream_ref stream);
 
     /**
      * @brief Create mapping from processed table indices to unprocessed table indices
@@ -179,7 +180,7 @@ class sort_merge_join {
      * @return A device vector containing the mapping from processed table indices to unprocessed
      * table indices
      */
-    rmm::device_uvector<size_type> map_table_to_unprocessed(rmm::cuda_stream_view stream) const;
+    rmm::device_uvector<size_type> map_table_to_unprocessed(cuda::stream_ref stream) const;
   };
 
   /**
@@ -229,7 +230,7 @@ class sort_merge_join {
   void postprocess_indices(preprocessed_table const& preprocessed_left,
                            device_span<size_type> smaller_indices,
                            device_span<size_type> larger_indices,
-                           rmm::cuda_stream_view stream) const;
+                           cuda::stream_ref stream) const;
 
   /**
    * @brief Core merge operation implementation for the sort-merge join algorithm.
@@ -245,7 +246,7 @@ class sort_merge_join {
   auto invoke_merge(table_view right_view,
                     table_view left_view,
                     MergeOperation&& op,
-                    rmm::cuda_stream_view stream) const;
+                    cuda::stream_ref stream) const;
 };
 
 }  // namespace detail

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,7 +45,7 @@ struct all_fn {
 
   template <typename T>
   std::unique_ptr<scalar> operator()(column_view const& input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<T>)
   {
@@ -66,7 +66,7 @@ struct all_fn {
   }
   template <typename T>
   std::unique_ptr<scalar> operator()(column_view const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(!std::is_arithmetic_v<T>)
   {
@@ -79,7 +79,7 @@ struct all_fn {
 std::unique_ptr<cudf::scalar> all(column_view const& col,
                                   cudf::data_type const output_dtype,
                                   std::optional<std::reference_wrapper<scalar const>> init,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,7 +45,7 @@ struct any_fn {
 
   template <typename T>
   std::unique_ptr<scalar> operator()(column_view const& input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<T>)
   {
@@ -66,7 +66,7 @@ struct any_fn {
   }
   template <typename T>
   std::unique_ptr<scalar> operator()(column_view const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(!std::is_arithmetic_v<T>)
   {
@@ -79,7 +79,7 @@ struct any_fn {
 std::unique_ptr<cudf::scalar> any(column_view const& col,
                                   cudf::data_type const output_dtype,
                                   std::optional<std::reference_wrapper<scalar const>> init,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),

--- a/cpp/src/reductions/approx_distinct_count.cu
+++ b/cpp/src/reductions/approx_distinct_count.cu
@@ -15,12 +15,12 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 
 #include <cmath>
 #include <utility>
@@ -166,7 +166,7 @@ approx_distinct_count<Hasher>::approx_distinct_count(
   std::int32_t precision,
   null_policy null_handling,
   nan_policy nan_handling,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _mr{std::move(mr)},
     _storage{rmm::device_uvector<register_type>{
@@ -176,7 +176,7 @@ approx_distinct_count<Hasher>::approx_distinct_count(
     _nan_handling{nan_handling}
 {
   auto sketch_span = sketch();
-  CUDF_CUDA_TRY(cudaMemsetAsync(sketch_span.data(), 0, sketch_span.size(), stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(sketch_span.data(), 0, sketch_span.size(), stream.get()));
 
   if (input.num_rows() > 0) { add(input, stream); }
 }
@@ -187,7 +187,7 @@ approx_distinct_count<Hasher>::approx_distinct_count(
   cudf::approx_distinct_count::desired_standard_error error,
   null_policy null_handling,
   nan_policy nan_handling,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : approx_distinct_count{input,
                           precision_from_standard_error(error.value),
@@ -214,7 +214,7 @@ approx_distinct_count<Hasher>::approx_distinct_count(
 }
 
 template <template <typename> class Hasher>
-void approx_distinct_count<Hasher>::add(table_view const& input, rmm::cuda_stream_view stream)
+void approx_distinct_count<Hasher>::add(table_view const& input, cuda::stream_ref stream)
 {
   auto const num_rows = input.num_rows();
   if (num_rows == 0) { return; }
@@ -268,7 +268,7 @@ void approx_distinct_count<Hasher>::add(table_view const& input, rmm::cuda_strea
 
 template <template <typename> class Hasher>
 void approx_distinct_count<Hasher>::merge(approx_distinct_count const& other,
-                                          rmm::cuda_stream_view stream)
+                                          cuda::stream_ref stream)
 {
   CUDF_EXPECTS(_precision == other._precision,
                "Cannot merge sketches with different precisions",
@@ -288,7 +288,7 @@ void approx_distinct_count<Hasher>::merge(approx_distinct_count const& other,
 
 template <template <typename> class Hasher>
 void approx_distinct_count<Hasher>::merge(cuda::std::span<cuda::std::byte const> sketch_span,
-                                          rmm::cuda_stream_view stream)
+                                          cuda::stream_ref stream)
 {
   auto const checked = check_sketch_span(sketch_span, _precision);
 
@@ -300,7 +300,7 @@ void approx_distinct_count<Hasher>::merge(cuda::std::span<cuda::std::byte const>
 }
 
 template <template <typename> class Hasher>
-std::size_t approx_distinct_count<Hasher>::estimate(rmm::cuda_stream_view stream) const
+std::size_t approx_distinct_count<Hasher>::estimate(cuda::stream_ref stream) const
 {
   typename approx_distinct_count<Hasher>::hll_ref_type ref{
     const_cast<approx_distinct_count*>(this)->sketch(), cuda::std::identity{}};
@@ -374,7 +374,7 @@ approx_distinct_count::approx_distinct_count(table_view const& input,
                                              std::int32_t precision,
                                              null_policy null_handling,
                                              nan_policy nan_handling,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl(std::make_unique<impl_type>(
       input, precision, null_handling, nan_handling, stream, std::move(mr)))
@@ -385,7 +385,7 @@ approx_distinct_count::approx_distinct_count(table_view const& input,
                                              desired_standard_error error,
                                              null_policy null_handling,
                                              nan_policy nan_handling,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl(
       std::make_unique<impl_type>(input, error, null_handling, nan_handling, stream, std::move(mr)))
@@ -401,23 +401,23 @@ approx_distinct_count::approx_distinct_count(cuda::std::span<cuda::std::byte> sk
 {
 }
 
-void approx_distinct_count::add(table_view const& input, rmm::cuda_stream_view stream)
+void approx_distinct_count::add(table_view const& input, cuda::stream_ref stream)
 {
   _impl->add(input, stream);
 }
 
-void approx_distinct_count::merge(approx_distinct_count const& other, rmm::cuda_stream_view stream)
+void approx_distinct_count::merge(approx_distinct_count const& other, cuda::stream_ref stream)
 {
   _impl->merge(*other._impl, stream);
 }
 
 void approx_distinct_count::merge(cuda::std::span<cuda::std::byte const> sketch_span,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   _impl->merge(sketch_span, stream);
 }
 
-std::size_t approx_distinct_count::estimate(rmm::cuda_stream_view stream) const
+std::size_t approx_distinct_count::estimate(cuda::stream_ref stream) const
 {
   return _impl->estimate(stream);
 }

--- a/cpp/src/reductions/argmax.cu
+++ b/cpp/src/reductions/argmax.cu
@@ -9,7 +9,7 @@ namespace cudf::reduction::detail {
 
 std::unique_ptr<scalar> argmax(column_view const& input,
                                data_type dispatch_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(

--- a/cpp/src/reductions/argmin.cu
+++ b/cpp/src/reductions/argmin.cu
@@ -9,7 +9,7 @@ namespace cudf::reduction::detail {
 
 std::unique_ptr<scalar> argmin(column_view const& input,
                                data_type dispatch_type,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(

--- a/cpp/src/reductions/bitwise.cu
+++ b/cpp/src/reductions/bitwise.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ struct dispatch_void_if_non_integral {
 
 std::unique_ptr<scalar> bitwise_reduction(bitwise_op bit_op,
                                           column_view const& col,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   auto const dtype =

--- a/cpp/src/reductions/collect_ops.cu
+++ b/cpp/src/reductions/collect_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -34,7 +34,7 @@ bool need_handle_nulls(column_view const& input, null_policy null_handling)
 
 std::unique_ptr<scalar> collect_list(column_view const& col,
                                      null_policy null_handling,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   if (need_handle_nulls(col, null_handling)) {
@@ -50,7 +50,7 @@ std::unique_ptr<scalar> collect_list(column_view const& col,
 }
 
 std::unique_ptr<scalar> merge_lists(lists_column_view const& col,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   auto flatten_col = col.get_sliced_child(stream);
@@ -61,7 +61,7 @@ std::unique_ptr<scalar> collect_set(column_view const& col,
                                     null_policy null_handling,
                                     null_equality nulls_equal,
                                     nan_equality nans_equal,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   // `input_as_collect_list` is the result of the input column that has been processed to obey
@@ -90,7 +90,7 @@ std::unique_ptr<scalar> collect_set(column_view const& col,
 std::unique_ptr<scalar> merge_sets(lists_column_view const& col,
                                    null_equality nulls_equal,
                                    nan_equality nans_equal,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   auto flatten_col    = col.get_sliced_child(stream);

--- a/cpp/src/reductions/compound.cuh
+++ b/cpp/src/reductions/compound.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -42,7 +42,7 @@ template <typename ElementType, typename ResultType, typename Op>
 std::unique_ptr<scalar> compound_reduction(column_view const& col,
                                            data_type const output_dtype,
                                            size_type ddof,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   auto const valid_count = col.size() - col.null_count();
@@ -99,7 +99,7 @@ struct result_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      cudf::data_type const output_dtype,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported_v<ResultType>())
   {
@@ -110,7 +110,7 @@ struct result_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      cudf::data_type const output_dtype,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(not is_supported_v<ResultType>())
   {
@@ -134,7 +134,7 @@ struct element_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      cudf::data_type const output_dtype,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported_v<ElementType>())
   {
@@ -147,7 +147,7 @@ struct element_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      cudf::data_type const output_dtype,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(not is_supported_v<ElementType>())
   {

--- a/cpp/src/reductions/count.cpp
+++ b/cpp/src/reductions/count.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -20,7 +20,7 @@ struct count_scalar_fn {
   template <typename T>
     requires(cudf::is_numeric_not_bool<T>())
   std::unique_ptr<cudf::scalar> operator()(size_type count,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     auto const value = static_cast<T>(count);
@@ -30,7 +30,7 @@ struct count_scalar_fn {
   template <typename T>
     requires(not cudf::is_numeric_not_bool<T>())
   std::unique_ptr<cudf::scalar> operator()(size_type,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("COUNT is not supported for boolean or non-numeric types", std::invalid_argument);
@@ -41,7 +41,7 @@ struct count_scalar_fn {
 std::unique_ptr<cudf::scalar> count(column_view const& col,
                                     cudf::null_policy null_handling,
                                     cudf::data_type const output_dtype,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   auto const count = col.size() - (null_handling == null_policy::EXCLUDE ? col.null_count() : 0);

--- a/cpp/src/reductions/distinct_count.cu
+++ b/cpp/src/reductions/distinct_count.cu
@@ -18,12 +18,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/logical.h>
@@ -96,7 +96,7 @@ struct has_nans {
    * @returns bool true if `input` has `NaN` else false
    */
   template <typename T>
-  bool operator()(column_view const& input, rmm::cuda_stream_view stream)
+  bool operator()(column_view const& input, cuda::stream_ref stream)
     requires(std::is_floating_point_v<T>)
   {
     auto input_device_view = cudf::column_device_view::create(input, stream);
@@ -120,7 +120,7 @@ struct has_nans {
    * @returns bool Always false as non-floating point columns can't have `NaN`
    */
   template <typename T>
-  bool operator()(column_view const&, rmm::cuda_stream_view)
+  bool operator()(column_view const&, cuda::stream_ref)
     requires(not std::is_floating_point_v<T>)
   {
     return false;
@@ -130,7 +130,7 @@ struct has_nans {
 
 cudf::size_type distinct_count(table_view const& keys,
                                null_equality nulls_equal,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   auto const num_rows = keys.num_rows();
   if (num_rows == 0) { return 0; }  // early exit for empty input
@@ -151,7 +151,7 @@ cudf::size_type distinct_count(table_view const& keys,
                                          {},
                                          {},
                                     rmm::mr::polymorphic_allocator<char>{},
-                                    stream.value()};
+                                    stream.get()};
 
     auto const iter = cuda::counting_iterator<cudf::size_type>{0};
     // when nulls are equal, we skip hashing any row that has a null
@@ -170,11 +170,11 @@ cudf::size_type distinct_count(table_view const& keys,
       // to do a filtered insertion.
       if (null_count > 0) {
         row_validity pred{static_cast<bitmask_type const*>(row_bitmask.data())};
-        return key_set.insert_if(iter, iter + num_rows, stencil, pred, stream.value()) + 1;
+        return key_set.insert_if(iter, iter + num_rows, stencil, pred, stream.get()) + 1;
       }
     }
     // otherwise, insert all
-    return key_set.insert(iter, iter + num_rows, stream.value());
+    return key_set.insert(iter, iter + num_rows, stream.get());
   };
 
   if (cudf::detail::has_nested_columns(keys)) {
@@ -189,7 +189,7 @@ cudf::size_type distinct_count(table_view const& keys,
 cudf::size_type distinct_count(column_view const& input,
                                null_policy null_handling,
                                nan_policy nan_handling,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   if (0 == input.size()) { return 0; }
 
@@ -221,7 +221,7 @@ cudf::size_type distinct_count(column_view const& input,
 cudf::size_type distinct_count(column_view const& input,
                                null_policy null_handling,
                                nan_policy nan_handling,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::distinct_count(input, null_handling, nan_handling, stream);
@@ -229,7 +229,7 @@ cudf::size_type distinct_count(column_view const& input,
 
 cudf::size_type distinct_count(table_view const& input,
                                null_equality nulls_equal,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::distinct_count(input, nulls_equal, stream);

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -14,10 +14,10 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/extrema.h>
 
 namespace cudf::reduction::simple::detail {
@@ -61,7 +61,7 @@ class arg_minmax_dispatcher {
   template <typename InputIterator, typename... Args>
   size_type find_extremum_idx(InputIterator it,
                               size_type size,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               Args&&... args) const
   {
     auto const pos = [&] {
@@ -83,8 +83,7 @@ class arg_minmax_dispatcher {
   }
 
   template <typename ElementType>
-  [[nodiscard]] size_type find_arg_minmax(column_view const& input,
-                                          rmm::cuda_stream_view stream) const
+  [[nodiscard]] size_type find_arg_minmax(column_view const& input, cuda::stream_ref stream) const
     requires(cudf::is_nested<ElementType>())
   {
     using Op = std::conditional_t<K == aggregation::ARGMIN,
@@ -103,8 +102,7 @@ class arg_minmax_dispatcher {
   // the lexicographic self_comparator compares `keys[indices[i]]` for dictionary columns
   // directly, so no decoding is required and no assumption is made that the keys are sorted.
   template <typename ElementType>
-  [[nodiscard]] size_type find_arg_minmax(column_view const& input,
-                                          rmm::cuda_stream_view stream) const
+  [[nodiscard]] size_type find_arg_minmax(column_view const& input, cuda::stream_ref stream) const
     requires(not cudf::is_nested<ElementType>() and not cudf::is_numeric<ElementType>())
   {
     // Nulls are considered "greater" (ARGMIN), or "less" (ARGMAX) than non-null values.
@@ -122,7 +120,7 @@ class arg_minmax_dispatcher {
 
   template <typename ElementType>
   [[nodiscard]] size_type find_arg_minmax(column_view const& input,
-                                          rmm::cuda_stream_view stream) const
+                                          cuda::stream_ref stream) const
     requires(cudf::is_numeric<ElementType>())  // integer + floating point numbers
   {
     using Op = std::conditional_t<K == aggregation::ARGMIN,
@@ -166,7 +164,7 @@ class arg_minmax_dispatcher {
    */
   template <typename ElementType>
   [[nodiscard]] std::unique_ptr<scalar> operator()(column_view const& input,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr) const
     requires(is_supported<ElementType>())
   {
@@ -176,7 +174,7 @@ class arg_minmax_dispatcher {
 
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref) const
     requires(not is_supported<ElementType>())
   {

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -62,7 +62,7 @@ struct is_not_zero {
 auto gather_histogram(table_view const& input,
                       device_span<size_type const> distinct_indices,
                       std::unique_ptr<column>&& distinct_counts,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   auto distinct_rows = cudf::detail::gather(input,
@@ -100,7 +100,7 @@ std::unique_ptr<column> make_empty_histogram_like(column_view const& values)
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>, std::unique_ptr<column>>
 compute_row_frequencies(table_view const& input,
                         std::optional<column_view> const& partial_counts,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   auto const has_nested_columns = cudf::detail::has_nested_columns(input);
@@ -148,7 +148,7 @@ compute_row_frequencies(table_view const& input,
                      {},  // thread scope
                      {},  // storage
                      rmm::mr::polymorphic_allocator<char>{},
-                     stream.value()};
+                     stream.get()};
 
   // Device-accessible reference to the hash set with `insert_and_find` operator
   auto row_set_ref = row_set.ref(cuco::op::insert_and_find);
@@ -193,7 +193,7 @@ compute_row_frequencies(table_view const& input,
 }
 
 std::unique_ptr<cudf::scalar> histogram(column_view const& input,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   // Empty group should be handled before reaching here.
@@ -206,7 +206,7 @@ std::unique_ptr<cudf::scalar> histogram(column_view const& input,
 }
 
 std::unique_ptr<cudf::scalar> merge_histogram(column_view const& input,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   // Empty group should be handled before reaching here.

--- a/cpp/src/reductions/max.cu
+++ b/cpp/src/reductions/max.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> max(column_view const& col,
                                   cudf::data_type const output_dtype,
                                   std::optional<std::reference_wrapper<scalar const>> init,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto const input_type =

--- a/cpp/src/reductions/mean.cu
+++ b/cpp/src/reductions/mean.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -17,7 +17,7 @@ namespace detail {
 
 std::unique_ptr<cudf::scalar> mean(column_view const& col,
                                    cudf::data_type const output_dtype,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   auto col_type =

--- a/cpp/src/reductions/min.cu
+++ b/cpp/src/reductions/min.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> min(column_view const& col,
                                   data_type const output_dtype,
                                   std::optional<std::reference_wrapper<scalar const>> init,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   auto const input_type =

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -18,11 +18,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/transform_reduce.h>
 
 #include <type_traits>
@@ -64,10 +63,7 @@ struct minmax_pair {
 template <typename Op,
           typename InputIterator,
           typename OutputType = cuda::std::iter_value_t<InputIterator>>
-auto reduce_device(InputIterator d_in,
-                   size_type num_items,
-                   Op binary_op,
-                   rmm::cuda_stream_view stream)
+auto reduce_device(InputIterator d_in, size_type num_items, Op binary_op, cuda::stream_ref stream)
 {
   OutputType identity{};
   cudf::detail::device_scalar<OutputType> result{
@@ -76,7 +72,7 @@ auto reduce_device(InputIterator d_in,
   // Allocate temporary storage
   size_t storage_bytes = 0;
   cub::DeviceReduce::Reduce(
-    nullptr, storage_bytes, d_in, result.data(), num_items, binary_op, identity, stream.value());
+    nullptr, storage_bytes, d_in, result.data(), num_items, binary_op, identity, stream.get());
   auto temp_storage =
     rmm::device_buffer{storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
@@ -88,7 +84,7 @@ auto reduce_device(InputIterator d_in,
                             num_items,
                             binary_op,
                             identity,
-                            stream.value());
+                            stream.get());
 
   return result;
 }
@@ -154,7 +150,7 @@ struct assign_min_max {
  * @tparam T The dictionary's key type
  */
 template <typename T>
-auto reduce_dictionary(column_view const& col, rmm::cuda_stream_view stream)
+auto reduce_dictionary(column_view const& col, cuda::stream_ref stream)
 {
   auto d_dictionary = column_device_view::create(col, stream);
   if (col.has_nulls()) {
@@ -183,7 +179,7 @@ struct minmax_dictionary_functor {
 
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(is_supported<T>() and !std::is_same_v<T, cudf::string_view>)
   {
     using storage_type  = device_storage_type_t<T>;
@@ -199,7 +195,7 @@ struct minmax_dictionary_functor {
 
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(std::is_same_v<T, cudf::string_view>)
   {
     auto dev_result        = reduce_dictionary<cudf::string_view>(col, stream);
@@ -210,7 +206,7 @@ struct minmax_dictionary_functor {
 
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    column_view const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+    column_view const&, cuda::stream_ref, rmm::device_async_resource_ref)
     requires(!is_supported<T>())
   {
     CUDF_FAIL("dictionary key type not supported for minmax() operation");
@@ -233,7 +229,7 @@ struct minmax_functor {
   }
 
   template <typename T>
-  auto reduce(column_view const& col, rmm::cuda_stream_view stream)
+  auto reduce(column_view const& col, cuda::stream_ref stream)
   {
     auto device_col = column_device_view::create(col, stream);
     // compute minimum and maximum values
@@ -250,7 +246,7 @@ struct minmax_functor {
 
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    cudf::column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    cudf::column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(is_supported<T>() and !std::is_same_v<T, cudf::string_view> and
              !cudf::is_dictionary<T>())
   {
@@ -272,7 +268,7 @@ struct minmax_functor {
    */
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    cudf::column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    cudf::column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(std::is_same_v<T, cudf::string_view>)
   {
     // compute minimum and maximum values
@@ -289,7 +285,7 @@ struct minmax_functor {
    */
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    cudf::column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    cudf::column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(cudf::is_dictionary<T>())
   {
     auto const keys_type = dictionary_column_view(col).keys().type();
@@ -298,7 +294,7 @@ struct minmax_functor {
 
   template <typename T>
   std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> operator()(
-    cudf::column_view const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+    cudf::column_view const&, cuda::stream_ref, rmm::device_async_resource_ref)
     requires(!is_supported<T>())
   {
     CUDF_FAIL("type not supported for minmax() operation");
@@ -313,7 +309,7 @@ struct minmax_functor {
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
-  cudf::column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   if (col.null_count() == col.size()) {
     // this handles empty and all-null columns; return scalars with valid==false.
@@ -331,7 +327,7 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
 }  // namespace reduction
 
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
-  column_view const& col, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& col, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   return reduction::detail::minmax(col, stream, mr);

--- a/cpp/src/reductions/nested_types_extrema_utils.cuh
+++ b/cpp/src/reductions/nested_types_extrema_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -73,7 +73,7 @@ class arg_minmax_binop_generator {
   cudf::table_view const input_tview;
   bool const has_nulls;
   bool const is_min_op;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   // Contains data used in `row_comparator` below, thus needs to be kept alive as a member variable.
   std::unique_ptr<cudf::structs::detail::flattened_table> const flattened_input;
@@ -81,9 +81,7 @@ class arg_minmax_binop_generator {
   // Contains data used in the returned binop, thus needs to be kept alive as a member variable.
   cudf::detail::row::lexicographic::self_comparator row_comparator;
 
-  arg_minmax_binop_generator(column_view const& input_,
-                             bool is_min_op_,
-                             rmm::cuda_stream_view stream_)
+  arg_minmax_binop_generator(column_view const& input_, bool is_min_op_, cuda::stream_ref stream_)
     : input_tview{cudf::table_view{{input_}}},
       has_nulls{cudf::has_nested_nulls(input_tview)},
       is_min_op{is_min_op_},
@@ -153,7 +151,7 @@ class arg_minmax_binop_generator {
   auto binop() const { return row_arg_minmax_fn(input_tview.num_rows(), less(), is_min_op); }
 
   template <typename BinOp>
-  static auto create(column_view const& input, rmm::cuda_stream_view stream)
+  static auto create(column_view const& input, cuda::stream_ref stream)
   {
     CUDF_EXPECTS(cudf::is_nested(input.type()),
                  "This utility class is designed exclusively for nested input types.");
@@ -164,7 +162,7 @@ class arg_minmax_binop_generator {
   }
 
   template <cudf::aggregation::Kind K>
-  static auto create(column_view const& input, rmm::cuda_stream_view stream)
+  static auto create(column_view const& input, cuda::stream_ref stream)
   {
     CUDF_EXPECTS(cudf::is_nested(input.type()),
                  "This utility class is designed exclusively for nested input types.");

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,11 +10,11 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
@@ -24,7 +24,7 @@ namespace cudf::reduction::detail {
 std::unique_ptr<cudf::scalar> nth_element(column_view const& col,
                                           size_type n,
                                           null_policy null_handling,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(n >= -col.size() and n < col.size(), "Index out of bounds");

--- a/cpp/src/reductions/nunique.cpp
+++ b/cpp/src/reductions/nunique.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -20,7 +20,7 @@ struct nunique_scalar_fn {
   template <typename T>
     requires(cudf::is_numeric_not_bool<T>())
   std::unique_ptr<cudf::scalar> operator()(size_type count,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     auto const value = static_cast<T>(count);
@@ -30,7 +30,7 @@ struct nunique_scalar_fn {
   template <typename T>
     requires(not cudf::is_numeric_not_bool<T>())
   std::unique_ptr<cudf::scalar> operator()(size_type,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("NUNIQUE is not supported for boolean or non-numeric types", std::invalid_argument);
@@ -41,7 +41,7 @@ struct nunique_scalar_fn {
 std::unique_ptr<cudf::scalar> nunique(column_view const& col,
                                       cudf::null_policy null_handling,
                                       cudf::data_type const output_dtype,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   size_type count =

--- a/cpp/src/reductions/product.cu
+++ b/cpp/src/reductions/product.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> product(column_view const& col,
                                       cudf::data_type const output_dtype,
                                       std::optional<std::reference_wrapper<scalar const>> init,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   return cudf::type_dispatcher(

--- a/cpp/src/reductions/quantile.cu
+++ b/cpp/src/reductions/quantile.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -21,7 +21,7 @@ std::unique_ptr<cudf::scalar> quantile(column_view const& col,
                                        double quantile_value,
                                        cudf::interpolation interpolation,
                                        cudf::data_type const output_type,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto current_mr = cudf::get_current_device_resource_ref();

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -19,7 +19,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <utility>
 
@@ -38,14 +38,14 @@ struct reduction_parameters {
   column_view const& col;
   data_type const output_dtype;
   std::optional<std::reference_wrapper<scalar const>> init;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   reduction_parameters(reduce_aggregation const& agg,
                        column_view const& col,
                        data_type const output_dtype,
                        std::optional<std::reference_wrapper<scalar const>> init,
-                       rmm::cuda_stream_view stream,
+                       cuda::stream_ref stream,
                        rmm::device_async_resource_ref mr)
     : agg(agg), col(col), output_dtype(output_dtype), init(init), stream(stream), mr(std::move(mr))
   {
@@ -475,7 +475,7 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                reduce_aggregation const& agg,
                                data_type output_dtype,
                                std::optional<std::reference_wrapper<scalar const>> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!init.has_value() || cudf::have_same_types(col, init.value().get()),
@@ -517,7 +517,7 @@ bool is_valid_aggregation(data_type source, aggregation::Kind kind)
 std::unique_ptr<scalar> reduce(column_view const& col,
                                reduce_aggregation const& agg,
                                data_type output_dtype,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -528,7 +528,7 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                reduce_aggregation const& agg,
                                data_type output_dtype,
                                std::optional<std::reference_wrapper<scalar const>> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/reductions/scan/ewm.cu
+++ b/cpp/src/reductions/scan/ewm.cu
@@ -11,13 +11,13 @@
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 #include <thrust/transform_scan.h>
 
@@ -130,8 +130,7 @@ struct ewma_noadjust_no_nulls_functor : public ewma_functor_base<T> {
 * Example: {1, NULL, 3, 4, NULL, NULL, 7}
         -> {0, 0     1, 0, 0,    1,    2}
 */
-rmm::device_uvector<cudf::size_type> null_roll_up(column_view const& input,
-                                                  rmm::cuda_stream_view stream)
+rmm::device_uvector<cudf::size_type> null_roll_up(column_view const& input, cuda::stream_ref stream)
 {
   rmm::device_uvector<cudf::size_type> output(input.size(), stream);
 
@@ -153,7 +152,7 @@ rmm::device_uvector<cudf::size_type> null_roll_up(column_view const& input,
 template <typename T>
 rmm::device_uvector<T> compute_ewma_adjust(column_view const& input,
                                            T const beta,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<T> output(input.size(), stream);
@@ -225,7 +224,7 @@ rmm::device_uvector<T> compute_ewma_adjust(column_view const& input,
 template <typename T>
 rmm::device_uvector<T> compute_ewma_noadjust(column_view const& input,
                                              T const beta,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<T> output(input.size(), stream);
@@ -281,7 +280,7 @@ struct ewma_functor {
   template <typename T, CUDF_ENABLE_IF(!std::is_floating_point<T>::value)>
   std::unique_ptr<column> operator()(scan_aggregation const& agg,
                                      column_view const& input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     CUDF_FAIL("Unsupported type for EWMA.");
@@ -290,7 +289,7 @@ struct ewma_functor {
   template <typename T, CUDF_ENABLE_IF(std::is_floating_point<T>::value)>
   std::unique_ptr<column> operator()(scan_aggregation const& agg,
                                      column_view const& input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     auto const ewma_agg       = dynamic_cast<ewma_aggregation const*>(&agg);
@@ -318,7 +317,7 @@ struct ewma_functor {
 
 std::unique_ptr<column> exponentially_weighted_moving_average(column_view const& input,
                                                               scan_aggregation const& agg,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(input.type(), ewma_functor{}, agg, input, stream, mr);

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,10 +12,10 @@
 #include <cudf/detail/utilities/device_operators.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
@@ -56,7 +56,7 @@ template <typename value_resolver, typename scan_operator>
 std::unique_ptr<column> rank_generator(column_view const& order_by,
                                        value_resolver resolver,
                                        scan_operator scan_op,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto const order_by_tview = table_view{{order_by}};
@@ -96,7 +96,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
 }  // namespace
 
 std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr)
 {
   return rank_generator(
@@ -108,7 +108,7 @@ std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
 }
 
 std::unique_ptr<column> inclusive_rank_scan(column_view const& order_by,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!cudf::structs::detail::is_or_has_nested_lists(order_by),
@@ -122,7 +122,7 @@ std::unique_ptr<column> inclusive_rank_scan(column_view const& order_by,
 }
 
 std::unique_ptr<column> inclusive_one_normalized_percent_rank_scan(
-  column_view const& order_by, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& order_by, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto const rank_column =
     inclusive_rank_scan(order_by, stream, cudf::get_current_device_resource_ref());

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@ std::unique_ptr<column> scan(column_view const& input,
                              scan_aggregation const& agg,
                              scan_type inclusive,
                              null_policy null_handling,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   if (agg.kind == aggregation::RANK) {
@@ -46,7 +46,7 @@ std::unique_ptr<column> scan(column_view const& input,
                              scan_aggregation const& agg,
                              scan_type inclusive,
                              null_policy null_handling,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/reductions/scan/scan.cuh
+++ b/cpp/src/reductions/scan/scan.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <utility>
 
@@ -22,20 +22,20 @@ namespace detail {
 // logical-and scan of the null mask of the input view
 std::pair<rmm::device_buffer, size_type> mask_scan(column_view const& input_view,
                                                    scan_type inclusive,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr);
 
 // exponentially weighted moving average of the input
 std::unique_ptr<column> exponentially_weighted_moving_average(column_view const& input,
                                                               scan_aggregation const& agg,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr);
 
 template <template <typename> typename DispatchFn>
 std::unique_ptr<column> scan_agg_dispatch(column_view const& input,
                                           scan_aggregation const& agg,
                                           bitmask_type const* output_mask,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   switch (agg.kind) {

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,10 +14,10 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/scan.h>
 
 namespace cudf {
@@ -45,7 +45,7 @@ struct scan_dispatcher {
   template <typename T>
   std::unique_ptr<column> operator()(column_view const& input,
                                      bitmask_type const*,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cuda::std::is_arithmetic_v<T>)
   {
@@ -67,7 +67,7 @@ struct scan_dispatcher {
                            identity,
                            binary_op);
 
-    CUDF_CHECK_CUDA(stream.value());
+    CUDF_CHECK_CUDA(stream.get());
     return output_column;
   }
 
@@ -84,7 +84,7 @@ struct scan_dispatcher {
 std::unique_ptr<column> scan_exclusive(column_view const& input,
                                        scan_aggregation const& agg,
                                        null_policy null_handling,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto [mask, null_count] = [&] {

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,11 +19,11 @@
 #include <cudf/structs/detail/scan.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/find.h>
 #include <thrust/scan.h>
 
@@ -35,7 +35,7 @@ namespace detail {
 // logical-and scan of the null mask of the input view
 std::pair<rmm::device_buffer, size_type> mask_scan(column_view const& input_view,
                                                    scan_type inclusive,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   rmm::device_buffer mask =
@@ -66,7 +66,7 @@ template <typename Op, typename T>
 struct scan_functor {
   static std::unique_ptr<column> invoke(column_view const& input_view,
                                         bitmask_type const*,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     auto output_column = detail::allocate_like(
@@ -85,7 +85,7 @@ struct scan_functor {
                            result.data<T>(),
                            binary_op);
 
-    CUDF_CHECK_CUDA(stream.value());
+    CUDF_CHECK_CUDA(stream.get());
     return output_column;
   }
 };
@@ -95,7 +95,7 @@ template <typename Op>
 struct scan_functor<Op, cudf::string_view> {
   static std::unique_ptr<column> invoke(column_view const& input_view,
                                         bitmask_type const* mask,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     return cudf::strings::detail::scan_inclusive<Op>(input_view, mask, stream, mr);
@@ -107,7 +107,7 @@ template <typename Op>
 struct scan_functor<Op, cudf::struct_view> {
   static std::unique_ptr<column> invoke(column_view const& input,
                                         bitmask_type const*,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     return cudf::structs::detail::scan_inclusive<Op>(input, stream, mr);
@@ -119,7 +119,7 @@ template <typename Op, typename T>
 struct scan_functor<Op, T> {
   static std::unique_ptr<column> invoke(column_view const& input_view,
                                         bitmask_type const* mask,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
   {
     auto output_column = make_numeric_column(data_type{type_to_id<size_type>()},
@@ -139,7 +139,7 @@ struct scan_functor<Op, T> {
                            begin + input_view.size(),
                            result.data<size_type>());
 
-    CUDF_CHECK_CUDA(stream.value());
+    CUDF_CHECK_CUDA(stream.get());
     return output_column;
   }
 };
@@ -178,7 +178,7 @@ struct scan_dispatcher {
   template <typename T>
   std::unique_ptr<column> operator()(column_view const& input,
                                      bitmask_type const* output_mask,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported<T>())
   {
@@ -198,7 +198,7 @@ struct scan_dispatcher {
 std::unique_ptr<column> scan_inclusive(column_view const& input,
                                        scan_aggregation const& agg,
                                        null_policy null_handling,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   auto [mask, null_count] = [&] {

--- a/cpp/src/reductions/segmented/all.cu
+++ b/cpp/src/reductions/segmented/all.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_all(
   cudf::data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),

--- a/cpp/src/reductions/segmented/any.cu
+++ b/cpp/src/reductions/segmented/any.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_any(
   cudf::data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),

--- a/cpp/src/reductions/segmented/compound.cuh
+++ b/cpp/src/reductions/segmented/compound.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -43,7 +43,7 @@ std::unique_ptr<column> compound_segmented_reduction(column_view const& col,
                                                      device_span<size_type const> offsets,
                                                      null_policy null_handling,
                                                      size_type ddof,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   auto d_col              = cudf::column_device_view::create(col, stream);
@@ -98,7 +98,7 @@ struct compound_float_output_dispatcher {
                                      device_span<size_type const> offsets,
                                      null_policy null_handling,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported_v<ResultType>())
   {
@@ -111,7 +111,7 @@ struct compound_float_output_dispatcher {
                                      device_span<size_type const>,
                                      null_policy,
                                      size_type,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not is_supported_v<ResultType>())
   {
@@ -135,7 +135,7 @@ struct compound_segmented_dispatcher {
                                      cudf::data_type const output_dtype,
                                      null_policy null_handling,
                                      size_type ddof,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported_v<ElementType>())
   {
@@ -155,7 +155,7 @@ struct compound_segmented_dispatcher {
                                      cudf::data_type const,
                                      null_policy,
                                      size_type,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not is_supported_v<ElementType>())
   {

--- a/cpp/src/reductions/segmented/counts.cu
+++ b/cpp/src/reductions/segmented/counts.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ rmm::device_uvector<size_type> segmented_counts(bitmask_type const* null_mask,
                                                 bool has_nulls,
                                                 device_span<size_type const> offsets,
                                                 null_policy null_handling,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   auto const num_segments = offsets.size() - 1;

--- a/cpp/src/reductions/segmented/counts.hpp
+++ b/cpp/src/reductions/segmented/counts.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,8 +9,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 class column_device_view;
@@ -37,7 +38,7 @@ rmm::device_uvector<size_type> segmented_counts(bitmask_type const* null_mask,
                                                 bool has_nulls,
                                                 device_span<size_type const> offsets,
                                                 null_policy null_handling,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/reductions/segmented/max.cu
+++ b/cpp/src/reductions/segmented/max.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_max(
   cudf::data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(col.type() == output_dtype,

--- a/cpp/src/reductions/segmented/mean.cu
+++ b/cpp/src/reductions/segmented/mean.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_mean(column_view const& col,
                                              device_span<size_type const> offsets,
                                              cudf::data_type const output_dtype,
                                              null_policy null_handling,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   using reducer            = compound::detail::compound_segmented_dispatcher<op::mean>;

--- a/cpp/src/reductions/segmented/min.cu
+++ b/cpp/src/reductions/segmented/min.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_min(
   data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(col.type() == output_dtype,

--- a/cpp/src/reductions/segmented/nunique.cu
+++ b/cpp/src/reductions/segmented/nunique.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,9 +15,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -43,7 +42,7 @@ struct is_unique_fn {
 std::unique_ptr<cudf::column> segmented_nunique(column_view const& col,
                                                 device_span<size_type const> offsets,
                                                 null_policy null_handling,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   // only support non-nested types

--- a/cpp/src/reductions/segmented/product.cu
+++ b/cpp/src/reductions/segmented/product.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,7 +17,7 @@ std::unique_ptr<cudf::column> segmented_product(
   cudf::data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   using reducer = simple::detail::column_type_dispatcher<op::product>;

--- a/cpp/src/reductions/segmented/reductions.cpp
+++ b/cpp/src/reductions/segmented/reductions.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -26,7 +26,7 @@ struct segmented_reduce_dispatch_functor {
   data_type output_dtype;
   null_policy null_handling;
   std::optional<std::reference_wrapper<scalar const>> init;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   segmented_reduce_dispatch_functor(column_view const& segmented_values,
@@ -34,7 +34,7 @@ struct segmented_reduce_dispatch_functor {
                                     data_type output_dtype,
                                     null_policy null_handling,
                                     std::optional<std::reference_wrapper<scalar const>> init,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
     : col(segmented_values),
       offsets(offsets),
@@ -50,7 +50,7 @@ struct segmented_reduce_dispatch_functor {
                                     device_span<size_type const> offsets,
                                     data_type output_dtype,
                                     null_policy null_handling,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
     : segmented_reduce_dispatch_functor(
         segmented_values, offsets, output_dtype, null_handling, std::nullopt, stream, mr)
@@ -107,7 +107,7 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
                                          data_type output_dtype,
                                          null_policy null_handling,
                                          std::optional<std::reference_wrapper<scalar const>> init,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!init.has_value() || cudf::have_same_types(segmented_values, init.value().get()),
@@ -143,7 +143,7 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
                                          segmented_reduce_aggregation const& agg,
                                          data_type output_dtype,
                                          null_policy null_handling,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -157,7 +157,7 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
                                          data_type output_dtype,
                                          null_policy null_handling,
                                          std::optional<std::reference_wrapper<scalar const>> init,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/reductions/segmented/simple.cuh
+++ b/cpp/src/reductions/segmented/simple.cuh
@@ -22,10 +22,9 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
@@ -59,7 +58,7 @@ std::unique_ptr<column> simple_segmented_reduction(
   device_span<size_type const> offsets,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto dcol               = cudf::column_device_view::create(col, stream);
@@ -145,7 +144,7 @@ template <typename InputType,
 std::unique_ptr<column> string_segmented_reduction(column_view const& col,
                                                    device_span<size_type const> offsets,
                                                    null_policy null_handling,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   // Pass to simple_segmented_reduction, get indices to gather, perform gather here.
@@ -189,7 +188,7 @@ template <typename InputType,
 std::unique_ptr<column> string_segmented_reduction(column_view const& col,
                                                    device_span<size_type const> offsets,
                                                    null_policy null_handling,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FAIL("Segmented reduction on string column only supports min and max reduction.");
@@ -215,7 +214,7 @@ std::unique_ptr<column> fixed_point_segmented_reduction(
   device_span<size_type const> offsets,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   using RepType = device_storage_type_t<InputType>;
@@ -286,7 +285,7 @@ struct bool_result_column_dispatcher {
                                      device_span<size_type const> offsets,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<ElementType>())
   {
@@ -299,7 +298,7 @@ struct bool_result_column_dispatcher {
                                      device_span<size_type const>,
                                      null_policy,
                                      std::optional<std::reference_wrapper<scalar const>>,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not cudf::is_numeric<ElementType>())
   {
@@ -333,7 +332,7 @@ struct same_column_type_dispatcher {
                                      device_span<size_type const> offsets,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return simple_segmented_reduction<ElementType, ElementType, Op>(
@@ -346,7 +345,7 @@ struct same_column_type_dispatcher {
                                      device_span<size_type const> offsets,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     CUDF_EXPECTS(!init.has_value(), "Initial value not supported for strings");
@@ -360,7 +359,7 @@ struct same_column_type_dispatcher {
                                      device_span<size_type const> offsets,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     return fixed_point_segmented_reduction<ElementType, Op>(
@@ -372,7 +371,7 @@ struct same_column_type_dispatcher {
                                      device_span<size_type const>,
                                      null_policy,
                                      std::optional<std::reference_wrapper<scalar const>>,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
   {
     CUDF_FAIL("Reduction operator not supported for this type");
@@ -403,7 +402,7 @@ struct column_type_dispatcher {
                                          data_type const output_type,
                                          null_policy null_handling,
                                          std::optional<std::reference_wrapper<scalar const>> init,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
     requires(std::is_floating_point<ElementType>::value)
   {
@@ -430,7 +429,7 @@ struct column_type_dispatcher {
                                          data_type const output_type,
                                          null_policy null_handling,
                                          std::optional<std::reference_wrapper<scalar const>> init,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
     requires(std::is_integral<ElementType>::value)
   {
@@ -459,7 +458,7 @@ struct column_type_dispatcher {
                                      data_type const output_type,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<ElementType>())
   {
@@ -478,7 +477,7 @@ struct column_type_dispatcher {
                                      data_type const output_type,
                                      null_policy null_handling,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<ElementType>())
   {
@@ -493,7 +492,7 @@ struct column_type_dispatcher {
                                      data_type const,
                                      null_policy,
                                      std::optional<std::reference_wrapper<scalar const>>,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not cudf::is_numeric<ElementType>() and not cudf::is_fixed_point<ElementType>())
   {

--- a/cpp/src/reductions/segmented/std.cu
+++ b/cpp/src/reductions/segmented/std.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -19,7 +19,7 @@ std::unique_ptr<cudf::column> segmented_standard_deviation(column_view const& co
                                                            cudf::data_type const output_dtype,
                                                            null_policy null_handling,
                                                            size_type ddof,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   using reducer = compound::detail::compound_segmented_dispatcher<op::standard_deviation>;

--- a/cpp/src/reductions/segmented/sum.cu
+++ b/cpp/src/reductions/segmented/sum.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_sum(
   cudf::data_type const output_dtype,
   null_policy null_handling,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   using reducer = simple::detail::column_type_dispatcher<op::sum>;

--- a/cpp/src/reductions/segmented/sum_of_squares.cu
+++ b/cpp/src/reductions/segmented/sum_of_squares.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> segmented_sum_of_squares(column_view const& col,
                                                        device_span<size_type const> offsets,
                                                        cudf::data_type const output_dtype,
                                                        null_policy null_handling,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   using reducer = simple::detail::column_type_dispatcher<op::sum_of_squares>;

--- a/cpp/src/reductions/segmented/update_validity.cu
+++ b/cpp/src/reductions/segmented/update_validity.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@ void segmented_update_validity(column& result,
                                device_span<size_type const> offsets,
                                null_policy null_handling,
                                std::optional<std::reference_wrapper<scalar const>> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   auto [output_null_mask, output_null_count] = cudf::detail::segmented_null_mask_reduction(

--- a/cpp/src/reductions/segmented/update_validity.hpp
+++ b/cpp/src/reductions/segmented/update_validity.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <optional>
 
@@ -40,7 +40,7 @@ void segmented_update_validity(column& result,
                                device_span<size_type const> offsets,
                                null_policy null_handling,
                                std::optional<std::reference_wrapper<scalar const>> init,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/reductions/segmented/var.cu
+++ b/cpp/src/reductions/segmented/var.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -19,7 +19,7 @@ std::unique_ptr<cudf::column> segmented_variance(column_view const& col,
                                                  cudf::data_type const output_dtype,
                                                  null_policy null_handling,
                                                  size_type ddof,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   using reducer = compound::detail::compound_segmented_dispatcher<op::variance>;

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,9 +20,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
@@ -47,7 +46,7 @@ namespace detail {
 template <typename ElementType, typename ResultType, typename Op>
 std::unique_ptr<scalar> simple_reduction(column_view const& col,
                                          std::optional<std::reference_wrapper<scalar const>> init,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   // reduction by iterator
@@ -100,7 +99,7 @@ template <typename DecimalXX, typename Op>
 std::unique_ptr<scalar> fixed_point_reduction(
   column_view const& col,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   using Type = device_storage_type_t<DecimalXX>;
@@ -143,7 +142,7 @@ template <typename ElementType, typename ResultType, typename Op>
 std::unique_ptr<scalar> dictionary_reduction(
   column_view const& col,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!init.has_value(), "Initial value not supported for dictionary reductions");
@@ -206,7 +205,7 @@ struct cast_numeric_scalar_fn {
  public:
   template <typename ResultType>
   std::unique_ptr<scalar> operator()(numeric_scalar<InputType>* input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported<ResultType>())
   {
@@ -220,7 +219,7 @@ struct cast_numeric_scalar_fn {
 
   template <typename ResultType>
   std::unique_ptr<scalar> operator()(numeric_scalar<InputType>*,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not is_supported<ResultType>())
   {
@@ -240,7 +239,7 @@ struct bool_result_element_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_arithmetic_v<ElementType>)
   {
@@ -250,7 +249,7 @@ struct bool_result_element_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const&,
                                      std::optional<std::reference_wrapper<scalar const>>,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not std::is_arithmetic_v<ElementType>)
   {
@@ -277,7 +276,7 @@ struct same_element_type_dispatcher {
   template <typename IndexType>
   std::unique_ptr<scalar> resolve_key(column_view const& keys,
                                       scalar const& keys_index,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
     requires(cudf::is_index_type<IndexType>())
   {
@@ -288,7 +287,7 @@ struct same_element_type_dispatcher {
   template <typename IndexType>
   std::unique_ptr<scalar> resolve_key(column_view const&,
                                       scalar const&,
-                                      rmm::cuda_stream_view,
+                                      cuda::stream_ref,
                                       rmm::device_async_resource_ref)
     requires(!cudf::is_index_type<IndexType>())
   {
@@ -299,7 +298,7 @@ struct same_element_type_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const& input,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_nested<ElementType>() &&
              (std::is_same_v<Op, cudf::reduction::detail::op::min> ||
@@ -326,7 +325,7 @@ struct same_element_type_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported<ElementType>() && !cudf::is_nested<ElementType>() &&
              !cudf::is_fixed_point<ElementType>())
@@ -342,7 +341,7 @@ struct same_element_type_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<ElementType>())
   {
@@ -352,7 +351,7 @@ struct same_element_type_dispatcher {
   template <typename ElementType>
   std::unique_ptr<scalar> operator()(column_view const&,
                                      std::optional<std::reference_wrapper<scalar const>>,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not is_supported<ElementType>())
   {
@@ -377,7 +376,7 @@ struct element_type_dispatcher {
   template <typename ElementType, typename OutputType>
   std::unique_ptr<scalar> reduce(column_view const& col,
                                  std::optional<std::reference_wrapper<scalar const>> init,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
   {
     return !cudf::is_dictionary(col.type())
@@ -400,7 +399,7 @@ struct element_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      data_type const output_type,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<ElementType>())
   {
@@ -426,7 +425,7 @@ struct element_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const& col,
                                      data_type const output_type,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<ElementType>())
   {
@@ -438,7 +437,7 @@ struct element_type_dispatcher {
   std::unique_ptr<scalar> operator()(column_view const&,
                                      data_type const,
                                      std::optional<std::reference_wrapper<scalar const>> init,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(not cudf::is_numeric<ElementType>() and not cudf::is_fixed_point<ElementType>())
   {

--- a/cpp/src/reductions/std.cu
+++ b/cpp/src/reductions/std.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> standard_deviation(column_view const& col,
                                                  cudf::data_type const output_dtype,
                                                  size_type ddof,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   using reducer = compound::detail::element_type_dispatcher<op::standard_deviation>;

--- a/cpp/src/reductions/sum.cu
+++ b/cpp/src/reductions/sum.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> sum(column_view const& col,
                                   cudf::data_type const output_dtype,
                                   std::optional<std::reference_wrapper<scalar const>> init,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   return cudf::type_dispatcher(

--- a/cpp/src/reductions/sum_of_squares.cu
+++ b/cpp/src/reductions/sum_of_squares.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -17,7 +17,7 @@ namespace detail {
 
 std::unique_ptr<cudf::scalar> sum_of_squares(column_view const& col,
                                              cudf::data_type const output_dtype,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   return cudf::type_dispatcher(

--- a/cpp/src/reductions/sum_overflow.cu
+++ b/cpp/src/reductions/sum_overflow.cu
@@ -18,11 +18,11 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/numeric>
+#include <cuda/stream_ref>
 #include <thrust/transform_reduce.h>
 
 namespace cudf::reduction::detail {
@@ -35,7 +35,7 @@ std::unique_ptr<cudf::scalar> make_sum_overflow_struct_scalar(
   bool overflow_value,
   bool sum_is_valid,
   cudf::data_type const& source_type,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const temp_mr = cudf::get_current_device_resource_ref();
@@ -64,7 +64,7 @@ template <typename Source>
 std::unique_ptr<cudf::scalar> sum_overflow_impl(
   column_view const& col,
   std::optional<std::reference_wrapper<scalar const>> init,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   using DeviceType = device_storage_type_t<Source>;
@@ -118,7 +118,7 @@ struct sum_overflow_dispatcher {
   template <cudf::detail::sum_overflow_supported Source>
   std::unique_ptr<cudf::scalar> operator()(column_view const& col,
                                            std::optional<std::reference_wrapper<scalar const>> init,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     return sum_overflow_impl<Source>(col, init, stream, mr);
@@ -128,7 +128,7 @@ struct sum_overflow_dispatcher {
     requires(!cudf::detail::sum_overflow_supported<Source>)
   std::unique_ptr<cudf::scalar> operator()(column_view const&,
                                            std::optional<std::reference_wrapper<scalar const>>,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("SUM_OVERFLOW reduction supports only signed integer and decimal types.",
@@ -141,7 +141,7 @@ struct sum_overflow_dispatcher {
 std::unique_ptr<cudf::scalar> sum_overflow(column_view const& col,
                                            cudf::data_type const output_dtype,
                                            std::optional<std::reference_wrapper<scalar const>> init,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/reductions/unique_count.cu
+++ b/cpp/src/reductions/unique_count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,10 +10,10 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
@@ -23,7 +23,7 @@ namespace detail {
 
 cudf::size_type unique_count(table_view const& keys,
                              null_equality nulls_equal,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   auto const row_comp = cudf::detail::row::equality::self_comparator(keys, stream);
   if (cudf::detail::has_nested_columns(keys)) {
@@ -61,7 +61,7 @@ cudf::size_type unique_count(table_view const& keys,
 
 cudf::size_type unique_count(table_view const& input,
                              null_equality nulls_equal,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::unique_count(input, nulls_equal, stream);

--- a/cpp/src/reductions/unique_count_column.cu
+++ b/cpp/src/reductions/unique_count_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,12 +13,12 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/cmath>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 
@@ -48,7 +48,7 @@ struct check_nan {
 cudf::size_type unique_count(column_view const& input,
                              null_policy null_handling,
                              nan_policy nan_handling,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   auto const num_rows = input.size();
 
@@ -91,7 +91,7 @@ cudf::size_type unique_count(column_view const& input,
 cudf::size_type unique_count(column_view const& input,
                              null_policy null_handling,
                              nan_policy nan_handling,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   return detail::unique_count(input, null_handling, nan_handling, stream);

--- a/cpp/src/reductions/var.cu
+++ b/cpp/src/reductions/var.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace reduction {
@@ -18,7 +18,7 @@ namespace detail {
 std::unique_ptr<cudf::scalar> variance(column_view const& col,
                                        cudf::data_type const output_dtype,
                                        size_type ddof,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   using reducer = compound::detail::element_type_dispatcher<op::variance>;

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -81,7 +81,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
                                                     PrecedingIter preceding,
                                                     FollowingIter following,
                                                     size_type row_offset,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(op == aggregation::LEAD || op == aggregation::LAG,

--- a/cpp/src/rolling/detail/nth_element.cuh
+++ b/cpp/src/rolling/detail/nth_element.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -47,7 +47,7 @@ struct gather_index_calculator {
   PrecedingIter preceding;
   FollowingIter following;
   size_type min_periods;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   static size_type constexpr NULL_INDEX =
     cuda::std::numeric_limits<size_type>::min();  // For nullifying with gather.
@@ -57,7 +57,7 @@ struct gather_index_calculator {
                           PrecedingIter preceding,
                           FollowingIter following,
                           size_type min_periods,
-                          rmm::cuda_stream_view stream)
+                          cuda::stream_ref stream)
     : n{n},
       input_nullmask{input.null_mask()},
       exclude_nulls{null_handling == null_policy::EXCLUDE and input.has_nulls()},
@@ -138,7 +138,7 @@ std::unique_ptr<column> nth_element(size_type n,
                                     PrecedingIter preceding,
                                     FollowingIter following,
                                     size_type min_periods,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   auto const gather_iter = cudf::detail::make_counting_transform_iterator(

--- a/cpp/src/rolling/detail/optimized_unbounded_window.cpp
+++ b/cpp/src/rolling/detail/optimized_unbounded_window.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -55,7 +55,7 @@ std::unique_ptr<Base> convert_to(cudf::rolling_aggregation const& aggr)
 std::unique_ptr<column> aggregation_based_rolling_window(table_view const& group_keys,
                                                          column_view const& input,
                                                          rolling_aggregation const& aggr,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(group_keys.num_columns() > 0,
@@ -89,7 +89,7 @@ std::unique_ptr<column> aggregation_based_rolling_window(table_view const& group
 /// Used for input that has no groupby keys. i.e. The window spans the column.
 std::unique_ptr<column> reduction_based_rolling_window(column_view const& input,
                                                        rolling_aggregation const& aggr,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   auto const reduce_results = [&] {
@@ -143,7 +143,7 @@ bool can_optimize_unbounded_window(bool unbounded_preceding,
 std::unique_ptr<column> optimized_unbounded_window(table_view const& group_keys,
                                                    column_view const& input,
                                                    rolling_aggregation const& aggr,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   return group_keys.num_columns() > 0

--- a/cpp/src/rolling/detail/optimized_unbounded_window.hpp
+++ b/cpp/src/rolling/detail/optimized_unbounded_window.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,8 +9,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 
@@ -39,7 +40,7 @@ bool can_optimize_unbounded_window(bool unbounded_preceding,
 std::unique_ptr<column> optimized_unbounded_window(table_view const& group_keys,
                                                    column_view const& input,
                                                    rolling_aggregation const& aggr,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr);
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/rolling/detail/range_rolling.hpp
+++ b/cpp/src/rolling/detail/range_rolling.hpp
@@ -13,8 +13,9 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -42,7 +43,7 @@ namespace cudf::detail {
   null_order null_order,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -67,7 +68,7 @@ namespace cudf::detail {
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -92,7 +93,7 @@ namespace cudf::detail {
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -117,7 +118,7 @@ namespace cudf::detail {
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**
@@ -142,7 +143,7 @@ namespace cudf::detail {
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::detail

--- a/cpp/src/rolling/detail/range_utils.cuh
+++ b/cpp/src/rolling/detail/range_utils.cuh
@@ -25,7 +25,6 @@
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/functional>
@@ -34,6 +33,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 
@@ -467,7 +467,7 @@ template <typename Transform>
 void materialize_range_window_bounds(size_type size,
                                      size_type* result,
                                      Transform transform,
-                                     rmm::cuda_stream_view stream)
+                                     cuda::stream_ref stream)
 {
   if (size == 0) { return; }
 
@@ -475,7 +475,7 @@ void materialize_range_window_bounds(size_type size,
   materialize_range_window_bounds_kernel<<<config.num_blocks,
                                            config.num_threads_per_block,
                                            0,
-                                           stream.value()>>>(size, result, transform);
+                                           stream.get()>>>(size, result, transform);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 
@@ -496,7 +496,7 @@ struct range_window_clamper {
                         direction direction,
                         size_type size,
                         mutable_column_view& result,
-                        rmm::cuda_stream_view stream) const
+                        cuda::stream_ref stream) const
   {
     materialize_range_window_bounds(
       size, result.data<size_type>(), unbounded_distance_functor{grouping, direction}, stream);
@@ -509,7 +509,7 @@ struct range_window_clamper {
                           column_device_view::const_iterator<OrderbyT> begin,
                           size_type size,
                           mutable_column_view& result,
-                          rmm::cuda_stream_view stream) const
+                          cuda::stream_ref stream) const
   {
     materialize_range_window_bounds(size,
                                     result.data<size_type>(),
@@ -525,7 +525,7 @@ struct range_window_clamper {
                       DeltaT const* row_delta,
                       size_type size,
                       mutable_column_view& result,
-                      rmm::cuda_stream_view stream) const
+                      cuda::stream_ref stream) const
   {
     materialize_range_window_bounds(
       size,
@@ -561,7 +561,7 @@ struct range_window_clamper {
     std::optional<preprocessed_group_info> const& grouping,
     bool nulls_at_start,
     scalar const* row_delta,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
   {
     auto result = make_numeric_column(
@@ -624,7 +624,7 @@ struct range_window_clamper {
     std::optional<preprocessed_group_info> const& grouping,
     bool nulls_at_start,
     scalar const* row_delta,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
   {
     using ScalarT = cudf::scalar_type_t<typename OrderbyT::duration>;
@@ -646,7 +646,7 @@ struct range_window_clamper {
     std::optional<preprocessed_group_info> const& grouping,
     bool nulls_at_start,
     scalar const* row_delta,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(!row_delta || (orderby.type().id() == row_delta->type().id()),
@@ -680,7 +680,7 @@ struct range_window_clamper {
     std::optional<preprocessed_group_info> const& grouping,
     bool nulls_at_start,
     scalar const* row_delta,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(!row_delta || cudf::have_same_types(orderby, *row_delta),
@@ -701,7 +701,7 @@ struct range_window_clamper {
     std::optional<preprocessed_group_info> const& grouping,
     bool nulls_at_start,
     scalar const* row_delta,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const
   {
     CUDF_EXPECTS(!row_delta,
@@ -717,7 +717,7 @@ struct range_window_clamper {
                                      std::optional<preprocessed_group_info> const&,
                                      bool,
                                      scalar const*,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("Unsupported rolling window type.", cudf::data_type_error);

--- a/cpp/src/rolling/detail/range_window_bounds.hpp
+++ b/cpp/src/rolling/detail/range_window_bounds.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -78,7 +78,7 @@ template <typename RangeT,
 RepT range_comparable_value_impl(scalar const& range_scalar,
                                  bool,
                                  data_type const&,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   auto val = static_cast<numeric_scalar<RangeT> const&>(range_scalar).value(stream);
   assert_non_negative(val);
@@ -89,7 +89,7 @@ template <typename RangeT, typename RepT, CUDF_ENABLE_IF(cudf::is_duration<Range
 RepT range_comparable_value_impl(scalar const& range_scalar,
                                  bool,
                                  data_type const&,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   auto val = static_cast<duration_scalar<RangeT> const&>(range_scalar).value(stream).count();
   assert_non_negative(val);
@@ -100,7 +100,7 @@ template <typename RangeT, typename RepT, CUDF_ENABLE_IF(cudf::is_fixed_point<Ra
 RepT range_comparable_value_impl(scalar const& range_scalar,
                                  bool is_unbounded,
                                  data_type const& order_by_data_type,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   CUDF_EXPECTS(is_unbounded || range_scalar.type().scale() >= order_by_data_type.scale(),
                "Range bounds scalar must match/exceed the scale of the orderby column.");
@@ -125,7 +125,7 @@ RepT range_comparable_value_impl(scalar const& range_scalar,
 template <typename OrderByType>
 range_rep_type<OrderByType> range_comparable_value(range_window_bounds const& range_bounds,
                                                    data_type const& order_by_data_type,
-                                                   rmm::cuda_stream_view stream)
+                                                   cuda::stream_ref stream)
 {
   auto const& range_scalar = range_bounds.range_scalar();
   CUDF_EXPECTS(

--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -33,8 +33,9 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -206,7 +207,7 @@ struct rolling_postprocessor {
   PrecedingWindowIterator preceding_window_begin;
   FollowingWindowIterator following_window_begin;
   int min_periods;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   // Default case: pass through the intermediate result unchanged
@@ -430,7 +431,7 @@ struct rolling_window_launcher {
                                      FollowingWindowIterator following_window_begin,
                                      int min_periods,
                                      [[maybe_unused]] rolling_aggregation const& agg,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(corresponding_rolling_operator<InputType, op>::type::is_supported())
   {
@@ -456,14 +457,14 @@ struct rolling_window_launcher {
       auto const grid           = cudf::detail::grid_1d(input.size(), block_size);
 
       gpu_rolling<OutType, block_size>
-        <<<grid.num_blocks, block_size, 0, stream.value()>>>(*d_inp_ptr,
-                                                             input.has_nulls(),
-                                                             *d_default_out_ptr,
-                                                             *d_out_ptr,
-                                                             d_valid_count.data(),
-                                                             device_op,
-                                                             preceding_window_begin,
-                                                             following_window_begin);
+        <<<grid.num_blocks, block_size, 0, stream.get()>>>(*d_inp_ptr,
+                                                           input.has_nulls(),
+                                                           *d_default_out_ptr,
+                                                           *d_out_ptr,
+                                                           d_valid_count.data(),
+                                                           device_op,
+                                                           preceding_window_begin,
+                                                           following_window_begin);
       CUDF_CUDA_TRY(cudaGetLastError());
 
       auto const valid_count = d_valid_count.value(stream);
@@ -497,7 +498,7 @@ struct rolling_window_launcher {
                                      FollowingWindowIterator,
                                      int,
                                      rolling_aggregation const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref)
     requires(!corresponding_rolling_operator<InputType, op>::type::is_supported())
   {
@@ -522,7 +523,7 @@ struct dispatch_rolling {
                                      FollowingWindowIterator following_window_begin,
                                      size_type min_periods,
                                      rolling_aggregation const& agg,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     // do any preprocessing of aggregations (eg, MIN -> ARGMIN, COLLECT_LIST -> nothing)
@@ -577,7 +578,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        FollowingWindowIterator following_window_begin,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   static_assert(warp_size == cudf::detail::size_in_bits<cudf::bitmask_type>(),

--- a/cpp/src/rolling/detail/rolling.hpp
+++ b/cpp/src/rolling/detail/rolling.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,8 +12,9 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -69,7 +70,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        size_type following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 /**
@@ -87,7 +88,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        column_view const& following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr);
 
 bool is_valid_rolling_aggregation(data_type input_type, aggregation::Kind kind);
@@ -117,7 +118,7 @@ bool is_valid_rolling_aggregation(data_type input_type, aggregation::Kind kind);
   host_span<null_order const> null_orders,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -29,7 +29,7 @@ namespace detail {
  * @see cudf::detail::get_list_child_to_list_row_mapping
  */
 std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view const& offsets,
-                                                           rmm::cuda_stream_view stream)
+                                                           cuda::stream_ref stream)
 {
   // First, scatter the count for each repeated offset (except the first and last),
   // into a column of N `0`s, where N == number of child rows.
@@ -87,7 +87,7 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
  */
 size_type count_child_nulls(column_view const& input,
                             std::unique_ptr<column> const& gather_map,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   auto input_device_view = column_device_view::create(input, stream);
 
@@ -109,7 +109,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   column_view const& gather_map,
   column_view const& offsets,
   size_type num_child_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto input_device_view = column_device_view::create(input, stream);

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,11 +12,11 @@
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/extrema.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
@@ -39,7 +39,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
                                                PrecedingIter preceding_begin,
                                                FollowingIter following_begin,
                                                size_type min_periods,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   // Materialize offsets column.
@@ -92,7 +92,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
  *  Mapping back to `input`    == [0,1,0,1,2,1,2,3,2,3,4,3,4]
  */
 std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view const& offsets,
-                                                           rmm::cuda_stream_view stream);
+                                                           cuda::stream_ref stream);
 
 /**
  * @brief Create gather map to generate the child column of the result of
@@ -102,7 +102,7 @@ template <typename PrecedingIter>
 std::unique_ptr<column> create_collect_gather_map(column_view const& child_offsets,
                                                   column_view const& per_row_mapping,
                                                   PrecedingIter preceding_iter,
-                                                  rmm::cuda_stream_view stream)
+                                                  cuda::stream_ref stream)
 {
   auto gather_map = make_fixed_width_column(data_type{type_to_id<size_type>()},
                                             per_row_mapping.size(),
@@ -134,7 +134,7 @@ std::unique_ptr<column> create_collect_gather_map(column_view const& child_offse
  */
 size_type count_child_nulls(column_view const& input,
                             std::unique_ptr<column> const& gather_map,
-                            rmm::cuda_stream_view stream);
+                            cuda::stream_ref stream);
 
 /**
  * @brief Purge entries for null inputs from gather_map, and adjust offsets.
@@ -144,7 +144,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   column_view const& gather_map,
   column_view const& offsets,
   size_type num_child_nulls,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template <typename PrecedingIter, typename FollowingIter>
@@ -154,7 +154,7 @@ std::unique_ptr<column> rolling_collect_list(column_view const& input,
                                              FollowingIter following_begin,
                                              size_type min_periods,
                                              null_policy null_handling,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(default_outputs.is_empty(),

--- a/cpp/src/rolling/detail/rolling_fixed_window.cu
+++ b/cpp/src/rolling/detail/rolling_fixed_window.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        size_type following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/rolling/detail/rolling_operators.cuh
+++ b/cpp/src/rolling/detail/rolling_operators.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,11 +22,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>

--- a/cpp/src/rolling/detail/rolling_udf.cuh
+++ b/cpp/src/rolling/detail/rolling_udf.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -49,7 +49,7 @@ inline std::unique_ptr<column> rolling_window_udf_impl(
   cudf::detail::window_wrapper_base const& following_window,
   size_type min_periods,
   rolling_aggregation const& agg,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   static_assert(warp_size == cudf::detail::size_in_bits<cudf::bitmask_type>(),
@@ -115,7 +115,7 @@ inline std::unique_ptr<column> rolling_window_udf_impl(
   output->set_null_count(output->size() - device_valid_count.value(stream));
 
   // check the stream for debugging
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 
   return output;
 }
@@ -127,7 +127,7 @@ std::unique_ptr<column> rolling_window_udf(column_view const& input,
                                            FollowingWindowIterator following_window,
                                            size_type min_periods,
                                            rolling_aggregation const& agg,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return rolling_window_udf_impl(input,

--- a/cpp/src/rolling/detail/rolling_variable_window.cu
+++ b/cpp/src/rolling/detail/rolling_variable_window.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        column_view const& following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -21,10 +21,9 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/functional>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 
 #include <concepts>
 #include <span>
@@ -40,7 +39,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                window_bounds following_window_bounds,
                                                size_type min_periods,
                                                rolling_aggregation const& aggr,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -133,7 +132,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                window_bounds following_window_bounds,
                                                size_type min_periods,
                                                rolling_aggregation const& aggr,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   return detail::grouped_rolling_window(group_keys,
@@ -153,7 +152,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                size_type following_window,
                                                size_type min_periods,
                                                rolling_aggregation const& aggr,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   return grouped_rolling_window(group_keys,
@@ -172,7 +171,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                window_bounds following_window,
                                                size_type min_periods,
                                                rolling_aggregation const& aggr,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   return detail::grouped_rolling_window(group_keys,
@@ -193,7 +192,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                size_type following_window,
                                                size_type min_periods,
                                                rolling_aggregation const& aggr,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   return detail::grouped_rolling_window(group_keys,
@@ -219,7 +218,7 @@ std::unique_ptr<table> grouped_range_rolling_window_impl(table_view const& group
                                                          range_window_type following,
                                                          size_type orderby_size,
                                                          MakeWindows&& make_windows,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   std::vector<std::unique_ptr<column>> results;
@@ -293,7 +292,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
                                                     range_window_type preceding,
                                                     range_window_type following,
                                                     std::span<rolling_request const> requests,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   return grouped_range_rolling_window_impl(
@@ -323,7 +322,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
                                                     range_window_type preceding,
                                                     range_window_type following,
                                                     host_span<rolling_request const> requests,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(orderby.num_columns() > 0, "orderby must be non-empty");
@@ -367,7 +366,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
   order order,
   rmm::device_uvector<size_type> const& offsets,
   rmm::device_uvector<size_type> const& per_group_nulls,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto d_orderby = column_device_view::create(orderby, stream);
   if (order == order::ASCENDING) {
@@ -439,7 +438,7 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                                      range_window_bounds const& following,
                                                      size_type min_periods,
                                                      rolling_aggregation const& aggr,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -546,7 +545,7 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                                      range_window_bounds const& following,
                                                      size_type min_periods,
                                                      rolling_aggregation const& aggr,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -569,7 +568,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
                                                     range_window_type preceding,
                                                     range_window_type following,
                                                     std::span<rolling_request const> requests,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -588,7 +587,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
                                                     range_window_type preceding,
                                                     range_window_type following,
                                                     host_span<rolling_request const> requests,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/rolling/range_rolling.cu
+++ b/cpp/src/rolling/range_rolling.cu
@@ -18,13 +18,13 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/functional>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -37,7 +37,7 @@ namespace detail {
 
 rmm::device_uvector<cudf::size_type> nulls_per_group(column_view const& orderby,
                                                      rmm::device_uvector<size_type> const& offsets,
-                                                     rmm::cuda_stream_view stream)
+                                                     cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   auto d_orderby        = column_device_view::create(orderby, stream);
@@ -57,7 +57,7 @@ rmm::device_uvector<cudf::size_type> nulls_per_group(column_view const& orderby,
                                   num_groups,
                                   offsets.begin(),
                                   offsets.begin() + 1,
-                                  stream.value());
+                                  stream.get());
   auto tmp = rmm::device_buffer(bytes, stream);
   cub::DeviceSegmentedReduce::Sum(tmp.data(),
                                   bytes,
@@ -66,7 +66,7 @@ rmm::device_uvector<cudf::size_type> nulls_per_group(column_view const& orderby,
                                   num_groups,
                                   offsets.begin(),
                                   offsets.begin() + 1,
-                                  stream.value());
+                                  stream.get());
   return null_counts;
 }
 
@@ -77,7 +77,7 @@ std::unique_ptr<column> make_range_window(
   order order,
   null_order null_order,
   range_window_type window,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -106,7 +106,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> make_range_windows(
   null_order null_order,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (group_keys.num_columns() > 0) {
@@ -157,7 +157,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> make_range_windows(
   null_order null_order,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/rolling/range_rolling_bounded_closed.cu
+++ b/cpp/src/rolling/range_rolling_bounded_closed.cu
@@ -14,8 +14,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -30,7 +31,7 @@ std::unique_ptr<column> dispatch_range_window(
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(orderby.type(),

--- a/cpp/src/rolling/range_rolling_bounded_open.cu
+++ b/cpp/src/rolling/range_rolling_bounded_open.cu
@@ -14,8 +14,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -30,7 +31,7 @@ std::unique_ptr<column> dispatch_range_window(
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(orderby.type(),

--- a/cpp/src/rolling/range_rolling_current_row.cu
+++ b/cpp/src/rolling/range_rolling_current_row.cu
@@ -14,8 +14,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -30,7 +31,7 @@ std::unique_ptr<column> dispatch_range_window(
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(orderby.type(),

--- a/cpp/src/rolling/range_rolling_multi_column.cu
+++ b/cpp/src/rolling/range_rolling_multi_column.cu
@@ -22,13 +22,13 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/copy.h>
 
 #include <memory>
@@ -96,7 +96,7 @@ void select_and_write_offsets(range_window_type const& preceding,
                               mutable_column_view preceding_view,
                               mutable_column_view following_view,
                               size_type num_rows,
-                              rmm::cuda_stream_view stream)
+                              cuda::stream_ref stream)
 {
   // Write the offsets to the output columns
   auto const write_offsets = [&](auto offset_fn) {
@@ -159,7 +159,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> make_range_windows(
   host_span<null_order const> null_orders,
   range_window_type preceding,
   range_window_type following,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/rolling/range_rolling_unbounded.cu
+++ b/cpp/src/rolling/range_rolling_unbounded.cu
@@ -14,8 +14,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <optional>
@@ -30,7 +31,7 @@ std::unique_ptr<column> dispatch_range_window(
   std::optional<rolling::preprocessed_group_info> const& grouping,
   bool nulls_at_start,
   scalar const* row_delta,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(orderby.type(),

--- a/cpp/src/rolling/range_window_bounds.cpp
+++ b/cpp/src/rolling/range_window_bounds.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,8 +21,7 @@ namespace {
  */
 struct range_scalar_constructor {
   template <typename T, CUDF_ENABLE_IF(not detail::is_supported_range_type<T>())>
-  std::unique_ptr<scalar> operator()(scalar const& range_scalar_,
-                                     rmm::cuda_stream_view stream) const
+  std::unique_ptr<scalar> operator()(scalar const& range_scalar_, cuda::stream_ref stream) const
   {
     CUDF_FAIL(
       "Unsupported range type. "
@@ -30,8 +29,7 @@ struct range_scalar_constructor {
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_duration<T>())>
-  std::unique_ptr<scalar> operator()(scalar const& range_scalar_,
-                                     rmm::cuda_stream_view stream) const
+  std::unique_ptr<scalar> operator()(scalar const& range_scalar_, cuda::stream_ref stream) const
   {
     return std::make_unique<duration_scalar<T>>(
       static_cast<duration_scalar<T> const&>(range_scalar_),
@@ -40,8 +38,7 @@ struct range_scalar_constructor {
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() && not cudf::is_boolean<T>())>
-  std::unique_ptr<scalar> operator()(scalar const& range_scalar_,
-                                     rmm::cuda_stream_view stream) const
+  std::unique_ptr<scalar> operator()(scalar const& range_scalar_, cuda::stream_ref stream) const
   {
     return std::make_unique<numeric_scalar<T>>(static_cast<numeric_scalar<T> const&>(range_scalar_),
                                                stream,
@@ -49,8 +46,7 @@ struct range_scalar_constructor {
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_point<T>())>
-  std::unique_ptr<scalar> operator()(scalar const& range_scalar_,
-                                     rmm::cuda_stream_view stream) const
+  std::unique_ptr<scalar> operator()(scalar const& range_scalar_, cuda::stream_ref stream) const
   {
     return std::make_unique<fixed_point_scalar<T>>(
       static_cast<fixed_point_scalar<T> const&>(range_scalar_),
@@ -62,7 +58,7 @@ struct range_scalar_constructor {
 
 range_window_bounds::range_window_bounds(extent_type extent_,
                                          std::unique_ptr<scalar> range_scalar_,
-                                         rmm::cuda_stream_view stream)
+                                         cuda::stream_ref stream)
   : _extent{extent_}, _range_scalar{std::move(range_scalar_)}
 {
   CUDF_EXPECTS(_range_scalar.get(), "Range window scalar cannot be null.");
@@ -71,21 +67,21 @@ range_window_bounds::range_window_bounds(extent_type extent_,
                "Bounded Range window scalar must be valid.");
 }
 
-range_window_bounds range_window_bounds::unbounded(data_type type, rmm::cuda_stream_view stream)
+range_window_bounds range_window_bounds::unbounded(data_type type, cuda::stream_ref stream)
 {
   auto s = make_default_constructed_scalar(type, stream, cudf::get_current_device_resource_ref());
   s->set_valid_async(true, stream);
   return {extent_type::UNBOUNDED, std::move(s), stream};
 }
 
-range_window_bounds range_window_bounds::current_row(data_type type, rmm::cuda_stream_view stream)
+range_window_bounds range_window_bounds::current_row(data_type type, cuda::stream_ref stream)
 {
   auto s = make_default_constructed_scalar(type, stream, cudf::get_current_device_resource_ref());
   s->set_valid_async(true, stream);
   return {extent_type::CURRENT_ROW, std::move(s), stream};
 }
 
-range_window_bounds range_window_bounds::get(scalar const& boundary, rmm::cuda_stream_view stream)
+range_window_bounds range_window_bounds::get(scalar const& boundary, cuda::stream_ref stream)
 {
   return {extent_type::BOUNDED,
           cudf::type_dispatcher(boundary.type(), range_scalar_constructor{}, boundary, stream),

--- a/cpp/src/rolling/rolling.cpp
+++ b/cpp/src/rolling/rolling.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,8 +13,9 @@
 #include <cudf/rolling.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace cudf {
 
@@ -26,7 +27,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        size_type following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -40,7 +41,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        size_type following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -62,7 +63,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        column_view const& following_window,
                                        size_type min_periods,
                                        rolling_aggregation const& agg,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,11 +12,11 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/count.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
@@ -27,7 +27,7 @@ namespace detail {
 bool is_sorted(cudf::table_view const& in,
                std::vector<order> const& column_order,
                std::vector<null_order> const& null_precedence,
-               rmm::cuda_stream_view stream)
+               cuda::stream_ref stream)
 {
   auto const comparator =
     detail::row::lexicographic::self_comparator{in, column_order, null_precedence, stream};
@@ -67,7 +67,7 @@ bool is_sorted(cudf::table_view const& in,
 bool is_sorted(cudf::table_view const& in,
                std::vector<order> const& column_order,
                std::vector<null_order> const& null_precedence,
-               rmm::cuda_stream_view stream)
+               cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   if (in.num_columns() == 0 || in.num_rows() == 0) { return true; }

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -18,7 +18,6 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
@@ -26,6 +25,7 @@
 #include <cuda/std/algorithm>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
@@ -58,7 +58,7 @@ struct unique_functor {
 // Assign rank from 1 to n unique values. Equal values get same rank value.
 rmm::device_uvector<size_type> sorted_dense_rank(column_view input_col,
                                                  column_view sorted_order_view,
-                                                 rmm::cuda_stream_view stream)
+                                                 cuda::stream_ref stream)
 {
   auto const t_input    = table_view{{input_col}};
   auto const comparator = cudf::detail::row::equality::self_comparator{t_input, stream};
@@ -120,7 +120,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
                                outputIterator rank_iter,
                                TieBreaker tie_breaker,
                                Transformer transformer,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   auto const input_size = sorted_order_view.size();
   // algorithm: reduce_by_key(dense_rank, 1, n, reduction_tie_breaker)
@@ -152,7 +152,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
 template <typename outputType>
 void rank_first(column_view sorted_order_view,
                 mutable_column_view rank_mutable_view,
-                rmm::cuda_stream_view stream)
+                cuda::stream_ref stream)
 {
   // stable sort order ranking (no ties)
   thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -166,7 +166,7 @@ template <typename outputType>
 void rank_dense(cudf::device_span<size_type const> dense_rank_sorted,
                 column_view sorted_order_view,
                 mutable_column_view rank_mutable_view,
-                rmm::cuda_stream_view stream)
+                cuda::stream_ref stream)
 {
   // All equal values have same rank and rank always increases by 1 between groups
   thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -180,7 +180,7 @@ template <typename outputType>
 void rank_min(cudf::device_span<size_type const> group_keys,
               column_view sorted_order_view,
               mutable_column_view rank_mutable_view,
-              rmm::cuda_stream_view stream)
+              cuda::stream_ref stream)
 {
   // min of first in the group
   // All equal values have min of ranks among them.
@@ -198,7 +198,7 @@ template <typename outputType>
 void rank_max(cudf::device_span<size_type const> group_keys,
               column_view sorted_order_view,
               mutable_column_view rank_mutable_view,
-              rmm::cuda_stream_view stream)
+              cuda::stream_ref stream)
 {
   // max of first in the group
   // All equal values have max of ranks among them.
@@ -221,7 +221,7 @@ struct index_counter {
 void rank_average(cudf::device_span<size_type const> group_keys,
                   column_view sorted_order_view,
                   mutable_column_view rank_mutable_view,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
 {
   // k, k+1, .. k+n-1
   // average = (n*k+ n*(n-1)/2)/n
@@ -256,7 +256,7 @@ std::unique_ptr<column> rank(column_view const& input,
                              null_policy null_handling,
                              null_order null_precedence,
                              bool percentage,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   data_type const output_type         = (percentage or method == rank_method::AVERAGE)
@@ -359,7 +359,7 @@ std::unique_ptr<column> rank(column_view const& input,
                              null_policy null_handling,
                              null_order null_precedence,
                              bool percentage,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@ namespace detail {
 
 rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
                                                    column_view const& offsets,
-                                                   rmm::cuda_stream_view stream)
+                                                   cuda::stream_ref stream)
 {
   rmm::device_uvector<size_type> segment_ids(num_rows, stream);
 
@@ -46,7 +46,7 @@ std::unique_ptr<column> segmented_sorted_order(table_view const& keys,
                                                column_view const& segment_offsets,
                                                std::vector<order> const& column_order,
                                                std::vector<null_order> const& null_precedence,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   return segmented_sorted_order_common<sort_method::UNSTABLE>(
@@ -58,7 +58,7 @@ std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
                                              column_view const& segment_offsets,
                                              std::vector<order> const& column_order,
                                              std::vector<null_order> const& null_precedence,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   return segmented_sort_by_key_common<sort_method::UNSTABLE>(
@@ -71,7 +71,7 @@ std::unique_ptr<column> segmented_sorted_order(table_view const& keys,
                                                column_view const& segment_offsets,
                                                std::vector<order> const& column_order,
                                                std::vector<null_order> const& null_precedence,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -84,7 +84,7 @@ std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
                                              column_view const& segment_offsets,
                                              std::vector<order> const& column_order,
                                              std::vector<null_order> const& null_precedence,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,10 +14,10 @@
 #include <cudf/detail/sorting.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cub/device/device_segmented_sort.cuh>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -57,7 +57,7 @@ struct column_fast_sort_fn {
                  column_view const& segment_offsets,
                  mutable_column_view& indices,
                  bool ascending,
-                 rmm::cuda_stream_view stream)
+                 cuda::stream_ref stream)
   {
     // CUB's segmented sort functions cannot accept iterators.
     // We create a temporary column here for it to use.
@@ -116,7 +116,7 @@ struct column_fast_sort_fn {
                    segment_offsets.size() - 1,
                    segment_offsets.begin<size_type>(),
                    segment_offsets.begin<size_type>() + 1,
-                   stream.value());
+                   stream.get());
   }
 
   template <typename T, CUDF_ENABLE_IF(is_fast_sort_supported<T>())>
@@ -124,14 +124,14 @@ struct column_fast_sort_fn {
                   column_view const& segment_offsets,
                   mutable_column_view& indices,
                   bool ascending,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     fast_sort<T>(input, segment_offsets, indices, ascending, stream);
   }
 
   template <typename T, CUDF_ENABLE_IF(!is_fast_sort_supported<T>())>
   void operator()(
-    column_view const&, column_view const&, mutable_column_view&, bool, rmm::cuda_stream_view)
+    column_view const&, column_view const&, mutable_column_view&, bool, cuda::stream_ref)
   {
     CUDF_FAIL("Column type cannot be used with fast-sort function");
   }
@@ -152,7 +152,7 @@ template <sort_method method>
 std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
                                                     column_view const& segment_offsets,
                                                     order const& column_order,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   // Unfortunately, CUB's segmented sort functions cannot accept iterators.
@@ -200,7 +200,7 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
  */
 rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
                                                    column_view const& offsets,
-                                                   rmm::cuda_stream_view stream);
+                                                   cuda::stream_ref stream);
 
 /**
  * @brief Segmented sorted-order utility
@@ -222,7 +222,7 @@ std::unique_ptr<column> segmented_sorted_order_common(
   column_view const& segment_offsets,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (keys.num_rows() == 0 || keys.num_columns() == 0) {
@@ -299,7 +299,7 @@ std::unique_ptr<table> segmented_sort_by_key_common(table_view const& values,
                                                     column_view const& segment_offsets,
                                                     std::vector<order> const& column_order,
                                                     std::vector<null_order> const& null_precedence,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),

--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -19,9 +19,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/iterator>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/remove.h>
@@ -75,7 +74,7 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
                                               column_view const& segment_offsets,
                                               size_type k,
                                               order topk_order,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(k >= 0, "k must be greater than or equal to 0", std::invalid_argument);
@@ -106,7 +105,7 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
     segment_offsets.size() - 1, stream, temp_mr);
   auto span_indices = device_span<size_type>{d_indices, static_cast<std::size_t>(indices->size())};
   auto const grid   = cudf::detail::grid_1d(indices->size(), 256);
-  resolve_segment_indices<<<grid.num_blocks, grid.num_threads_per_block, 0, stream>>>(
+  resolve_segment_indices<<<grid.num_blocks, grid.num_threads_per_block, 0, stream.get()>>>(
     segment_offsets, k, span_indices, segment_sizes.data());
   CUDF_CUDA_TRY(cudaGetLastError());
   auto [offsets, total_elements] =
@@ -131,7 +130,7 @@ std::unique_ptr<column> segmented_top_k(column_view const& col,
                                         column_view const& segment_offsets,
                                         size_type k,
                                         order topk_order,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   if (col.is_empty()) { return cudf::make_empty_column(col.type()); }
@@ -159,7 +158,7 @@ std::unique_ptr<column> segmented_top_k(column_view const& col,
                                         column_view const& segment_offsets,
                                         size_type k,
                                         order topk_order,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -170,7 +169,7 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
                                               column_view const& segment_offsets,
                                               size_type k,
                                               order topk_order,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,14 +15,14 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> sorted_order(table_view const& input,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   return sorted_order<sort_method::UNSTABLE>(input, column_order, null_precedence, stream, mr);
@@ -32,7 +32,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
                                    table_view const& keys,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
@@ -52,7 +52,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
 std::unique_ptr<table> sort(table_view const& input,
                             std::vector<order> const& column_order,
                             std::vector<null_order> const& null_precedence,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr)
 {
   // fast-path sort conditions: single, fixed-width column with no nulls
@@ -71,7 +71,7 @@ std::unique_ptr<table> sort(table_view const& input,
 std::unique_ptr<column> sorted_order(table_view const& input,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -81,7 +81,7 @@ std::unique_ptr<column> sorted_order(table_view const& input,
 std::unique_ptr<table> sort(table_view const& input,
                             std::vector<order> const& column_order,
                             std::vector<null_order> const& null_precedence,
-                            rmm::cuda_stream_view stream,
+                            cuda::stream_ref stream,
                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -92,7 +92,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
                                    table_view const& keys,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/sort.hpp
+++ b/cpp/src/sort/sort.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -8,7 +8,7 @@
 #include <cudf/sorting.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -36,7 +36,7 @@ template <sort_method method>
 std::unique_ptr<column> sorted_order(column_view const& input,
                                      order column_order,
                                      null_order null_precedence,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr);
 
 }  // namespace detail

--- a/cpp/src/sort/sort_column.cu
+++ b/cpp/src/sort/sort_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,13 +17,13 @@ namespace detail {
 
 /**
  * @copydoc
- * sorted_order(column_view&,order,null_order,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * sorted_order(column_view&,order,null_order,cuda::stream_ref,rmm::device_async_resource_ref)
  */
 template <>
 std::unique_ptr<column> sorted_order<sort_method::UNSTABLE>(column_view const& input,
                                                             order column_order,
                                                             null_order null_precedence,
-                                                            rmm::cuda_stream_view stream,
+                                                            cuda::stream_ref stream,
                                                             rmm::device_async_resource_ref mr)
 {
   auto sorted_indices = cudf::make_numeric_column(

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,12 +16,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_merge_sort.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/gather.h>
 
 namespace cudf {
@@ -74,7 +74,7 @@ struct column_sorted_order_fn {
                     mutable_column_view& indices,
                     bool ascending,
                     null_order null_precedence,
-                    rmm::cuda_stream_view stream)
+                    cuda::stream_ref stream)
   {
     auto keys      = column_device_view::create(input, stream);
     auto comp      = simple_comparator<T>{*keys, input.has_nulls(), ascending, null_precedence};
@@ -83,16 +83,16 @@ struct column_sorted_order_fn {
     auto tmp_bytes = std::size_t{0};
     if constexpr (method == sort_method::STABLE) {
       cub::DeviceMergeSort::StableSortKeysCopy(
-        nullptr, tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.value());
+        nullptr, tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.get());
       auto tmp_stg = rmm::device_buffer(tmp_bytes, stream);
       cub::DeviceMergeSort::StableSortKeysCopy(
-        tmp_stg.data(), tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.value());
+        tmp_stg.data(), tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.get());
     } else {
       cub::DeviceMergeSort::SortKeysCopy(
-        nullptr, tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.value());
+        nullptr, tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.get());
       auto tmp_stg = rmm::device_buffer(tmp_bytes, stream);
       cub::DeviceMergeSort::SortKeysCopy(
-        tmp_stg.data(), tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.value());
+        tmp_stg.data(), tmp_bytes, in_keys, out_keys, indices.size(), comp, stream.get());
     }
   }
 
@@ -102,14 +102,14 @@ struct column_sorted_order_fn {
                   mutable_column_view& indices,
                   bool ascending,
                   null_order null_precedence,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     sorted_order<T>(input, indices, ascending, null_precedence, stream);
   }
 
   template <typename T>
     requires(not cudf::is_relationally_comparable<T, T>())
-  void operator()(column_view const&, mutable_column_view&, bool, null_order, rmm::cuda_stream_view)
+  void operator()(column_view const&, mutable_column_view&, bool, null_order, cuda::stream_ref)
   {
     CUDF_FAIL("Column type must be relationally comparable");
   }
@@ -120,7 +120,7 @@ struct column_sorted_order_fn {
                   mutable_column_view& indices,
                   bool ascending,
                   null_order null_precedence,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     auto const keys = dictionary_column_view(input).keys();
     // For the keys we do an arg-sort of arg-sort to get the rank and use that as a map

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ template <sort_method method>
 std::unique_ptr<column> sorted_order(table_view input,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   if (input.num_rows() == 0 or input.num_columns() == 0) {

--- a/cpp/src/sort/sort_radix.cu
+++ b/cpp/src/sort/sort_radix.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,12 +7,12 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -50,10 +50,10 @@ struct float_to_pair_fn {
  * Should not be used if `input.has_nulls()==true`
  */
 struct sort_radix_fn {
-  column_view const input;       // input column to sort
-  mutable_column_view output;    // output sorted
-  bool ascending;                // true if ascending sort
-  rmm::cuda_stream_view stream;  // stream for allocations and kernel launches
+  column_view const input;     // input column to sort
+  mutable_column_view output;  // output sorted
+  bool ascending;              // true if ascending sort
+  cuda::stream_ref stream;     // stream for allocations and kernel launches
 
   template <typename T>
   void sort_radix()
@@ -61,7 +61,7 @@ struct sort_radix_fn {
     auto d_in          = input.data<T>();
     auto d_out         = output.data<T>();
     auto const end_bit = sizeof(T) * 8;
-    auto const sv      = stream.value();
+    auto const sv      = stream.get();
     auto const n       = input.size();
     // cub radix sort implementation is always stable
     std::size_t tmp_bytes = 0;
@@ -94,7 +94,7 @@ struct sort_radix_fn {
 
     auto const decomposer = float_decomposer<T>{};
     auto const end_bit    = sizeof(float_pair<T>) * 8;
-    auto const sv         = stream.value();
+    auto const sv         = stream.get();
     auto const n          = input.size();
     // cub radix sort implementation is always stable
     std::size_t tmp_bytes = 0;
@@ -150,7 +150,7 @@ bool is_radix_sortable(column_view const& column)
 
 std::unique_ptr<column> sort_radix(column_view const& input,
                                    bool ascending,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   auto result   = std::make_unique<column>(input, stream, mr);

--- a/cpp/src/sort/sort_radix.hpp
+++ b/cpp/src/sort/sort_radix.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -7,7 +7,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -33,7 +33,7 @@ bool is_radix_sortable(column_view const& column);
  */
 std::unique_ptr<column> sort_radix(column_view const& input,
                                    bool ascending,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -49,6 +49,6 @@ std::unique_ptr<column> sort_radix(column_view const& input,
 void sorted_order_radix(column_view const& input,
                         mutable_column_view& indices,
                         bool ascending,
-                        rmm::cuda_stream_view stream);
+                        cuda::stream_ref stream);
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/sorted_order_radix.cu
+++ b/cpp/src/sort/sorted_order_radix.cu
@@ -11,12 +11,12 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
@@ -58,7 +58,7 @@ struct sorted_order_radix_fn {
   column_view const& input;      // keys to sort
   mutable_column_view& indices;  // output of sort
   bool ascending;                // true for ascending sort
-  rmm::cuda_stream_view stream;  // for allocation and kernel launches
+  cuda::stream_ref stream;       // for allocation and kernel launches
 
   template <typename T>
   void radix_sort()
@@ -75,7 +75,7 @@ struct sorted_order_radix_fn {
     auto dv_out = indices.begin<cudf::size_type>();
 
     auto const n       = input.size();
-    auto const sv      = stream.value();
+    auto const sv      = stream.get();
     auto const end_bit = sizeof(T) * 8;
 
     // cub radix sort implementation is always stable
@@ -117,7 +117,7 @@ struct sorted_order_radix_fn {
 
     auto const decomposer = float_decomposer<T>{};
     auto const end_bit    = sizeof(float_pair<T>) * 8;
-    auto const sv         = stream.value();
+    auto const sv         = stream.get();
     auto const n          = input.size();
     // cub radix sort implementation is always stable
     std::size_t tmp_bytes = 0;
@@ -173,7 +173,7 @@ struct sorted_order_radix_fn {
 void sorted_order_radix(column_view const& input,
                         mutable_column_view& indices,
                         bool ascending,
-                        rmm::cuda_stream_view stream)
+                        cuda::stream_ref stream)
 {
   cudf::type_dispatcher<dispatch_storage_type>(
     input.type(), sorted_order_radix_fn{input, indices, ascending, stream});

--- a/cpp/src/sort/stable_segmented_sort.cu
+++ b/cpp/src/sort/stable_segmented_sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   return segmented_sorted_order_common<sort_method::STABLE>(
@@ -31,7 +31,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
                                                     column_view const& segment_offsets,
                                                     std::vector<order> const& column_order,
                                                     std::vector<null_order> const& null_precedence,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   return segmented_sort_by_key_common<sort_method::STABLE>(
@@ -45,7 +45,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order,
   std::vector<null_order> const& null_precedence,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -58,7 +58,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
                                                     column_view const& segment_offsets,
                                                     std::vector<order> const& column_order,
                                                     std::vector<null_order> const& null_precedence,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,14 +15,14 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             std::vector<order> const& column_order,
                                             std::vector<null_order> const& null_precedence,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   return sorted_order<sort_method::STABLE>(input, column_order, null_precedence, stream, mr);
@@ -31,7 +31,7 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
 std::unique_ptr<table> stable_sort(table_view const& input,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   // fast-path sort conditions: single, fixed-width column with no nulls
@@ -49,7 +49,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
                                           table_view const& keys,
                                           std::vector<order> const& column_order,
                                           std::vector<null_order> const& null_precedence,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
@@ -70,7 +70,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
 std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             std::vector<order> const& column_order,
                                             std::vector<null_order> const& null_precedence,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -80,7 +80,7 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
 std::unique_ptr<table> stable_sort(table_view const& input,
                                    std::vector<order> const& column_order,
                                    std::vector<null_order> const& null_precedence,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -91,7 +91,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
                                           table_view const& keys,
                                           std::vector<order> const& column_order,
                                           std::vector<null_order> const& null_precedence,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/sort/stable_sort_column.cu
+++ b/cpp/src/sort/stable_sort_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,13 +17,13 @@ namespace detail {
 
 /**
  * @copydoc
- * stable_sorted_order(column_view&,order,null_order,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * stable_sorted_order(column_view&,order,null_order,cuda::stream_ref,rmm::device_async_resource_ref)
  */
 template <>
 std::unique_ptr<column> sorted_order<sort_method::STABLE>(column_view const& input,
                                                           order column_order,
                                                           null_order null_precedence,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr)
 {
   auto sorted_indices = cudf::make_numeric_column(

--- a/cpp/src/sort/top_k.cu
+++ b/cpp/src/sort/top_k.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -26,6 +25,7 @@
 #include <cuda/iterator>
 #include <cuda/std/execution>
 #include <cuda/stream>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -41,7 +41,7 @@ struct dispatch_topk_fn {
   column_view input;
   size_type k;
   order topk_order;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   template <typename T>
@@ -49,7 +49,7 @@ struct dispatch_topk_fn {
   {
     auto requirements = cuda::execution::require(cuda::execution::determinism::not_guaranteed,
                                                  cuda::execution::output_ordering::unsorted);
-    auto env          = cuda::std::execution::env{cuda::stream_ref{stream.value()}, requirements};
+    auto env          = cuda::std::execution::env{cuda::stream_ref{stream.get()}, requirements};
     auto tmp_size     = std::size_t{0};
     auto const size   = input.size();
 
@@ -104,7 +104,7 @@ struct dispatch_topk_fn {
 std::unique_ptr<column> top_k(column_view const& col,
                               size_type k,
                               order topk_order,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(k >= 0, "k must be non-negative", std::invalid_argument);
@@ -133,7 +133,7 @@ std::unique_ptr<column> top_k(column_view const& col,
 std::unique_ptr<column> top_k_order(column_view const& col,
                                     size_type k,
                                     order topk_order,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(k >= 0, "k must be non-negative", std::invalid_argument);
@@ -163,7 +163,7 @@ std::unique_ptr<column> top_k_order(column_view const& col,
 std::unique_ptr<column> top_k(column_view const& col,
                               size_type k,
                               order topk_order,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -173,7 +173,7 @@ std::unique_ptr<column> top_k(column_view const& col,
 std::unique_ptr<column> top_k_order(column_view const& col,
                                     size_type k,
                                     order topk_order,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,12 +16,12 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
-  column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == type_id::BOOL8, "Input is not of type bool");
 
@@ -48,7 +48,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
 }  // namespace detail
 
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
-  column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   return detail::bools_to_mask(input, stream, mr);

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,8 +20,9 @@
 #include <cudf/transform.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <algorithm>
 
@@ -29,7 +30,7 @@ namespace cudf {
 namespace detail {
 std::unique_ptr<column> compute_column(table_view const& table,
                                        ast::expression const& expr,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   if (get_context().use_jit()) { return compute_column_jit(table, expr, stream, mr); }
@@ -103,7 +104,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
     }
   }
 
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
   output_column->set_null_count(
     cudf::detail::null_count(mutable_output_device->null_mask(), 0, output_column->size(), stream));
   return output_column;
@@ -113,7 +114,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
 
 std::unique_ptr<column> compute_column(table_view const& table,
                                        ast::expression const& expr,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/compute_column_kernel.cuh
+++ b/cpp/src/transform/compute_column_kernel.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 /**
@@ -67,10 +67,10 @@ void launch_compute_column_kernel(table_device_view const& table_device,
                                   mutable_column_device_view& mutable_output_device,
                                   cudf::detail::grid_1d const& config,
                                   size_t shmem_per_block,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   compute_column_kernel<MAX_BLOCK_SIZE, HasNull, HasComplexType>
-    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.value()>>>(
+    <<<config.num_blocks, config.num_threads_per_block, shmem_per_block, stream.get()>>>(
       table_device, device_expression_data, mutable_output_device);
   CUDF_CUDA_TRY(cudaGetLastError());
 }

--- a/cpp/src/transform/compute_column_kernel.hpp
+++ b/cpp/src/transform/compute_column_kernel.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf::detail {
 /**
@@ -41,5 +41,5 @@ void launch_compute_column_kernel(table_device_view const& table_device,
                                   mutable_column_device_view& mutable_output_device,
                                   cudf::detail::grid_1d const& config,
                                   size_t shmem_per_block,
-                                  rmm::cuda_stream_view stream);
+                                  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/transform/compute_column_kernel_complex.cu
+++ b/cpp/src/transform/compute_column_kernel_complex.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,5 +13,5 @@ template void launch_compute_column_kernel<false, true>(
   mutable_column_device_view& mutable_output_device,
   cudf::detail::grid_1d const& config,
   size_t shmem_per_block,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/transform/compute_column_kernel_null_complex.cu
+++ b/cpp/src/transform/compute_column_kernel_null_complex.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,5 +13,5 @@ template void launch_compute_column_kernel<true, true>(
   mutable_column_device_view& mutable_output_device,
   cudf::detail::grid_1d const& config,
   size_t shmem_per_block,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/transform/compute_column_kernel_null_primitive.cu
+++ b/cpp/src/transform/compute_column_kernel_null_primitive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,5 +13,5 @@ template void launch_compute_column_kernel<true, false>(
   mutable_column_device_view& mutable_output_device,
   cudf::detail::grid_1d const& config,
   size_t shmem_per_block,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/transform/compute_column_kernel_primitive.cu
+++ b/cpp/src/transform/compute_column_kernel_primitive.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,5 +13,5 @@ template void launch_compute_column_kernel<false, false>(
   mutable_column_device_view& mutable_output_device,
   cudf::detail::grid_1d const& config,
   size_t shmem_per_block,
-  rmm::cuda_stream_view stream);
+  cuda::stream_ref stream);
 }  // namespace cudf::detail

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,9 +18,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <numeric>
@@ -31,7 +32,7 @@ namespace cudf {
 namespace detail {
 
 std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(table_view const& input_table,
-                                                                  rmm::cuda_stream_view stream,
+                                                                  cuda::stream_ref stream,
                                                                   rmm::device_async_resource_ref mr)
 {
   auto const num_cols = input_table.num_columns();
@@ -61,7 +62,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(table_view con
 }  // namespace detail
 
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
-  cudf::table_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::table_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   return detail::encode(input, stream, mr);

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,10 +12,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -23,7 +23,7 @@ namespace detail {
 std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
                                       size_type begin_bit,
                                       size_type end_bit,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   auto const length = end_bit - begin_bit;
@@ -50,7 +50,7 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
 std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
                                       size_type begin_bit,
                                       size_type end_bit,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,17 +16,16 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
 struct dispatch_nan_to_null {
   template <typename T>
   std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> operator()(
-    column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(std::is_floating_point_v<T>)
   {
     auto input_device_view_ptr = column_device_view::create(input, stream);
@@ -48,7 +47,7 @@ struct dispatch_nan_to_null {
 
   template <typename T>
   std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> operator()(
-    column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
     requires(!std::is_floating_point_v<T>)
   {
     CUDF_FAIL("Input column can't be a non-floating type");
@@ -56,7 +55,7 @@ struct dispatch_nan_to_null {
 };
 
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
-  column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::is_floating_point(input.type()),
                "Input must be a floating point type",
@@ -68,7 +67,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
 
 struct copy_float_data_fn {
   column_view const& input;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   template <typename T>
@@ -88,7 +87,7 @@ struct copy_float_data_fn {
 };
 
 std::unique_ptr<column> column_nans_to_nulls(column_view const& input,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::is_floating_point(input.type()),
@@ -109,14 +108,14 @@ std::unique_ptr<column> column_nans_to_nulls(column_view const& input,
 }  // namespace detail
 
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
-  column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   return detail::nans_to_nulls(input, stream, mr);
 }
 
 std::unique_ptr<column> column_nans_to_nulls(column_view const& input,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,10 +17,10 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 #include <algorithm>
@@ -49,7 +49,7 @@ struct ohe_equality_functor {
 
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const& input,
                                                               column_view const& categories,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(cudf::have_same_types(input, categories),
@@ -103,7 +103,7 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
 
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const& input,
                                                               column_view const& categories,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,12 +20,12 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/stream_ref>
 #include <thrust/tabulate.h>
 
 namespace cudf {
@@ -148,7 +148,7 @@ void flatten_hierarchy(ColIter begin,
                        std::vector<cudf::column_view>& out,
                        std::vector<column_info>& info,
                        hierarchy_info& h_info,
-                       rmm::cuda_stream_view stream,
+                       cuda::stream_ref stream,
                        size_type cur_depth                   = 0,
                        size_type cur_branch_depth            = 0,
                        cuda::std::optional<int> parent_index = {});
@@ -164,7 +164,7 @@ struct flatten_functor {
                   std::vector<cudf::column_view>& out,
                   std::vector<column_info>& info,
                   hierarchy_info& h_info,
-                  rmm::cuda_stream_view,
+                  cuda::stream_ref,
                   size_type cur_depth,
                   size_type cur_branch_depth,
                   cuda::std::optional<int>)
@@ -182,7 +182,7 @@ struct flatten_functor {
                   std::vector<cudf::column_view>& out,
                   std::vector<column_info>& info,
                   hierarchy_info& h_info,
-                  rmm::cuda_stream_view,
+                  cuda::stream_ref,
                   size_type cur_depth,
                   size_type cur_branch_depth,
                   cuda::std::optional<int>)
@@ -199,7 +199,7 @@ struct flatten_functor {
                   std::vector<cudf::column_view>& out,
                   std::vector<column_info>& info,
                   hierarchy_info& h_info,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   size_type cur_depth,
                   size_type cur_branch_depth,
                   cuda::std::optional<int> parent_index)
@@ -238,7 +238,7 @@ struct flatten_functor {
                   std::vector<cudf::column_view>& out,
                   std::vector<column_info>& info,
                   hierarchy_info& h_info,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   size_type cur_depth,
                   size_type cur_branch_depth,
                   cuda::std::optional<int>)
@@ -279,7 +279,7 @@ void flatten_hierarchy(ColIter begin,
                        std::vector<cudf::column_view>& out,
                        std::vector<column_info>& info,
                        hierarchy_info& h_info,
-                       rmm::cuda_stream_view stream,
+                       cuda::stream_ref stream,
                        size_type cur_depth,
                        size_type cur_branch_depth,
                        cuda::std::optional<int> parent_index)
@@ -476,7 +476,7 @@ CUDF_KERNEL void compute_segment_sizes(device_span<column_device_view const> col
 
 std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
                                                 size_type segment_length,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   // If there is no rows, segment_length will not be checked.
@@ -546,7 +546,7 @@ std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
   CUDF_EXPECTS(block_size > 0, "Encountered a column hierarchy too complex for row_bit_count");
 
   cudf::detail::grid_1d grid{num_segments, block_size, 1};
-  compute_segment_sizes<<<grid.num_blocks, block_size, shared_mem_size, stream.value()>>>(
+  compute_segment_sizes<<<grid.num_blocks, block_size, shared_mem_size, stream.get()>>>(
     {std::get<1>(d_cols), cols.size()},
     {d_info.data(), info.size()},
     {mcv.data<size_type>(), static_cast<std::size_t>(mcv.size())},
@@ -558,7 +558,7 @@ std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
 }
 
 std::unique_ptr<column> row_bit_count(table_view const& t,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   return detail::segmented_row_bit_count(t, 1, stream, mr);
@@ -568,7 +568,7 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
 
 std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
                                                 size_type segment_length,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -576,7 +576,7 @@ std::unique_ptr<column> segmented_row_bit_count(table_view const& t,
 }
 
 std::unique_ptr<column> row_bit_count(table_view const& t,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -20,9 +20,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <cudf_fragments.hpp>
 #include <jit/cache.hpp>
@@ -47,7 +46,7 @@ column_view as_column_view(column_view const& column) { return column; }
 struct mutable_fixed_width_column_view {
   mutable_column_view _view;
 
-  auto to_device(rmm::cuda_stream_view stream) const
+  auto to_device(cuda::stream_ref stream) const
   {
     return mutable_column_device_view::create(_view, stream);
   }
@@ -60,7 +59,7 @@ struct fixed_width_column {
                    size_type size,
                    rmm::device_buffer null_mask,
                    size_type null_count,
-                   rmm::cuda_stream_view stream,
+                   cuda::stream_ref stream,
                    rmm::device_async_resource_ref mr)
   {
     return fixed_width_column{
@@ -83,7 +82,7 @@ struct mutable_string_views_column_view {
   size_type _offset{0};
   size_type _null_count{0};
 
-  auto to_device(rmm::cuda_stream_view stream) const
+  auto to_device(cuda::stream_ref stream) const
   {
     using view = mutable_column_device_view;
     return std::unique_ptr<view, std::function<void(view*)>>(
@@ -102,7 +101,7 @@ struct string_views_column {
   static auto make(size_type size,
                    rmm::device_buffer null_mask,
                    size_type null_count,
-                   rmm::cuda_stream_view stream,
+                   cuda::stream_ref stream,
                    rmm::device_async_resource_ref mr)
   {
     rmm::device_buffer data{static_cast<size_t>(size) * sizeof(string_view), stream, mr};
@@ -129,7 +128,7 @@ struct string_views_column {
 struct mutable_strings_column_view {
   mutable_column_view _view;
 
-  auto to_device(rmm::cuda_stream_view stream) const
+  auto to_device(cuda::stream_ref stream) const
   {
     return mutable_column_device_view::create(_view, stream);
   }
@@ -198,7 +197,7 @@ void launch(cudf::kernel const& kernel,
             column_device_view_core const* input_cols,
             mutable_column_device_view_core const* output_cols,
             int32_t* max_error,
-            rmm::cuda_stream_view stream)
+            cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
   void* args[] = {&row_size, &stencil, &user_data, &input_cols, &output_cols, &max_error};
@@ -448,7 +447,7 @@ std::tuple<rtcx::blob, lto_binary_type, std::string> instantiate_fragment(
 
 auto to_args(std::span<input_column_view const> inputs,
              std::span<output_column const> outputs,
-             rmm::cuda_stream_view stream,
+             cuda::stream_ref stream,
              rmm::device_async_resource_ref mr)
 {
   std::vector<handle> handles;
@@ -494,7 +493,7 @@ void run(bool is_null_aware,
          int32_t* d_max_error,
          std::string const& udf,
          udf_source_type source_type,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr)
 {
   auto [in_types, out_types, ptx_in_types, ptx_out_types] = reflect(source_type, inputs, outputs);
@@ -538,7 +537,7 @@ void run_lto(std::optional<std::tuple<std::span<uint8_t const>, lto_binary_type,
              int32_t* d_max_error,
              std::span<uint8_t const> udf_binary,
              lto_binary_type source_type,
-             rmm::cuda_stream_view stream,
+             cuda::stream_ref stream,
              rmm::device_async_resource_ref mr)
 {
   auto [in_types, out_types, ptx_in_types, ptx_out_types] = reflect(source_type, inputs, outputs);
@@ -599,7 +598,7 @@ CUDF_KERNEL void copy_offset_bitmask(bitmask_type* __restrict__ destination,
 size_type inplace_null_mask_and(bitmask_type* null_mask,
                                 size_type row_size,
                                 std::span<transform_input const> inputs,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
 
@@ -673,9 +672,9 @@ size_type inplace_null_mask_and(bitmask_type* null_mask,
         null_mask, nullable_masks[0] + (src_begin / bits_per_word), num_bytes, stream));
     } else {
       detail::grid_1d config(row_size, 256);
-      copy_offset_bitmask<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+      copy_offset_bitmask<<<config.num_blocks, config.num_threads_per_block, 0, stream.get()>>>(
         static_cast<bitmask_type*>(null_mask), nullable_masks[0], src_begin, src_end, num_words);
-      CUDF_CHECK_CUDA(stream.value());
+      CUDF_CHECK_CUDA(stream.get());
     }
     return nullable_null_counts[0];
   }
@@ -821,7 +820,7 @@ std::optional<std::pair<bitmask_type*, size_type>> make_stencil(
   size_type row_size,
   std::span<transform_input const> inputs,
   std::span<output_column> outputs,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
 
@@ -860,7 +859,7 @@ rmm::device_uvector<char> make_chars_buffer(column_view const& offsets_view,
                                             string_view const* begin,
                                             bitmask_type const* stencil,
                                             size_type size,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   auto offsets = detail::offsetalator_factory::make_input_iterator(offsets_view);
@@ -882,10 +881,10 @@ rmm::device_uvector<char> make_chars_buffer(column_view const& offsets_view,
 
   size_t temp_storage_bytes = 0;
   CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(
-    nullptr, temp_storage_bytes, srcs, dsts, src_sizes, size, stream.value()));
+    nullptr, temp_storage_bytes, srcs, dsts, src_sizes, size, stream.get()));
   rmm::device_buffer d_temp_storage(temp_storage_bytes, stream);
   CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(
-    d_temp_storage.data(), temp_storage_bytes, srcs, dsts, src_sizes, size, stream.value()));
+    d_temp_storage.data(), temp_storage_bytes, srcs, dsts, src_sizes, size, stream.get()));
 
   return chars;
 }
@@ -893,7 +892,7 @@ rmm::device_uvector<char> make_chars_buffer(column_view const& offsets_view,
 std::unique_ptr<column> make_strings_column(device_span<string_view const> strings,
                                             rmm::device_buffer null_mask,
                                             size_type null_count,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -924,7 +923,7 @@ auto make_outputs(null_aware is_null_aware,
                   std::span<transform_output const> outputs,
                   std::span<char const> is_output_nullable,
                   std::vector<std::unique_ptr<column>> string_offsets,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -966,7 +965,7 @@ auto make_outputs(null_aware is_null_aware,
 void update_null_counts(std::span<output_column> outputs,
                         null_aware is_null_aware,
                         size_type row_size,
-                        rmm::cuda_stream_view stream)
+                        cuda::stream_ref stream)
 {
   // update null counts if the function is not null-aware, since we haven't processed nullability
   // ahead of time (as in the non-null-aware case)
@@ -993,20 +992,18 @@ void update_null_counts(std::span<output_column> outputs,
   }
 }
 
-auto finalize_output(fixed_width_column&& c, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+auto finalize_output(fixed_width_column&& c, cuda::stream_ref, rmm::device_async_resource_ref)
 {
   return std::move(c._col);
 }
 
-auto finalize_output(mutable_strings_column&& c,
-                     rmm::cuda_stream_view,
-                     rmm::device_async_resource_ref)
+auto finalize_output(mutable_strings_column&& c, cuda::stream_ref, rmm::device_async_resource_ref)
 {
   return std::move(c._col);
 }
 
 auto finalize_output(string_views_column&& c,
-                     rmm::cuda_stream_view stream,
+                     cuda::stream_ref stream,
                      rmm::device_async_resource_ref mr)
 {
   return make_strings_column(
@@ -1021,7 +1018,7 @@ auto finalize_output(string_views_column&& c,
 auto finalize_outputs(null_aware is_null_aware,
                       size_type row_size,
                       std::vector<output_column> outputs,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -1045,7 +1042,7 @@ std::unique_ptr<table> execute_transform(std::string const& udf,
                                          std::span<transform_input const> inputs,
                                          std::span<transform_output const> outputs,
                                          std::vector<std::unique_ptr<column>> string_offsets,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   auto row_size = in_row_size.has_value() ? *in_row_size : jit::get_projection_size(inputs);
@@ -1100,7 +1097,7 @@ std::unique_ptr<table> transform(std::string const& udf,
                                  std::span<transform_output const> outputs,
                                  std::vector<std::unique_ptr<column>>&& string_offsets,
                                  std::optional<size_type> row_size,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -1125,7 +1122,7 @@ std::unique_ptr<table> multi_transform(std::string const& udf,
                                        std::span<transform_output const> outputs,
                                        std::vector<std::unique_ptr<column>>&& string_offsets,
                                        std::optional<size_type> row_size,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   return transform(udf,
@@ -1148,7 +1145,7 @@ std::unique_ptr<column> transform_extended(std::span<transform_input const> inpu
                                            null_aware is_null_aware,
                                            std::optional<size_type> row_size,
                                            output_nullability null_policy,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   transform_output outputs[] = {{.type = output_type, .nullability = null_policy}};
@@ -1161,7 +1158,7 @@ std::unique_ptr<column> transform_extended(std::span<transform_input const> inpu
 
 std::unique_ptr<column> compute_column_jit(table_view const& table,
                                            ast::expression const& expr,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   auto args = detail::row_ir::ast_converter::compute_column(
@@ -1231,7 +1228,7 @@ std::unique_ptr<table> transform_lto(std::span<uint8_t const> udf,
                                      std::span<transform_output const> outputs,
                                      std::vector<std::unique_ptr<column>>&& string_offsets,
                                      std::optional<size_type> in_row_size,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,10 +21,10 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -160,7 +160,7 @@ struct device_cast {
 template <typename T>
 std::unique_ptr<column> rescale(column_view input,
                                 numeric::scale_type scale,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
   requires(is_fixed_point<T>())
 {
@@ -226,7 +226,7 @@ struct dispatch_unary_cast_to {
 
   template <typename TargetT, typename SourceT = _SourceT>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(is_supported_non_fixed_point_cast<SourceT, TargetT>())
   {
@@ -250,7 +250,7 @@ struct dispatch_unary_cast_to {
 
   template <typename TargetT, typename SourceT = _SourceT>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<SourceT>() && cudf::is_numeric<TargetT>())
   {
@@ -277,7 +277,7 @@ struct dispatch_unary_cast_to {
 
   template <typename TargetT, typename SourceT = _SourceT>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_numeric<SourceT>() && cudf::is_fixed_point<TargetT>())
   {
@@ -317,7 +317,7 @@ struct dispatch_unary_cast_to {
 
   template <typename TargetT, typename SourceT = _SourceT>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<SourceT>() && cudf::is_fixed_point<TargetT>() &&
              std::is_same_v<SourceT, TargetT>)
@@ -331,7 +331,7 @@ struct dispatch_unary_cast_to {
 
   template <typename TargetT, typename SourceT = _SourceT>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<SourceT>() && cudf::is_fixed_point<TargetT>() &&
              not std::is_same_v<SourceT, TargetT>)
@@ -374,9 +374,7 @@ struct dispatch_unary_cast_to {
   }
 
   template <typename TargetT, typename SourceT = _SourceT>
-  std::unique_ptr<column> operator()(data_type,
-                                     rmm::cuda_stream_view,
-                                     rmm::device_async_resource_ref)
+  std::unique_ptr<column> operator()(data_type, cuda::stream_ref, rmm::device_async_resource_ref)
 
     requires(not is_supported_cast<SourceT, TargetT>())
   {
@@ -398,7 +396,7 @@ struct dispatch_unary_cast_from {
 
   template <typename T>
   std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_width<T>())
   {
@@ -416,7 +414,7 @@ struct dispatch_unary_cast_from {
 
 std::unique_ptr<column> cast(column_view const& input,
                              data_type type,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(is_fixed_width(type), "Unary cast type must be fixed-width.");
@@ -436,7 +434,7 @@ struct is_supported_cast_impl {
 
 std::unique_ptr<column> cast(column_view const& input,
                              data_type type,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,12 +14,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/bit>
 #include <cuda/std/cmath>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -294,7 +294,7 @@ struct fixed_point_negate {
 
 template <typename T, template <typename> typename FixedPointFunctor>
 std::unique_ptr<column> unary_op_with(column_view const& input,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   using Type                     = device_storage_type_t<T>;
@@ -336,7 +336,7 @@ std::unique_ptr<cudf::column> transform_fn(InputIterator begin,
                                            InputIterator end,
                                            rmm::device_buffer&& null_mask,
                                            size_type null_count,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   auto const size = cudf::distance(begin, end);
@@ -361,7 +361,7 @@ std::unique_ptr<cudf::column> transform_fn(InputIterator begin,
 
 template <typename T, typename UFN>
 std::unique_ptr<cudf::column> transform_fn(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return transform_fn<T, UFN>(input.begin<T>(),
@@ -374,7 +374,7 @@ std::unique_ptr<cudf::column> transform_fn(cudf::column_view const& input,
 
 template <typename T, typename UFN>
 std::unique_ptr<cudf::column> transform_fn(cudf::dictionary_column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   auto dictionary_view = cudf::column_device_view::create(input.parent(), stream);
@@ -424,7 +424,7 @@ template <typename UFN, template <typename> typename Supported>
 struct MathOpDispatcher {
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(Supported<T>::is_supported())
   {
@@ -456,7 +456,7 @@ struct BitwiseCountDispatcher {
  public:
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(is_supported<T>())
   {
@@ -498,7 +498,7 @@ struct LogicalOpDispatcher {
  public:
   template <typename T>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(is_supported<T>())
   {
@@ -539,7 +539,7 @@ struct FixedPointOpDispatcher {
   template <typename T>
   std::unique_ptr<column> operator()(column_view const& input,
                                      cudf::unary_operator op,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(cudf::is_fixed_point<T>())
   {
@@ -559,7 +559,7 @@ struct FixedPointOpDispatcher {
 
 std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
                                               cudf::unary_operator op,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   if (cudf::is_fixed_point(input.type()))
@@ -657,7 +657,7 @@ std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
 
 std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
                                               cudf::unary_operator op,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/unary/nan_ops.cu
+++ b/cpp/src/unary/nan_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace cudf {
 namespace detail {
@@ -23,7 +23,7 @@ struct nan_dispatcher {
   template <typename T, typename Predicate>
   std::unique_ptr<column> operator()(cudf::column_view const& input,
                                      Predicate predicate,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(std::is_floating_point_v<T>)
   {
@@ -51,7 +51,7 @@ struct nan_dispatcher {
   template <typename T, typename Predicate>
   std::unique_ptr<column> operator()(cudf::column_view const& input,
                                      Predicate predicate,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
     requires(!std::is_floating_point_v<T>)
   {
@@ -60,7 +60,7 @@ struct nan_dispatcher {
 };
 
 std::unique_ptr<column> is_nan(cudf::column_view const& input,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   auto predicate = [] __device__(auto element_validity_pair) {
@@ -71,7 +71,7 @@ std::unique_ptr<column> is_nan(cudf::column_view const& input,
 }
 
 std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   auto predicate = [] __device__(auto element_validity_pair) {
@@ -84,7 +84,7 @@ std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
 }  // namespace detail
 
 std::unique_ptr<column> is_nan(cudf::column_view const& input,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -92,7 +92,7 @@ std::unique_ptr<column> is_nan(cudf::column_view const& input,
 }
 
 std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> is_null(cudf::column_view const& input,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   auto input_device_view = column_device_view::create(input, stream);
@@ -31,7 +31,7 @@ std::unique_ptr<column> is_null(cudf::column_view const& input,
 }
 
 std::unique_ptr<column> is_valid(cudf::column_view const& input,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   auto input_device_view = column_device_view::create(input, stream);
@@ -48,7 +48,7 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
 }  // namespace detail
 
 std::unique_ptr<column> is_null(cudf::column_view const& input,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -56,7 +56,7 @@ std::unique_ptr<column> is_null(cudf::column_view const& input,
 }
 
 std::unique_ptr<column> is_valid(cudf::column_view const& input,
-                                 rmm::cuda_stream_view stream,
+                                 cuda::stream_ref stream,
                                  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/unary/true_if.cuh
+++ b/cpp/src/unary/true_if.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,9 +8,9 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -38,7 +38,7 @@ std::unique_ptr<column> true_if(InputIterator begin,
                                 InputIterator end,
                                 size_type size,
                                 Predicate p,
-                                rmm::cuda_stream_view stream,
+                                cuda::stream_ref stream,
                                 rmm::device_async_resource_ref mr)
 {
   auto output =

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,9 +12,9 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -23,7 +23,7 @@ template <typename T, typename Tout, typename F>
 struct launcher {
   static std::unique_ptr<cudf::column> launch(cudf::column_view const& input,
                                               cudf::unary_operator op,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
   {
     std::unique_ptr<cudf::column> output = [&] {
@@ -62,7 +62,7 @@ struct launcher {
                       output_view.begin<Tout>(),
                       F{});
 
-    CUDF_CHECK_CUDA(stream.value());
+    CUDF_CHECK_CUDA(stream.get());
 
     return output;
   }

--- a/cpp/tests/groupby/host_udf_example_tests.cu
+++ b/cpp/tests/groupby/host_udf_example_tests.cu
@@ -35,14 +35,14 @@ struct host_udf_groupby_example : cudf::groupby_host_udf {
   host_udf_groupby_example() = default;
 
   [[nodiscard]] std::unique_ptr<cudf::column> get_empty_output(
-    rmm::cuda_stream_view, rmm::device_async_resource_ref) const override
+    cuda::stream_ref, rmm::device_async_resource_ref) const override
   {
     return cudf::make_empty_column(
       cudf::data_type{cudf::type_to_id<typename groupby_fn::OutputType>()});
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> operator()(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
   {
     auto const values = get_grouped_values();
     return cudf::type_dispatcher(values.type(), groupby_fn{*this}, stream, mr);
@@ -74,7 +74,7 @@ struct host_udf_groupby_example : cudf::groupby_host_udf {
     }
 
     template <typename T, CUDF_ENABLE_IF(std::is_same_v<InputType, T>)>
-    std::unique_ptr<cudf::column> operator()(rmm::cuda_stream_view stream,
+    std::unique_ptr<cudf::column> operator()(cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr) const
     {
       auto const values = parent.get_grouped_values();

--- a/cpp/tests/groupby/host_udf_example_tests.cu
+++ b/cpp/tests/groupby/host_udf_example_tests.cu
@@ -35,14 +35,14 @@ struct host_udf_groupby_example : cudf::groupby_host_udf {
   host_udf_groupby_example() = default;
 
   [[nodiscard]] std::unique_ptr<cudf::column> get_empty_output(
-    cuda::stream_ref, rmm::device_async_resource_ref) const override
+    rmm::cuda_stream_view, rmm::device_async_resource_ref) const override
   {
     return cudf::make_empty_column(
       cudf::data_type{cudf::type_to_id<typename groupby_fn::OutputType>()});
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> operator()(
-    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
+    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
   {
     auto const values = get_grouped_values();
     return cudf::type_dispatcher(values.type(), groupby_fn{*this}, stream, mr);
@@ -74,7 +74,7 @@ struct host_udf_groupby_example : cudf::groupby_host_udf {
     }
 
     template <typename T, CUDF_ENABLE_IF(std::is_same_v<InputType, T>)>
-    std::unique_ptr<cudf::column> operator()(cuda::stream_ref stream,
+    std::unique_ptr<cudf::column> operator()(rmm::cuda_stream_view stream,
                                              rmm::device_async_resource_ref mr) const
     {
       auto const values = parent.get_grouped_values();

--- a/cpp/tests/groupby/host_udf_tests.cpp
+++ b/cpp/tests/groupby/host_udf_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ struct host_udf_groupby_test : cudf::groupby_host_udf {
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> get_empty_output(
-    [[maybe_unused]] rmm::cuda_stream_view stream,
+    [[maybe_unused]] cuda::stream_ref stream,
     [[maybe_unused]] rmm::device_async_resource_ref mr) const override
   {
     // Dummy output.
@@ -67,7 +67,7 @@ struct host_udf_groupby_test : cudf::groupby_host_udf {
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> operator()(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
   {
     SCOPED_TRACE("Test instance created at line: " + std::to_string(test_location_line));
 

--- a/cpp/tests/groupby/host_udf_tests.cpp
+++ b/cpp/tests/groupby/host_udf_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ struct host_udf_groupby_test : cudf::groupby_host_udf {
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> get_empty_output(
-    [[maybe_unused]] cuda::stream_ref stream,
+    [[maybe_unused]] rmm::cuda_stream_view stream,
     [[maybe_unused]] rmm::device_async_resource_ref mr) const override
   {
     // Dummy output.
@@ -67,7 +67,7 @@ struct host_udf_groupby_test : cudf::groupby_host_udf {
   }
 
   [[nodiscard]] std::unique_ptr<cudf::column> operator()(
-    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
+    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
   {
     SCOPED_TRACE("Test instance created at line: " + std::to_string(test_location_line));
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -26,9 +26,10 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <future>
@@ -52,10 +53,10 @@ enum class algorithm { HASH, HASH_PARTITIONED, SORT_MERGE, MERGE };
 
 void expect_match_counts_equal(rmm::device_uvector<cudf::size_type> const& actual_counts,
                                std::vector<cudf::size_type> const& expected_counts,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   auto const host_actual_counts = cudf::detail::make_host_vector_async(actual_counts, stream);
-  stream.synchronize();
+  stream.wait();
 
   ASSERT_EQ(host_actual_counts.size(), expected_counts.size());
   EXPECT_TRUE(
@@ -75,7 +76,7 @@ std::unique_ptr<cudf::table> join_and_gather(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   cudf::null_equality compare_nulls,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto left_selected  = left_input.select(left_on);
@@ -113,7 +114,7 @@ std::unique_ptr<cudf::table> inner_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::sort_merge_join obj(right, cudf::sorted::NO, compare_nulls, stream);
         return obj.inner_join(left, stream, mr);
@@ -128,7 +129,7 @@ std::unique_ptr<cudf::table> inner_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::sort_merge_join obj(right, cudf::sorted::YES, compare_nulls, stream);
         return obj.inner_join(left, stream, mr);
@@ -143,7 +144,7 @@ std::unique_ptr<cudf::table> inner_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::hash_join hash_joiner(right, compare_nulls, stream);
         auto match_ctx = hash_joiner.inner_join_match_context(left, stream, mr);
@@ -161,7 +162,7 @@ std::unique_ptr<cudf::table> inner_join(
     [](cudf::table_view const& left,
        cudf::table_view const& right,
        cudf::null_equality compare_nulls,
-       rmm::cuda_stream_view stream,
+       cuda::stream_ref stream,
        rmm::device_async_resource_ref mr) {
       return cudf::inner_join(left, right, compare_nulls, stream, mr);
     },
@@ -204,7 +205,7 @@ std::unique_ptr<cudf::table> left_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::sort_merge_join obj(right, cudf::sorted::NO, compare_nulls, stream);
         return obj.left_join(left, stream, mr);
@@ -219,7 +220,7 @@ std::unique_ptr<cudf::table> left_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::sort_merge_join obj(right, cudf::sorted::YES, compare_nulls, stream);
         return obj.left_join(left, stream, mr);
@@ -234,7 +235,7 @@ std::unique_ptr<cudf::table> left_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::hash_join hash_joiner(right, compare_nulls, stream);
         auto match_ctx = hash_joiner.left_join_match_context(left, stream, mr);
@@ -252,7 +253,7 @@ std::unique_ptr<cudf::table> left_join(
     [](cudf::table_view const& left,
        cudf::table_view const& right,
        cudf::null_equality compare_nulls,
-       rmm::cuda_stream_view stream,
+       cuda::stream_ref stream,
        rmm::device_async_resource_ref mr) {
       return cudf::left_join(left, right, compare_nulls, stream, mr);
     },
@@ -276,7 +277,7 @@ std::unique_ptr<cudf::table> full_join(
       [](cudf::table_view const& left,
          cudf::table_view const& right,
          cudf::null_equality compare_nulls,
-         rmm::cuda_stream_view stream,
+         cuda::stream_ref stream,
          rmm::device_async_resource_ref mr) {
         cudf::hash_join hash_joiner(right, compare_nulls, stream);
         auto match_ctx = hash_joiner.full_join_match_context(left, stream, mr);
@@ -301,7 +302,7 @@ std::unique_ptr<cudf::table> full_join(
     [](cudf::table_view const& left,
        cudf::table_view const& right,
        cudf::null_equality compare_nulls,
-       rmm::cuda_stream_view stream,
+       cuda::stream_ref stream,
        rmm::device_async_resource_ref mr) {
       return cudf::full_join(left, right, compare_nulls, stream, mr);
     },
@@ -2420,7 +2421,7 @@ TEST_F(JoinTest, HashJoinInnerMatchContext)
   Table t0(std::move(cols0));
   Table t1(std::move(cols1));
 
-  auto const stream = cudf::get_default_stream();
+  cuda::stream_ref const stream = cudf::get_default_stream();
 
   // Test single column join with null_equality::EQUAL
   {
@@ -2431,7 +2432,7 @@ TEST_F(JoinTest, HashJoinInnerMatchContext)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.synchronize();
+    stream.wait();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const inner_join_size = hash_join.inner_join_size(t0.select({0}));
@@ -2480,7 +2481,7 @@ TEST_F(JoinTest, HashJoinLeftMatchContext)
   Table t0(std::move(cols0));
   Table t1(std::move(cols1));
 
-  auto const stream = cudf::get_default_stream();
+  cuda::stream_ref const stream = cudf::get_default_stream();
 
   // Test single column join
   {
@@ -2491,7 +2492,7 @@ TEST_F(JoinTest, HashJoinLeftMatchContext)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.synchronize();
+    stream.wait();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const left_join_size = hash_join.left_join_size(t0.select({0}));
@@ -2532,7 +2533,7 @@ TEST_F(JoinTest, HashJoinFullMatchContext)
   Table t0(std::move(cols0));
   Table t1(std::move(cols1));
 
-  auto const stream = cudf::get_default_stream();
+  cuda::stream_ref const stream = cudf::get_default_stream();
 
   // Test single column join
   {
@@ -2564,7 +2565,7 @@ TEST_F(JoinTest, HashJoinMatchContextEmptyRight)
   Table t0(std::move(cols0));
   Table t1(std::move(cols1));
 
-  auto const stream = cudf::get_default_stream();
+  cuda::stream_ref const stream = cudf::get_default_stream();
   cudf::hash_join const hash_join(t1, cudf::null_equality::EQUAL);
 
   // Test inner join match context
@@ -2604,7 +2605,7 @@ TEST_F(JoinTest, HashJoinMatchContextDuplicatesAndEdgeCases)
   Table t0(std::move(cols0));
   Table t1(std::move(cols1));
 
-  auto const stream = cudf::get_default_stream();
+  cuda::stream_ref const stream = cudf::get_default_stream();
 
   // Test inner join with multiple matches per row
   {
@@ -2615,7 +2616,7 @@ TEST_F(JoinTest, HashJoinMatchContextDuplicatesAndEdgeCases)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.synchronize();
+    stream.wait();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const inner_join_size = hash_join.inner_join_size(t0.select({0}));
@@ -3109,7 +3110,7 @@ struct JoinParameterizedTestLists : public JoinTestLists,
     auto join_lambda = [](cudf::table_view const& left,
                           cudf::table_view const& right,
                           cudf::null_equality compare_nulls,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr) -> JoinResult {
       cudf::sort_merge_join obj(right, cudf::sorted::NO, compare_nulls, stream);
       return obj.inner_join(left, stream, mr);
@@ -3129,7 +3130,7 @@ struct JoinParameterizedTestLists : public JoinTestLists,
     auto join_lambda = [](cudf::table_view const& left,
                           cudf::table_view const& right,
                           cudf::null_equality compare_nulls,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr) -> JoinResult {
       cudf::sort_merge_join obj(right, cudf::sorted::NO, compare_nulls, stream);
       return obj.left_join(left, stream, mr);

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -56,7 +56,7 @@ void expect_match_counts_equal(rmm::device_uvector<cudf::size_type> const& actua
                                cuda::stream_ref stream)
 {
   auto const host_actual_counts = cudf::detail::make_host_vector_async(actual_counts, stream);
-  stream.wait();
+  stream.sync();
 
   ASSERT_EQ(host_actual_counts.size(), expected_counts.size());
   EXPECT_TRUE(
@@ -2432,7 +2432,7 @@ TEST_F(JoinTest, HashJoinInnerMatchContext)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.wait();
+    stream.sync();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const inner_join_size = hash_join.inner_join_size(t0.select({0}));
@@ -2492,7 +2492,7 @@ TEST_F(JoinTest, HashJoinLeftMatchContext)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.wait();
+    stream.sync();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const left_join_size = hash_join.left_join_size(t0.select({0}));
@@ -2616,7 +2616,7 @@ TEST_F(JoinTest, HashJoinMatchContextDuplicatesAndEdgeCases)
 
     auto const host_match_counts =
       cudf::detail::make_host_vector_async(*match_context._match_counts, stream);
-    stream.wait();
+    stream.sync();
     cudf::size_type const total_matches =
       std::accumulate(host_match_counts.begin(), host_match_counts.end(), cudf::size_type{0});
     auto const inner_join_size = hash_join.inner_join_size(t0.select({0}));

--- a/cpp/tests/join/semi_anti_join_tests.cpp
+++ b/cpp/tests/join/semi_anti_join_tests.cpp
@@ -21,10 +21,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <limits>

--- a/cpp/tests/reductions/host_udf_example_tests.cu
+++ b/cpp/tests/reductions/host_udf_example_tests.cu
@@ -39,7 +39,7 @@ struct host_udf_reduction_example : cudf::reduce_host_udf {
     cudf::column_view const& input,
     cudf::data_type output_dtype,
     std::optional<std::reference_wrapper<cudf::scalar const>> init,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const override
   {
     return cudf::double_type_dispatcher(
@@ -78,7 +78,7 @@ struct host_udf_reduction_example : cudf::reduce_host_udf {
       cudf::column_view const& input,
       cudf::data_type output_dtype,
       std::optional<std::reference_wrapper<cudf::scalar const>> init,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const
     {
       CUDF_EXPECTS(output_dtype == cudf::data_type{cudf::type_to_id<OutputType>()},
@@ -174,7 +174,7 @@ struct host_udf_segmented_reduction_example : cudf::segmented_reduce_host_udf {
     cudf::data_type output_dtype,
     cudf::null_policy null_handling,
     std::optional<std::reference_wrapper<cudf::scalar const>> init,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const override
   {
     return cudf::double_type_dispatcher(input.type(),
@@ -223,7 +223,7 @@ struct host_udf_segmented_reduction_example : cudf::segmented_reduce_host_udf {
       cudf::data_type output_dtype,
       cudf::null_policy null_handling,
       std::optional<std::reference_wrapper<cudf::scalar const>> init,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const
     {
       CUDF_EXPECTS(output_dtype == cudf::data_type{cudf::type_to_id<OutputType>()},

--- a/cpp/tests/reductions/host_udf_example_tests.cu
+++ b/cpp/tests/reductions/host_udf_example_tests.cu
@@ -39,7 +39,7 @@ struct host_udf_reduction_example : cudf::reduce_host_udf {
     cudf::column_view const& input,
     cudf::data_type output_dtype,
     std::optional<std::reference_wrapper<cudf::scalar const>> init,
-    cuda::stream_ref stream,
+    rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const override
   {
     return cudf::double_type_dispatcher(
@@ -78,7 +78,7 @@ struct host_udf_reduction_example : cudf::reduce_host_udf {
       cudf::column_view const& input,
       cudf::data_type output_dtype,
       std::optional<std::reference_wrapper<cudf::scalar const>> init,
-      cuda::stream_ref stream,
+      rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const
     {
       CUDF_EXPECTS(output_dtype == cudf::data_type{cudf::type_to_id<OutputType>()},
@@ -174,7 +174,7 @@ struct host_udf_segmented_reduction_example : cudf::segmented_reduce_host_udf {
     cudf::data_type output_dtype,
     cudf::null_policy null_handling,
     std::optional<std::reference_wrapper<cudf::scalar const>> init,
-    cuda::stream_ref stream,
+    rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const override
   {
     return cudf::double_type_dispatcher(input.type(),
@@ -223,7 +223,7 @@ struct host_udf_segmented_reduction_example : cudf::segmented_reduce_host_udf {
       cudf::data_type output_dtype,
       cudf::null_policy null_handling,
       std::optional<std::reference_wrapper<cudf::scalar const>> init,
-      cuda::stream_ref stream,
+      rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const
     {
       CUDF_EXPECTS(output_dtype == cudf::data_type{cudf::type_to_id<OutputType>()},


### PR DESCRIPTION
## Description
This third batch migrates compute libcudf joins, groupby, reductions, rolling, sorting, transform, unary, and binary operation APIs and tests from `rmm::cuda_stream_view` to `cuda::stream_ref`. It also includes small follow-up documentation fixes from the previous stream-ref batch.

Contributes to https://github.com/NVIDIA/cudf/issues/23636

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.