### PR TITLE
Allow large strings input within the parquet make_column utility

### DIFF
--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -12,6 +12,7 @@
 
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
+#include <cudf/detail/unary.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
@@ -227,12 +228,23 @@ std::unique_ptr<column> make_column(column_buffer_base<string_policy>& buffer,
             }
           }
 
-          return make_lists_column(
-            num_rows,
-            std::move(col_content.children[strings_column_view::offsets_column_index]),
-            std::move(uint8_col),
-            null_count,
-            std::move(*col_content.null_mask));
+          // A strings column may carry 64-bit offsets, but a LIST column's offsets child is
+          // always 32-bit. The `char_size` check above bounds the chars by `size_type`, so
+          // every offset value is representable as an int32_t and this cannot lose data.
+          auto offsets_col =
+            std::move(col_content.children[strings_column_view::offsets_column_index]);
+          if (offsets_col->type().id() != type_id::INT32) {
+            offsets_col = cudf::detail::cast(offsets_col->view(),
+                                             data_type{type_id::INT32},
+                                             stream,
+                                             cudf::get_current_device_resource_ref());
+          }
+
+          return make_lists_column(num_rows,
+                                   std::move(offsets_col),
+                                   std::move(uint8_col),
+                                   null_count,
+                                   std::move(*col_content.null_mask));
         }
       }
 

--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -234,10 +234,8 @@ std::unique_ptr<column> make_column(column_buffer_base<string_policy>& buffer,
           auto offsets_col =
             std::move(col_content.children[strings_column_view::offsets_column_index]);
           if (offsets_col->type().id() != type_id::INT32) {
-            offsets_col = cudf::detail::cast(offsets_col->view(),
-                                             data_type{type_id::INT32},
-                                             stream,
-                                             cudf::get_current_device_resource_ref());
+            offsets_col = cudf::detail::cast(
+              offsets_col->view(), data_type{type_id::INT32}, stream, buffer._mr);
           }
 
           return make_lists_column(num_rows,

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -1684,6 +1684,43 @@ TEST_F(ParquetReaderTest, NestedByteArray)
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
 }
 
+// A binary column is read back as a strings column and then converted to `list<uint8>`.
+// A strings column may carry 64-bit offsets, but a LIST column's offsets child is always
+// 32-bit, so that conversion must not hand an INT64 offsets column to `make_lists_column`.
+TEST_F(ParquetReaderTest, BinaryAsListLargeStringsThreshold)
+{
+  // Force the intermediate strings column onto the 64-bit offsets path. The data below is far
+  // under `INT32_MAX` bytes, so every offset value stays representable as an int32_t.
+  tmp_env_var const large_strings_threshold{"LIBCUDF_LARGE_STRINGS_THRESHOLD", "8"};
+
+  cudf::test::lists_column_wrapper<uint8_t> list_int_col{
+    {'M', 'o', 'n', 'd', 'a', 'y'},
+    {'W', 'e', 'd', 'n', 'e', 's', 'd', 'a', 'y'},
+    {'F', 'r', 'i', 'd', 'a', 'y'},
+    {'F', 'u', 'n', 'd', 'a', 'y'}};
+
+  auto const expected = table_view{{list_int_col}};
+  cudf::io::table_input_metadata output_metadata(expected);
+  output_metadata.column_metadata[0].set_name("col_binary").set_output_as_binary(true);
+
+  auto filepath = temp_env->get_temp_filepath("BinaryAsListLargeStringsThreshold.parquet");
+  cudf::io::parquet_writer_options out_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, expected)
+      .metadata(std::move(output_metadata));
+  cudf::io::write_parquet(out_opts);
+
+  cudf::io::parquet_reader_options in_opts =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+      .set_column_schema({cudf::io::reader_column_schema().set_convert_binary_to_strings(false)});
+  auto result = cudf::io::read_parquet(in_opts);
+
+  auto const col = result.tbl->view().column(0);
+  ASSERT_EQ(col.type().id(), cudf::type_id::LIST);
+  EXPECT_EQ(col.child(cudf::lists_column_view::offsets_column_index).type().id(),
+            cudf::type_id::INT32);
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
 TEST_F(ParquetReaderTest, StructByteArray)
 {
   constexpr auto num_rows = 100;


### PR DESCRIPTION
## Description
Fixes a silent-corruption bug in the Parquet reader's `binary→list<uint8>` conversion.

When a binary column is read with `set_convert_binary_to_strings(false)`, the reader first materializes it as a strings column, then hands that column's offsets child directly to `cudf::make_lists_column`:

Any strings column may carry 64-bit offsets. A LIST column's offsets child is always 32-bit — per the Arrow columnar format (a 64-bit variant would be a distinct LargeList type which libcudf does not currently support). So this produces a malformed LIST column with an INT64 offsets child.

Because there is a  guard already bounding the chars by `max(int32)`, every offset value is representable as an `int32_t`, so the fix just converts the offsets.

A new gtest is added taking advantage of the `LIBCUDF_LARGE_STRINGS_THRESHOLD` env var to produce a strings column with INT64 offsets.

This fix was discovered as part of the work on https://github.com/NVIDIA/cudf/pull/23607

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
