### PR TITLE
Fix racecheck in parquet page_string_decode kernels

### DIFF
--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -462,6 +462,7 @@ __device__ cuda::std::pair<size_t, size_t> totalDeltaByteArraySize(uint8_t const
         }
       }
 
+      warp.sync();
       if (lane_id == 0) { db->setup_next_mini_block(true); }
       warp.sync();
     }
@@ -782,6 +783,7 @@ CUDF_KERNEL void __launch_bounds__(delta_length_block_size)
         }
       }
 
+      warp.sync();
       if (t == 0) { string_lengths.setup_next_mini_block(true); }
       warp.sync();
     }


### PR DESCRIPTION
## Description
Fixes a racecheck found in the weekend compute-sanitizer run in the parquet `page_strings_decode.cu` kernels `totalDeltaByteArraySize` and `compute_delta_length_page_string_sizes_kernel`. Adds a `warp.sync()` before the call to the `setup_next_mini_block()` utility which runs only on warp lane=0.

https://github.com/NVIDIA/cudf/actions/runs/31878600604/job/94998078592#step:5:2953

```
[ RUN      ] ParquetStringsTest.ReadLargeStrings
========= Warning: Race reported between Read access at cudf::io::parquet::detail::<unnamed>::totalDeltaByteArraySize(const unsigned char *, const unsigned char *, int, int)+0x9910 in page_string_decode.cu:455
=========     and Write access at cudf::io::parquet::detail::delta_binary_decoder::setup_next_mini_block(bool)+0x9be0 in delta_binary.cuh:208 [1250960 hazards]
========= 
[       OK ] ParquetStringsTest.ReadLargeStrings (77563 ms)
```

The change was introduced in PR #23314 which rewrote the delta decode loops in `cpp/src/io/parquet/delta_binary.cuh` and `cpp/src/io/parquet/page_string_decode.cu` to decode one warp-size pass at a time. That refactor introduced the pass-by-pass loop pattern in `totalDeltaByteArraySize` and the `DELTA_LENGTH_BYTE_ARRAY` string-size kernel where all lanes read `current_value_idx` without a synchronizing `warp.sync()` before lane 0 advances it in `setup_next_mini_block`, causing the race. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
