### PR TITLE
Use cuda::stream_ref in Python stream shims

### DIFF
--- a/python/cudf/udf_cpp/strings/src/strings/udf/udf_apis.cu
+++ b/python/cudf/udf_cpp/strings/src/strings/udf/udf_apis.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -48,7 +48,7 @@ struct managed_udf_string_to_string_view_transform_fn {
  * @param stream CUDA stream used for allocating/copying device memory and launching kernels
  */
 std::unique_ptr<rmm::device_buffer> to_string_view_array(cudf::column_view const input,
-                                                         rmm::cuda_stream_view stream)
+                                                         cuda::stream_ref stream)
 {
   return std::make_unique<rmm::device_buffer>(
     std::move(cudf::strings::create_string_vector_from_column(
@@ -62,7 +62,7 @@ std::unique_ptr<rmm::device_buffer> to_string_view_array(cudf::column_view const
  * @param stream CUDA stream used for allocating/copying device memory and launching kernels
  */
 std::unique_ptr<cudf::column> column_from_managed_udf_string_array(
-  managed_udf_string* managed_strings, cudf::size_type size, rmm::cuda_stream_view stream)
+  managed_udf_string* managed_strings, cudf::size_type size, cuda::stream_ref stream)
 {
   // create string_views of the udf_strings
   auto indices = rmm::device_uvector<cudf::string_view>(size, stream);
@@ -73,7 +73,7 @@ std::unique_ptr<cudf::column> column_from_managed_udf_string_array(
                     managed_udf_string_to_string_view_transform_fn{});
 
   auto result = cudf::make_strings_column(indices, cudf::string_view(nullptr, 0), stream);
-  stream.synchronize();
+  stream.sync();
   return result;
 }
 

--- a/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
@@ -12,7 +12,7 @@ cdef extern from * nogil:
     """
     #include <cudf/detail/utilities/stream_pool.hpp>
     #include <cudf/utilities/span.hpp>
-    #include <cuda/stream_ref>
+    #include <cuda/stream>
     #include <vector>
 
     namespace {

--- a/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
@@ -12,7 +12,7 @@ cdef extern from * nogil:
     """
     #include <cudf/detail/utilities/stream_pool.hpp>
     #include <cudf/utilities/span.hpp>
-    #include <cuda/stream>
+    #include <cuda/stream_ref>
     #include <vector>
 
     namespace {

--- a/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
@@ -12,9 +12,7 @@ cdef extern from * nogil:
     """
     #include <cudf/detail/utilities/stream_pool.hpp>
     #include <cudf/utilities/span.hpp>
-
     #include <cuda/stream_ref>
-
     #include <vector>
 
     namespace {


### PR DESCRIPTION
## Description
This split batch migrates the remaining Python/Cython stream shims from `rmm::cuda_stream_view` to `cuda::stream_ref`.

The pylibcudf stream pool shim follows the core stream pool signature change in https://github.com/NVIDIA/cudf/pull/23691, so this draft should be merged after that PR.

Contributes to https://github.com/NVIDIA/cudf/issues/23636

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
