### PR TITLE
Change deprecated calls of stream_ref.wait() to stream_ref.sync()

### DIFF
--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1367,7 +1367,7 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
 
   partition_buf_size_and_dst_buf_info->copy_to_host();
 
-  stream.wait();
+  stream.sync();
 
   return partition_buf_size_and_dst_buf_info;
 }

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -556,7 +556,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Scatter input rows into partitioned output
   auto output = detail::scatter(input, scatter_map, input, stream, mr);
 
-  stream.wait();  // Pinned async D2H copy must finish before returning host vec
+  stream.sync();  // Pinned async D2H copy must finish before returning host vec
 
   // Convert pinned host_vector to std::vector for the return type
   auto partition_offsets = std::vector<size_type>(pinned_offsets.begin(), pinned_offsets.end());
@@ -724,7 +724,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
         input, gather_map.begin(), output_cols, detail::gather_bitmask_op::DONT_CHECK, stream, mr);
     }
 
-    stream.wait();  // Async D2H copy must finish before returning host vec
+    stream.sync();  // Async D2H copy must finish before returning host vec
     return std::pair{std::make_unique<table>(std::move(output_cols), num_rows),
                      std::move(partition_offsets)};
   } else {
@@ -742,7 +742,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
     // Use the resulting scatter map to materialize the output
     auto output = detail::scatter(input, row_partition_numbers, input, stream, mr);
 
-    stream.wait();  // Async D2H copy must finish before returning host vec
+    stream.sync();  // Async D2H copy must finish before returning host vec
     return std::pair{std::move(output), std::move(partition_offsets)};
   }
 }

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -60,7 +60,7 @@ struct TypedColumnTest : public cudf::test::BaseFixture {
     CUDF_CUDA_TRY(
       cudaMemcpyAsync(typed_mask, h_mask.data(), mask.size(), cudaMemcpyDefault, stream.get()));
     _null_count = cudf::null_count(static_cast<cudf::bitmask_type*>(mask.data()), 0, _num_elements);
-    stream.wait();
+    stream.sync();
   }
 
   [[nodiscard]] cudf::size_type num_elements() const { return _num_elements; }


### PR DESCRIPTION
## Description
Fixes deprecation warnings for calls to `cuda::stream_ref::wait()` by changing them to the recommended `cuda::stream_ref::sync()` instead.

Example deprecation warning:
```
/cudf/cpp/src/partitioning/partitioning.cu:745:12: warning: 'void cuda::__4::stream_ref::wait() const' is deprecated: Use sync() instead. [-Wdeprecated-declarations]
  745 |     stream.wait();  // Async D2H copy must finish before returning host vec
      |     ~~~~~~~^~
/cudf/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/__stream/stream_ref.h:179:95: note: declared here
  179 |   CCCL_DEPRECATED_BECAUSE("Use sync() instead.") _CCCL_HOST_API void wait() const

```

Introduced by https://github.com/NVIDIA/cudf/pull/23645

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
