### PR TITLE
Replace `<cuda/stream_ref>` includes with `<cuda/stream>`

### DIFF
--- a/cpp/include/cudf/aggregation/host_udf.hpp
+++ b/cpp/include/cudf/aggregation/host_udf.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <functional>
 #include <optional>

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -13,7 +13,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <type_traits>

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -19,7 +19,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <functional>

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -14,7 +14,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/include/cudf/column/column_stream.hpp
+++ b/cpp/include/cudf/column/column_stream.hpp
@@ -6,7 +6,7 @@
 
 #include <cudf/column/column.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/concatenate.hpp
+++ b/cpp/include/cudf/concatenate.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <span>

--- a/cpp/include/cudf/detail/algorithms/copy_if.cuh
+++ b/cpp/include/cudf/detail/algorithms/copy_if.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf/detail/algorithms/copy_if.cuh
+++ b/cpp/include/cudf/detail/algorithms/copy_if.cuh
@@ -15,7 +15,7 @@
 #include <cub/device/device_select.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 
 namespace cudf::detail {

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -15,7 +15,7 @@
 #include <cub/device/device_reduce.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/include/cudf/detail/binaryop.hpp
+++ b/cpp/include/cudf/detail/binaryop.hpp
@@ -8,7 +8,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 //! Inner interfaces and implementations

--- a/cpp/include/cudf/detail/concatenate.hpp
+++ b/cpp/include/cudf/detail/concatenate.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 #include <vector>

--- a/cpp/include/cudf/detail/concatenate_masks.hpp
+++ b/cpp/include/cudf/detail/concatenate_masks.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 

--- a/cpp/include/cudf/detail/contiguous_split.hpp
+++ b/cpp/include/cudf/detail/contiguous_split.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 #include <optional>

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -13,7 +13,7 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <initializer_list>
 #include <span>

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -19,7 +19,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cub/cub.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime.h>
 
 #include <memory>

--- a/cpp/include/cudf/detail/fill.hpp
+++ b/cpp/include/cudf/detail/fill.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/gather.hpp
+++ b/cpp/include/cudf/detail/gather.hpp
@@ -13,7 +13,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/groupby.hpp
+++ b/cpp/include/cudf/detail/groupby.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/include/cudf/detail/groupby/sort_helper.hpp
+++ b/cpp/include/cudf/detail/groupby/sort_helper.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby::detail::sort {

--- a/cpp/include/cudf/detail/is_element_valid.hpp
+++ b/cpp/include/cudf/detail/is_element_valid.hpp
@@ -8,7 +8,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace CUDF_EXPORT cudf {
 namespace detail {

--- a/cpp/include/cudf/detail/join/distinct_hash_join.cuh
+++ b/cpp/include/cudf/detail/join/distinct_hash_join.cuh
@@ -12,7 +12,7 @@
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/include/cudf/detail/join/filtered_join.cuh
+++ b/cpp/include/cudf/detail/join/filtered_join.cuh
@@ -20,7 +20,7 @@
 #include <cuco/pair.cuh>
 #include <cuco/probing_scheme.cuh>
 #include <cuco/types.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/cpp/include/cudf/detail/join/hash_join.hpp
+++ b/cpp/include/cudf/detail/join/hash_join.hpp
@@ -16,7 +16,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/include/cudf/detail/join/join.hpp
+++ b/cpp/include/cudf/detail/join/join.hpp
@@ -13,7 +13,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -24,7 +24,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 #include <vector>

--- a/cpp/include/cudf/detail/repeat.hpp
+++ b/cpp/include/cudf/detail/repeat.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/rolling.hpp
+++ b/cpp/include/cudf/detail/rolling.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -8,7 +8,7 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -26,7 +26,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scatter.h>

--- a/cpp/include/cudf/detail/scatter.hpp
+++ b/cpp/include/cudf/detail/scatter.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/search.hpp
+++ b/cpp/include/cudf/detail/search.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/detail/sorting.hpp
+++ b/cpp/include/cudf/detail/sorting.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <vector>

--- a/cpp/include/cudf/detail/transform.hpp
+++ b/cpp/include/cudf/detail/transform.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/dictionary/detail/concatenate.hpp
+++ b/cpp/include/cudf/dictionary/detail/concatenate.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary::detail {

--- a/cpp/include/cudf/dictionary/detail/encode.hpp
+++ b/cpp/include/cudf/dictionary/detail/encode.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary::detail {

--- a/cpp/include/cudf/dictionary/detail/merge.hpp
+++ b/cpp/include/cudf/dictionary/detail/merge.hpp
@@ -9,7 +9,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary::detail {

--- a/cpp/include/cudf/dictionary/detail/replace.hpp
+++ b/cpp/include/cudf/dictionary/detail/replace.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary::detail {

--- a/cpp/include/cudf/dictionary/detail/search.hpp
+++ b/cpp/include/cudf/dictionary/detail/search.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary {

--- a/cpp/include/cudf/dictionary/detail/update_keys.hpp
+++ b/cpp/include/cudf/dictionary/detail/update_keys.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 

--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -14,7 +14,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <span>

--- a/cpp/include/cudf/join/conditional_join.hpp
+++ b/cpp/include/cudf/join/conditional_join.hpp
@@ -15,7 +15,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 #include <utility>

--- a/cpp/include/cudf/join/direct_join.hpp
+++ b/cpp/include/cudf/join/direct_join.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/include/cudf/join/distinct_hash_join.hpp
+++ b/cpp/include/cudf/join/distinct_hash_join.hpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <utility>
 

--- a/cpp/include/cudf/join/filtered_join.hpp
+++ b/cpp/include/cudf/join/filtered_join.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -16,7 +16,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 #include <utility>

--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -15,7 +15,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/cpp/include/cudf/join/key_remapping.hpp
+++ b/cpp/include/cudf/join/key_remapping.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/join/mark_join.hpp
+++ b/cpp/include/cudf/join/mark_join.hpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/join/mixed_join.hpp
+++ b/cpp/include/cudf/join/mixed_join.hpp
@@ -15,7 +15,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 #include <utility>

--- a/cpp/include/cudf/join/sort_merge_join.hpp
+++ b/cpp/include/cudf/join/sort_merge_join.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -12,7 +12,7 @@
 
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 #include <vector>

--- a/cpp/include/cudf/partitioning.hpp
+++ b/cpp/include/cudf/partitioning.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <vector>

--- a/cpp/include/cudf/reduction/approx_distinct_count.hpp
+++ b/cpp/include/cudf/reduction/approx_distinct_count.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/std/span>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/cpp/include/cudf/reduction/detail/approx_distinct_count.cuh
+++ b/cpp/include/cudf/reduction/detail/approx_distinct_count.cuh
@@ -16,7 +16,7 @@
 #include <cuco/hyperloglog_ref.cuh>
 #include <cuda/functional>
 #include <cuda/std/span>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/cpp/include/cudf/reduction/detail/distinct_count.hpp
+++ b/cpp/include/cudf/reduction/detail/distinct_count.hpp
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/reduction/detail/histogram.hpp
+++ b/cpp/include/cudf/reduction/detail/histogram.hpp
@@ -13,7 +13,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/include/cudf/reduction/detail/reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/reduction.cuh
@@ -18,7 +18,7 @@
 
 #include <cub/device/device_reduce.cuh>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 
 #include <optional>

--- a/cpp/include/cudf/reduction/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction_functions.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 

--- a/cpp/include/cudf/reduction/detail/segmented_reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/segmented_reduction.cuh
@@ -15,7 +15,7 @@
 
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/include/cudf/reduction/detail/segmented_reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/segmented_reduction_functions.hpp
@@ -10,7 +10,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 

--- a/cpp/include/cudf/reduction/detail/unique_count.hpp
+++ b/cpp/include/cudf/reduction/detail/unique_count.hpp
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/include/cudf/reduction/distinct_count.hpp
+++ b/cpp/include/cudf/reduction/distinct_count.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/include/cudf/reduction/unique_count.hpp
+++ b/cpp/include/cudf/reduction/unique_count.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -15,7 +15,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 #include <string_view>

--- a/cpp/include/cudf/scalar/scalar_factories.hpp
+++ b/cpp/include/cudf/scalar/scalar_factories.hpp
@@ -10,7 +10,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 

--- a/cpp/include/cudf_test/column_utilities.hpp
+++ b/cpp/include/cudf_test/column_utilities.hpp
@@ -18,7 +18,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/cpp/include/cudf_test/memory_resource_utilities.hpp
+++ b/cpp/include/cudf_test/memory_resource_utilities.hpp
@@ -16,7 +16,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <concepts>
 #include <cstddef>

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -13,7 +13,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <iostream>

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -40,7 +40,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cuda/std/optional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <string>
 

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -21,7 +21,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/binaryop/compiled/binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/binary_ops.cuh
@@ -18,7 +18,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace binops {

--- a/cpp/src/binaryop/compiled/binary_ops.hpp
+++ b/cpp/src/binaryop/compiled/binary_ops.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 

--- a/cpp/src/binaryop/compiled/struct_binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/struct_binary_ops.cuh
@@ -18,7 +18,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf::binops::compiled::detail {

--- a/cpp/src/bitmask/is_element_valid.cpp
+++ b/cpp/src/bitmask/is_element_valid.cpp
@@ -8,7 +8,7 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -25,7 +25,7 @@
 #include <cub/cub.cuh>
 #include <cuda/atomic>
 #include <cuda/numeric>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/execution_policy.h>
 #include <thrust/tabulate.h>
 

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -26,7 +26,7 @@
 
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <algorithm>

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -9,7 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <functional>
 #include <numeric>

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -31,7 +31,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -27,7 +27,7 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -12,7 +12,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -23,7 +23,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <stdexcept>
 

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -25,7 +25,7 @@
 #include <cudf/utilities/type_checks.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <stdexcept>

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -15,7 +15,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <stdexcept>

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -19,7 +19,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <stdexcept>
 

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -7,7 +7,7 @@
 #include <cudf/detail/contiguous_split.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/copying/reverse.cu
+++ b/cpp/src/copying/reverse.cu
@@ -16,7 +16,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 
 namespace cudf {

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -17,7 +17,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/random.h>
 #include <thrust/random/uniform_int_distribution.h>
 #include <thrust/shuffle.h>

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -28,7 +28,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scatter.h>

--- a/cpp/src/copying/segmented_shift.cu
+++ b/cpp/src/copying/segmented_shift.cu
@@ -13,7 +13,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/transform_iterator.h>

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -22,7 +22,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -13,7 +13,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <algorithm>

--- a/cpp/src/copying/split.cpp
+++ b/cpp/src/copying/split.cpp
@@ -7,7 +7,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <stdexcept>

--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -14,7 +14,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary {

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -29,7 +29,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/gather.h>

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -15,7 +15,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/dictionary/dictionary_factories.cu
+++ b/cpp/src/dictionary/dictionary_factories.cu
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace {

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -31,7 +31,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>

--- a/cpp/src/dictionary/match_keys.cu
+++ b/cpp/src/dictionary/match_keys.cu
@@ -25,7 +25,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <iterator>

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -23,7 +23,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/fill.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -17,7 +17,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary {

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -16,7 +16,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cub/device/device_find.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace dictionary {

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -26,7 +26,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -14,7 +14,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -26,7 +26,7 @@
 #include <cudf/utilities/type_checks.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -24,7 +24,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -19,7 +19,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/sequence.h>
 #include <thrust/tabulate.h>
 

--- a/cpp/src/groupby/common/m2_var_std.cu
+++ b/cpp/src/groupby/common/m2_var_std.cu
@@ -17,7 +17,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cmath>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/tabulate.h>
 
 namespace cudf::groupby::detail {

--- a/cpp/src/groupby/common/m2_var_std.hpp
+++ b/cpp/src/groupby/common/m2_var_std.hpp
@@ -10,7 +10,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::groupby::detail {
 

--- a/cpp/src/groupby/common/utils.hpp
+++ b/cpp/src/groupby/common/utils.hpp
@@ -15,7 +15,7 @@
 
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <span>

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -28,7 +28,7 @@
 #include <cudf/utilities/type_checks.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/groupby/hash/compute_groupby.cu
+++ b/cpp/src/groupby/hash/compute_groupby.cu
@@ -23,7 +23,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/tabulate.h>
 
 namespace cudf::groupby::detail::hash {

--- a/cpp/src/groupby/hash/compute_groupby.hpp
+++ b/cpp/src/groupby/hash/compute_groupby.hpp
@@ -12,7 +12,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/hash/compute_mapping_indices.cuh
+++ b/cpp/src/groupby/hash/compute_mapping_indices.cuh
@@ -15,7 +15,7 @@
 #include <cooperative_groups.h>
 #include <cuco/static_set_ref.cuh>
 #include <cuda/std/atomic>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 

--- a/cpp/src/groupby/hash/compute_mapping_indices.hpp
+++ b/cpp/src/groupby/hash/compute_mapping_indices.hpp
@@ -7,7 +7,7 @@
 #include <cudf/types.hpp>
 
 #include <cuda/std/atomic>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::groupby::detail::hash {
 

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
@@ -26,7 +26,7 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
@@ -8,7 +8,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
@@ -23,7 +23,7 @@
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 
 namespace cudf::groupby::detail::hash {

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::groupby::detail::hash {
 

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -21,7 +21,7 @@
 #include <cudf/utilities/traits.cuh>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
+++ b/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
@@ -17,7 +17,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::groupby::detail::hash {
 

--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -22,7 +22,7 @@
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/groupby/hash/output_utils.hpp
+++ b/cpp/src/groupby/hash/output_utils.hpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -26,7 +26,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <unordered_map>

--- a/cpp/src/groupby/sort/functors.hpp
+++ b/cpp/src/groupby/sort/functors.hpp
@@ -11,7 +11,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/group_argmax.cu
+++ b/cpp/src/groupby/sort/group_argmax.cu
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/gather.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_argmin.cu
+++ b/cpp/src/groupby/sort/group_argmin.cu
@@ -11,7 +11,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/gather.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_bitwise.cu
+++ b/cpp/src/groupby/sort/group_bitwise.cu
@@ -18,7 +18,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::groupby::detail {
 

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -13,7 +13,7 @@
 #include <cudf/utilities/span.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -20,7 +20,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 #include <type_traits>

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -15,7 +15,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/adjacent_difference.h>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/cpp/src/groupby/sort/group_count_scan.cu
+++ b/cpp/src/groupby/sort/group_count_scan.cu
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -19,7 +19,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_max.cu
+++ b/cpp/src/groupby/sort/group_max.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_max_scan.cu
+++ b/cpp/src/groupby/sort/group_max_scan.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -10,7 +10,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/gather.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -12,7 +12,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_min.cu
+++ b/cpp/src/groupby/sort/group_min.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_min_scan.cu
+++ b/cpp/src/groupby/sort/group_min_scan.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -19,7 +19,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/scatter.h>

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -14,7 +14,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_product.cu
+++ b/cpp/src/groupby/sort/group_product.cu
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_product_scan.cu
+++ b/cpp/src/groupby/sort/group_product_scan.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -21,7 +21,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -22,7 +22,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/group_scan.hpp
+++ b/cpp/src/groupby/sort/group_scan.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -27,7 +27,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -23,7 +23,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/reduce.h>
 
 namespace cudf {

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -21,7 +21,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>

--- a/cpp/src/groupby/sort/group_sum.cu
+++ b/cpp/src/groupby/sort/group_sum.cu
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_sum_overflow.cu
+++ b/cpp/src/groupby/sort/group_sum_overflow.cu
@@ -23,7 +23,7 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/reduce.h>
 
 #include <memory>

--- a/cpp/src/groupby/sort/group_sum_scan.cu
+++ b/cpp/src/groupby/sort/group_sum_scan.cu
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/src/groupby/sort/group_topk.cu
+++ b/cpp/src/groupby/sort/group_topk.cu
@@ -9,7 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/scan.cpp
+++ b/cpp/src/groupby/sort/scan.cpp
@@ -24,7 +24,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -23,7 +23,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 #include <algorithm>

--- a/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
+++ b/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
@@ -20,7 +20,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf::groupby::detail::sort {

--- a/cpp/src/groupby/streaming_groupby.cpp
+++ b/cpp/src/groupby/streaming_groupby.cpp
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/src/groupby/streaming_groupby/aggregate.cu
+++ b/cpp/src/groupby/streaming_groupby/aggregate.cu
@@ -13,7 +13,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 
 #include <limits>

--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -24,7 +24,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/std/functional>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <vector>

--- a/cpp/src/groupby/streaming_groupby/impl.cu
+++ b/cpp/src/groupby/streaming_groupby/impl.cu
@@ -25,7 +25,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <memory>

--- a/cpp/src/groupby/streaming_groupby/insert.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert.cuh
@@ -17,7 +17,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/groupby/streaming_groupby/insert_first.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert_first.cuh
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 
 #include <cstddef>

--- a/cpp/src/groupby/streaming_groupby/insert_subsequent.cuh
+++ b/cpp/src/groupby/streaming_groupby/insert_subsequent.cuh
@@ -12,7 +12,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 
 namespace cudf::groupby {

--- a/cpp/src/groupby/streaming_groupby/merge.cu
+++ b/cpp/src/groupby/streaming_groupby/merge.cu
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/for_each.h>
 
 #include <string>

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -20,7 +20,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 #include <vector>

--- a/cpp/src/join/conditional_join.hpp
+++ b/cpp/src/join/conditional_join.hpp
@@ -11,7 +11,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -17,7 +17,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 #include <limits>

--- a/cpp/src/join/direct_join.cu
+++ b/cpp/src/join/direct_join.cu
@@ -18,7 +18,7 @@
 #include <cub/device/device_transform.cuh>
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -28,7 +28,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/fill.h>
 #include <thrust/sequence.h>
 

--- a/cpp/src/join/filter_join_indices/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices.cu
@@ -38,7 +38,7 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
@@ -30,7 +30,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <jit/cache.hpp>
 #include <jit/helpers.hpp>

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit_kernel.cuh
@@ -12,7 +12,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <string>

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel.cuh
@@ -15,7 +15,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/join/filter_join_indices/filter_join_indices_kernel.hpp
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_kernel.hpp
@@ -10,7 +10,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
@@ -17,7 +17,7 @@
 #include <cudf/utilities/span.hpp>
 
 #include <cuda/atomic>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.hpp
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.hpp
@@ -13,7 +13,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/cpp/src/join/filtered_join/filtered_join.cu
+++ b/cpp/src/join/filtered_join/filtered_join.cu
@@ -25,7 +25,7 @@
 
 #include <cuco/extent.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 #include <thrust/sequence.h>
 

--- a/cpp/src/join/filtered_join/filtered_join_common.cuh
+++ b/cpp/src/join/filtered_join/filtered_join_common.cuh
@@ -17,7 +17,7 @@
 
 #include <cuco/detail/open_addressing/kernels.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstdint>

--- a/cpp/src/join/filtered_join/filtered_join_flat.cu
+++ b/cpp/src/join/filtered_join/filtered_join_flat.cu
@@ -18,7 +18,7 @@
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/filtered_join/filtered_join_nested.cu
+++ b/cpp/src/join/filtered_join/filtered_join_nested.cu
@@ -16,7 +16,7 @@
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/join/filtered_join/filtered_join_nested_query.cu
+++ b/cpp/src/join/filtered_join/filtered_join_nested_query.cu
@@ -19,7 +19,7 @@
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/filtered_join/filtered_join_primitive.cu
+++ b/cpp/src/join/filtered_join/filtered_join_primitive.cu
@@ -18,7 +18,7 @@
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/hash_join/common.cuh
+++ b/cpp/src/join/hash_join/common.cuh
@@ -14,7 +14,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/hash_join/finalize_partitioned_full_join.cpp
+++ b/cpp/src/join/hash_join/finalize_partitioned_full_join.cpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 

--- a/cpp/src/join/hash_join/partitioned_count_kernels.cuh
+++ b/cpp/src/join/hash_join/partitioned_count_kernels.cuh
@@ -11,7 +11,7 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/join/hash_join/partitioned_count_kernels.hpp
+++ b/cpp/src/join/hash_join/partitioned_count_kernels.hpp
@@ -7,7 +7,7 @@
 
 #include "kernels_common.cuh"
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/join/hash_join/partitioned_retrieve_kernels.cuh
+++ b/cpp/src/join/hash_join/partitioned_retrieve_kernels.cuh
@@ -20,7 +20,7 @@
 #include <cuda/atomic>
 #include <cuda/std/bit>
 #include <cuda/std/cstdint>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/reduce.h>
 
 namespace cudf::detail {

--- a/cpp/src/join/hash_join/partitioned_retrieve_kernels.hpp
+++ b/cpp/src/join/hash_join/partitioned_retrieve_kernels.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -18,7 +18,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/join_common_utils.cuh
+++ b/cpp/src/join/join_common_utils.cuh
@@ -12,7 +12,7 @@
 #include <cudf/detail/row_operator/hashing.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/join_common_utils.hpp
+++ b/cpp/src/join/join_common_utils.hpp
@@ -12,7 +12,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -22,7 +22,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/uninitialized_fill.h>

--- a/cpp/src/join/key_remapping.cu
+++ b/cpp/src/join/key_remapping.cu
@@ -32,7 +32,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/atomic>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/reduce.h>

--- a/cpp/src/join/mark_join.cuh
+++ b/cpp/src/join/mark_join.cuh
@@ -25,7 +25,7 @@
 #include <cuco/probing_scheme.cuh>
 #include <cuco/types.cuh>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -20,7 +20,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/uninitialized_fill.h>
 
 #include <memory>

--- a/cpp/src/join/mixed_join_kernels_semi.cuh
+++ b/cpp/src/join/mixed_join_kernels_semi.cuh
@@ -13,7 +13,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -27,7 +27,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/fill.h>
 
 #include <optional>

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -39,7 +39,7 @@
 #include <cuda/std/execution>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
 #include <thrust/sort.h>

--- a/cpp/src/join/sort_merge_join.hpp
+++ b/cpp/src/join/sort_merge_join.hpp
@@ -16,7 +16,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -28,7 +28,7 @@
 #include <cuda/atomic>
 #include <cuda/devices>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -24,7 +24,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -33,7 +33,7 @@
 #include <cuda/iterator>
 #include <cuda/std/span>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/reductions/approx_distinct_count.cu
+++ b/cpp/src/reductions/approx_distinct_count.cu
@@ -20,7 +20,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cmath>
 #include <utility>

--- a/cpp/src/reductions/count.cpp
+++ b/cpp/src/reductions/count.cpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/distinct_count.cu
+++ b/cpp/src/reductions/distinct_count.cu
@@ -23,7 +23,7 @@
 
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/logical.h>

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -17,7 +17,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/extrema.h>
 
 namespace cudf::reduction::simple::detail {

--- a/cpp/src/reductions/max.cu
+++ b/cpp/src/reductions/max.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/mean.cu
+++ b/cpp/src/reductions/mean.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -21,7 +21,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform_reduce.h>
 
 #include <type_traits>

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -14,7 +14,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>

--- a/cpp/src/reductions/nunique.cpp
+++ b/cpp/src/reductions/nunique.cpp
@@ -9,7 +9,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/product.cu
+++ b/cpp/src/reductions/product.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/quantile.cu
+++ b/cpp/src/reductions/quantile.cu
@@ -11,7 +11,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -19,7 +19,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <utility>
 

--- a/cpp/src/reductions/scan/ewm.cu
+++ b/cpp/src/reductions/scan/ewm.cu
@@ -17,7 +17,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 #include <thrust/transform_scan.h>
 

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/reductions/scan/scan.cuh
+++ b/cpp/src/reductions/scan/scan.cuh
@@ -12,7 +12,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <utility>
 

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -17,7 +17,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/scan.h>
 
 namespace cudf {

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -23,7 +23,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/find.h>
 #include <thrust/scan.h>
 

--- a/cpp/src/reductions/segmented/counts.hpp
+++ b/cpp/src/reductions/segmented/counts.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 class column_device_view;

--- a/cpp/src/reductions/segmented/mean.cu
+++ b/cpp/src/reductions/segmented/mean.cu
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/segmented/nunique.cu
+++ b/cpp/src/reductions/segmented/nunique.cu
@@ -16,7 +16,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/reductions/segmented/reductions.cpp
+++ b/cpp/src/reductions/segmented/reductions.cpp
@@ -13,7 +13,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/segmented/simple.cuh
+++ b/cpp/src/reductions/segmented/simple.cuh
@@ -24,7 +24,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 

--- a/cpp/src/reductions/segmented/std.cu
+++ b/cpp/src/reductions/segmented/std.cu
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/segmented/sum_of_squares.cu
+++ b/cpp/src/reductions/segmented/sum_of_squares.cu
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/segmented/update_validity.hpp
+++ b/cpp/src/reductions/segmented/update_validity.hpp
@@ -11,7 +11,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <optional>
 

--- a/cpp/src/reductions/segmented/var.cu
+++ b/cpp/src/reductions/segmented/var.cu
@@ -8,7 +8,7 @@
 #include <cudf/reduction/detail/segmented_reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -21,7 +21,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 

--- a/cpp/src/reductions/std.cu
+++ b/cpp/src/reductions/std.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/sum.cu
+++ b/cpp/src/reductions/sum.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/sum_of_squares.cu
+++ b/cpp/src/reductions/sum_of_squares.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/reductions/sum_overflow.cu
+++ b/cpp/src/reductions/sum_overflow.cu
@@ -22,7 +22,7 @@
 
 #include <cuda/iterator>
 #include <cuda/numeric>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform_reduce.h>
 
 namespace cudf::reduction::detail {

--- a/cpp/src/reductions/unique_count.cu
+++ b/cpp/src/reductions/unique_count.cu
@@ -13,7 +13,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>

--- a/cpp/src/reductions/unique_count_column.cu
+++ b/cpp/src/reductions/unique_count_column.cu
@@ -18,7 +18,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cmath>
 #include <cuda/std/type_traits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 

--- a/cpp/src/reductions/var.cu
+++ b/cpp/src/reductions/var.cu
@@ -9,7 +9,7 @@
 #include <cudf/reduction/detail/reduction_functions.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace reduction {

--- a/cpp/src/rolling/detail/optimized_unbounded_window.hpp
+++ b/cpp/src/rolling/detail/optimized_unbounded_window.hpp
@@ -11,7 +11,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 

--- a/cpp/src/rolling/detail/range_rolling.hpp
+++ b/cpp/src/rolling/detail/range_rolling.hpp
@@ -15,7 +15,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/rolling/detail/range_utils.cuh
+++ b/cpp/src/rolling/detail/range_utils.cuh
@@ -33,7 +33,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 

--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -35,7 +35,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/rolling/detail/rolling.hpp
+++ b/cpp/src/rolling/detail/rolling.hpp
@@ -14,7 +14,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -16,7 +16,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/extrema.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>

--- a/cpp/src/rolling/detail/rolling_operators.cuh
+++ b/cpp/src/rolling/detail/rolling_operators.cuh
@@ -26,7 +26,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>

--- a/cpp/src/rolling/detail/rolling_udf.cuh
+++ b/cpp/src/rolling/detail/rolling_udf.cuh
@@ -19,7 +19,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -23,7 +23,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <concepts>
 #include <span>

--- a/cpp/src/rolling/range_rolling.cu
+++ b/cpp/src/rolling/range_rolling.cu
@@ -24,7 +24,7 @@
 
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/functional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/src/rolling/range_rolling_bounded_closed.cu
+++ b/cpp/src/rolling/range_rolling_bounded_closed.cu
@@ -16,7 +16,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/rolling/range_rolling_bounded_open.cu
+++ b/cpp/src/rolling/range_rolling_bounded_open.cu
@@ -16,7 +16,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/rolling/range_rolling_current_row.cu
+++ b/cpp/src/rolling/range_rolling_current_row.cu
@@ -16,7 +16,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/rolling/range_rolling_multi_column.cu
+++ b/cpp/src/rolling/range_rolling_multi_column.cu
@@ -28,7 +28,7 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 
 #include <memory>

--- a/cpp/src/rolling/range_rolling_unbounded.cu
+++ b/cpp/src/rolling/range_rolling_unbounded.cu
@@ -16,7 +16,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/src/rolling/rolling.cpp
+++ b/cpp/src/rolling/rolling.cpp
@@ -15,7 +15,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <string>
 

--- a/cpp/src/scalar/scalar_factories.cpp
+++ b/cpp/src/scalar/scalar_factories.cpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace {

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -12,7 +12,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -22,7 +22,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/search/contains_table.cu
+++ b/cpp/src/search/contains_table.cu
@@ -16,7 +16,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuco/static_set.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 

--- a/cpp/src/search/contains_table_impl.cuh
+++ b/cpp/src/search/contains_table_impl.cuh
@@ -21,7 +21,7 @@
 #include <cuco/static_set.cuh>
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -16,7 +16,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 
 namespace cudf {

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -16,7 +16,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/count.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -25,7 +25,7 @@
 #include <cuda/std/algorithm>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -17,7 +17,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cub/device/device_segmented_sort.cuh>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -20,7 +20,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/std/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/remove.h>

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -15,7 +15,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/sort.hpp
+++ b/cpp/src/sort/sort.hpp
@@ -8,7 +8,7 @@
 #include <cudf/sorting.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -21,7 +21,7 @@
 
 #include <cub/device/device_merge_sort.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/gather.h>
 
 namespace cudf {

--- a/cpp/src/sort/sort_radix.cu
+++ b/cpp/src/sort/sort_radix.cu
@@ -12,7 +12,7 @@
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/sort/sort_radix.hpp
+++ b/cpp/src/sort/sort_radix.hpp
@@ -7,7 +7,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/sorted_order_radix.cu
+++ b/cpp/src/sort/sorted_order_radix.cu
@@ -16,7 +16,7 @@
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -15,7 +15,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/top_k.cu
+++ b/cpp/src/sort/top_k.cu
@@ -25,7 +25,6 @@
 #include <cuda/iterator>
 #include <cuda/std/execution>
 #include <cuda/stream>
-#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/top_k.cu
+++ b/cpp/src/sort/top_k.cu
@@ -25,7 +25,7 @@
 #include <cuda/iterator>
 #include <cuda/std/execution>
 #include <cuda/stream>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -16,7 +16,7 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -22,7 +22,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 

--- a/cpp/src/transform/compute_column_kernel.cuh
+++ b/cpp/src/transform/compute_column_kernel.cuh
@@ -14,7 +14,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 /**

--- a/cpp/src/transform/compute_column_kernel.hpp
+++ b/cpp/src/transform/compute_column_kernel.hpp
@@ -11,7 +11,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::detail {
 /**

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -21,7 +21,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <numeric>

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -15,7 +15,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -18,7 +18,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -20,7 +20,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 #include <algorithm>

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -25,7 +25,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/optional>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/tabulate.h>
 
 namespace cudf {

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -21,7 +21,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cudf_fragments.hpp>
 #include <jit/cache.hpp>

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -24,7 +24,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -19,7 +19,7 @@
 #include <cuda/std/bit>
 #include <cuda/std/cmath>
 #include <cuda/std/type_traits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/unary/nan_ops.cu
+++ b/cpp/src/unary/nan_ops.cu
@@ -15,7 +15,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/unary/true_if.cuh
+++ b/cpp/src/unary/true_if.cuh
@@ -10,7 +10,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -14,7 +14,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 namespace cudf {

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -21,7 +21,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <stdexcept>
 

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -13,7 +13,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 #include <thrust/transform.h>
 

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -18,7 +18,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 
 struct ColumnDeviceViewTest : public cudf::test::BaseFixture {};

--- a/cpp/tests/copying/shift_tests.cpp
+++ b/cpp/tests/copying/shift_tests.cpp
@@ -14,7 +14,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <limits>
 #include <memory>

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -29,7 +29,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <future>

--- a/cpp/tests/join/semi_anti_join_tests.cpp
+++ b/cpp/tests/join/semi_anti_join_tests.cpp
@@ -24,7 +24,7 @@
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <limits>

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -30,7 +30,7 @@
 #include <cuda/std/cmath>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/copy.h>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>

--- a/cpp/tests/utilities/memory_resource_utilities.cpp
+++ b/cpp/tests/utilities/memory_resource_utilities.cpp
@@ -9,7 +9,7 @@
 
 #include <rmm/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <utility>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

CCCL deprecated the `<cuda/stream_ref>` header; `cuda::stream_ref` is now provided by `<cuda/stream>`. This PR switches every `#include <cuda/stream_ref>` to `#include <cuda/stream>` so libcudf builds against newer CCCL.

Rebased onto main after #23649 (`Use cuda::stream_ref for compute APIs`) so the additional includes from that migration are covered as well. Also drops a duplicate `<cuda/stream>` include in `top_k.cu` that the rename introduced.

The `cuda::stream_ref` type is unchanged. This matches the same change in RMM (rapidsai/rmm#2513) and was observed in rapids-cmake CI: https://github.com/rapidsai/rapids-cmake/actions/runs/31745925779/job/94600794610?pr=1073

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C0B3FFMK6PK/p1786722557219489?thread_ts=1786722557.219489&cid=C0B3FFMK6PK)

<div><a href="https://cursor.com/agents/bc-39928b49-4a7e-5399-9795-10b769fc79bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39928b49-4a7e-5399-9795-10b769fc79bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

