### PR TITLE
Use cuda::stream_ref in benchmarks and examples

### DIFF
--- a/cpp/benchmarks/ast/transform.cpp
+++ b/cpp/benchmarks/ast/transform.cpp
@@ -18,7 +18,6 @@
 #include <cudf/utilities/error.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/ast/transform.cpp
+++ b/cpp/benchmarks/ast/transform.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,9 +17,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/binaryop/binaryop.cpp
+++ b/cpp/benchmarks/binaryop/binaryop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -104,7 +104,7 @@ static void BM_string_compare_binaryop_transform(nvbench::state& state)
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream{launch.get_stream().get_stream()};
+    cuda::stream_ref stream{launch.get_stream().get_stream()};
     std::unique_ptr<cudf::column> reduction =
       cudf::binary_operation(table.get_column(0), table.get_column(1), cmp_op, bool_type, stream);
     std::for_each(
@@ -115,7 +115,7 @@ static void BM_string_compare_binaryop_transform(nvbench::state& state)
           table.get_column(idx * 2), table.get_column(idx * 2 + 1), cmp_op, bool_type, stream);
         std::unique_ptr<cudf::column> reduced =
           cudf::binary_operation(*comparison, *reduction, reduce_op, bool_type, stream);
-        stream.synchronize();
+        stream.sync();
         reduction = std::move(reduced);
       });
   });

--- a/cpp/benchmarks/binaryop/polynomials.cpp
+++ b/cpp/benchmarks/binaryop/polynomials.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -58,7 +58,7 @@ static void BM_binaryop_polynomials(nvbench::state& state)
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // computes polynomials: (((ax + b)x + c)x + d)x + e... = ax**4 + bx**3 + cx**2 + dx + e....
     cudf::benchmark::scoped_range range{"benchmark_iteration"};
-    rmm::cuda_stream_view stream{launch.get_stream().get_stream()};
+    cuda::stream_ref stream{launch.get_stream().get_stream()};
     std::vector<std::unique_ptr<cudf::column>> intermediates;
 
     auto result = cudf::make_column_from_scalar(constants[0], num_rows, stream);

--- a/cpp/benchmarks/bitmask/bitmask_and.cpp
+++ b/cpp/benchmarks/bitmask/bitmask_and.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,7 +70,7 @@ void BM_segmented_bitmask_and(nvbench::state& state)
 
   auto [segments, masks, mask_pointers, mask_begin_bits, data_bytes] = setup_masks(state);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_element_count(data_bytes, "input size");
   state.template add_global_memory_reads<nvbench::int8_t>(data_bytes);
   auto const mem_stats_logger = cudf::memory_stats_logger();
@@ -91,7 +91,7 @@ void BM_multi_segment_bitmask_and(nvbench::state& state)
 
   auto [segments, masks, mask_pointers, mask_begin_bits, data_bytes] = setup_masks(state);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_element_count(data_bytes, "input size");
   state.template add_global_memory_reads<nvbench::int8_t>(data_bytes);
   auto const mem_stats_logger = cudf::memory_stats_logger();

--- a/cpp/benchmarks/bitmask/set_null_mask.cpp
+++ b/cpp/benchmarks/bitmask/set_null_mask.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -61,7 +61,7 @@ void BM_setnullmask(nvbench::state& state)
   rmm::device_buffer mask = cudf::create_null_mask(mask_size, cudf::mask_state::UNINITIALIZED);
   auto begin = 0, end = mask_size;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
@@ -90,7 +90,7 @@ void BM_setnullmask_unsafe_bulk(nvbench::state& state)
   auto [begin_bits, end_bits, valids, masks, masks_ptr] =
     generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
@@ -118,7 +118,7 @@ void BM_setnullmask_safe_bulk(nvbench::state& state)
   auto [begin_bits, end_bits, valids, masks, masks_ptr] =
     generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
@@ -146,7 +146,7 @@ void BM_setnullmask_loop(nvbench::state& state)
   auto [begin_bits, end_bits, valids, masks, masks_ptr] =
     generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,

--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -24,8 +24,9 @@
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <array>
 #include <string>
@@ -142,7 +143,7 @@ constexpr std::array vocab_containers{
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_orders_independent(double scale_factor,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -266,7 +267,7 @@ std::unique_ptr<cudf::table> generate_orders_independent(double scale_factor,
  */
 std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& orders_independent,
                                                        double scale_factor,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -437,7 +438,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_orders_dependent(cudf::table_view const& lineitem_partial,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -530,7 +531,7 @@ std::unique_ptr<cudf::table> generate_orders_dependent(cudf::table_view const& l
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_partsupp(double scale_factor,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -578,7 +579,7 @@ std::unique_ptr<cudf::table> generate_partsupp(double scale_factor,
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_part(double scale_factor,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -704,7 +705,7 @@ std::unique_ptr<cudf::table> generate_part(double scale_factor,
  */
 std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>>
 generate_orders_lineitem_part(double scale_factor,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -771,7 +772,7 @@ generate_orders_lineitem_part(double scale_factor,
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_supplier(double scale_factor,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -832,7 +833,7 @@ std::unique_ptr<cudf::table> generate_supplier(double scale_factor,
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_customer(double scale_factor,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -899,7 +900,7 @@ std::unique_ptr<cudf::table> generate_customer(double scale_factor,
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
-std::unique_ptr<cudf::table> generate_nation(rmm::cuda_stream_view stream,
+std::unique_ptr<cudf::table> generate_nation(cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -939,7 +940,7 @@ std::unique_ptr<cudf::table> generate_nation(rmm::cuda_stream_view stream,
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
-std::unique_ptr<cudf::table> generate_region(rmm::cuda_stream_view stream,
+std::unique_ptr<cudf::table> generate_region(cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();

--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -26,7 +26,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <string>

--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.hpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@ namespace datagen {
 std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>>
 generate_orders_lineitem_part(
   double scale_factor,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -34,7 +34,7 @@ generate_orders_lineitem_part(
  */
 std::unique_ptr<cudf::table> generate_partsupp(
   double scale_factor,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -46,7 +46,7 @@ std::unique_ptr<cudf::table> generate_partsupp(
  */
 std::unique_ptr<cudf::table> generate_supplier(
   double scale_factor,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -58,7 +58,7 @@ std::unique_ptr<cudf::table> generate_supplier(
  */
 std::unique_ptr<cudf::table> generate_customer(
   double scale_factor,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -68,7 +68,7 @@ std::unique_ptr<cudf::table> generate_customer(
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_nation(
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -78,7 +78,7 @@ std::unique_ptr<cudf::table> generate_nation(
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<cudf::table> generate_region(
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace datagen

--- a/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.cu
+++ b/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.cu
@@ -79,7 +79,7 @@ struct random_number_generator {
 std::unique_ptr<cudf::column> generate_random_string_column(cudf::size_type lower,
                                                             cudf::size_type upper,
                                                             cudf::size_type num_rows,
-                                                            rmm::cuda_stream_view stream,
+                                                            cuda::stream_ref stream,
                                                             rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -107,7 +107,7 @@ template <typename T>
 std::unique_ptr<cudf::column> generate_random_numeric_column(T lower,
                                                              T upper,
                                                              cudf::size_type num_rows,
-                                                             rmm::cuda_stream_view stream,
+                                                             cuda::stream_ref stream,
                                                              rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -127,33 +127,33 @@ template std::unique_ptr<cudf::column> generate_random_numeric_column<int8_t>(
   int8_t lower,
   int8_t upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template std::unique_ptr<cudf::column> generate_random_numeric_column<int16_t>(
   int16_t lower,
   int16_t upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template std::unique_ptr<cudf::column> generate_random_numeric_column<cudf::size_type>(
   cudf::size_type lower,
   cudf::size_type upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template std::unique_ptr<cudf::column> generate_random_numeric_column<double>(
   double lower,
   double upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> generate_primary_key_column(cudf::scalar const& start,
                                                           cudf::size_type num_rows,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -162,7 +162,7 @@ std::unique_ptr<cudf::column> generate_primary_key_column(cudf::scalar const& st
 
 std::unique_ptr<cudf::column> generate_repeat_string_column(std::string const& value,
                                                             cudf::size_type num_rows,
-                                                            rmm::cuda_stream_view stream,
+                                                            cuda::stream_ref stream,
                                                             rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -173,7 +173,7 @@ std::unique_ptr<cudf::column> generate_repeat_string_column(std::string const& v
 std::unique_ptr<cudf::column> generate_random_string_column_from_set(
   cudf::host_span<char const* const> set,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -199,7 +199,7 @@ template <typename T>
 std::unique_ptr<cudf::column> generate_repeat_sequence_column(T seq_length,
                                                               bool zero_indexed,
                                                               cudf::size_type num_rows,
-                                                              rmm::cuda_stream_view stream,
+                                                              cuda::stream_ref stream,
                                                               rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -224,14 +224,14 @@ template std::unique_ptr<cudf::column> generate_repeat_sequence_column<int8_t>(
   int8_t seq_length,
   bool zero_indexed,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 template std::unique_ptr<cudf::column> generate_repeat_sequence_column<cudf::size_type>(
   cudf::size_type seq_length,
   bool zero_indexed,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 }  // namespace cudf::datagen

--- a/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.hpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.hpp
@@ -26,7 +26,7 @@ std::unique_ptr<cudf::column> generate_random_string_column(
   cudf::size_type lower,
   cudf::size_type upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -51,7 +51,7 @@ std::unique_ptr<cudf::column> generate_random_numeric_column(
   T lower,
   T upper,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -71,7 +71,7 @@ std::unique_ptr<cudf::column> generate_random_numeric_column(
 std::unique_ptr<cudf::column> generate_primary_key_column(
   cudf::scalar const& start,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -91,7 +91,7 @@ std::unique_ptr<cudf::column> generate_primary_key_column(
 std::unique_ptr<cudf::column> generate_repeat_string_column(
   std::string const& value,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -111,7 +111,7 @@ std::unique_ptr<cudf::column> generate_repeat_string_column(
 std::unique_ptr<cudf::column> generate_random_string_column_from_set(
   cudf::host_span<char const* const> set,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -135,7 +135,7 @@ std::unique_ptr<cudf::column> generate_repeat_sequence_column(
   T seq_length,
   bool zero_indexed,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace cudf::datagen

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,8 +24,9 @@
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <vector>
 
@@ -41,7 +42,7 @@ namespace cudf::datagen {
  */
 std::unique_ptr<cudf::column> add_calendrical_days(cudf::column_view const& timestamp_days,
                                                    cudf::column_view const& days,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -67,7 +68,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
                                                cudf::table_view const& right_input,
                                                std::vector<cudf::size_type> const& left_on,
                                                std::vector<cudf::size_type> const& right_on,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -102,9 +103,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_p_retailprice(
-  cudf::column_view const& p_partkey,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  cudf::column_view const& p_partkey, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
   // Expression: (90000 + ((p_partkey/10) modulo 20001) + 100 * (p_partkey modulo 1000)) / 100
@@ -147,7 +146,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_l_suppkey(cudf::column_view const& l_partkey,
                                                                 cudf::size_type scale_factor,
                                                                 cudf::size_type num_rows,
-                                                                rmm::cuda_stream_view stream,
+                                                                cuda::stream_ref stream,
                                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -219,7 +218,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
   cudf::column_view const& ps_partkey,
   cudf::size_type scale_factor,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -286,7 +285,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 [[nodiscard]] cudf::size_type calculate_l_cardinality(cudf::column_view const& o_rep_freqs,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -309,7 +308,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_charge(cudf::column_view const& extendedprice,
                                                              cudf::column_view const& tax,
                                                              cudf::column_view const& discount,
-                                                             rmm::cuda_stream_view stream,
+                                                             cuda::stream_ref stream,
                                                              rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
@@ -340,7 +339,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 [[nodiscard]] std::unique_ptr<cudf::column> generate_address_column(
-  cudf::size_type num_rows, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::size_type num_rows, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
   return generate_random_string_column(10, 40, num_rows, stream, mr);
@@ -354,7 +353,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 [[nodiscard]] std::unique_ptr<cudf::column> generate_phone_column(cudf::size_type num_rows,
-                                                                  rmm::cuda_stream_view stream,
+                                                                  cuda::stream_ref stream,
                                                                   rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
@@ -26,7 +26,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <vector>
 

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.hpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ namespace cudf::datagen {
 std::unique_ptr<cudf::column> add_calendrical_days(
   cudf::column_view const& timestamp_days,
   cudf::column_view const& days,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -46,7 +46,7 @@ std::unique_ptr<cudf::table> perform_left_join(
   cudf::table_view const& right_input,
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -58,7 +58,7 @@ std::unique_ptr<cudf::table> perform_left_join(
  */
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_p_retailprice(
   cudf::column_view const& p_partkey,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -74,7 +74,7 @@ std::unique_ptr<cudf::table> perform_left_join(
   cudf::column_view const& l_partkey,
   cudf::size_type scale_factor,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -90,7 +90,7 @@ std::unique_ptr<cudf::table> perform_left_join(
   cudf::column_view const& ps_partkey,
   cudf::size_type scale_factor,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 /**
  * @brief Calculate the cardinality of the `lineitem` table
@@ -101,7 +101,7 @@ std::unique_ptr<cudf::table> perform_left_join(
  */
 [[nodiscard]] cudf::size_type calculate_l_cardinality(
   cudf::column_view const& o_rep_freqs,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 /**
  * @brief Calculate the charge column for the `lineitem` table
@@ -116,7 +116,7 @@ std::unique_ptr<cudf::table> perform_left_join(
   cudf::column_view const& extendedprice,
   cudf::column_view const& tax,
   cudf::column_view const& discount,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -128,7 +128,7 @@ std::unique_ptr<cudf::table> perform_left_join(
  */
 [[nodiscard]] std::unique_ptr<cudf::column> generate_address_column(
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -140,7 +140,7 @@ std::unique_ptr<cudf::table> perform_left_join(
  */
 [[nodiscard]] std::unique_ptr<cudf::column> generate_phone_column(
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace cudf::datagen

--- a/cpp/benchmarks/contiguous_split/contiguous_split.cpp
+++ b/cpp/benchmarks/contiguous_split/contiguous_split.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,7 +29,7 @@ void chunked_pack(cudf::table_view const& src_table, std::vector<cudf::size_type
   while (chunked_pack->has_next()) {
     (void)chunked_pack->next(user_buffer);
   }
-  stream.synchronize();
+  stream.sync();
 }
 
 template <typename ContigSplitImpl>
@@ -58,7 +58,7 @@ void contiguous_split_common(nvbench::state& state,
   auto const src_table = cudf::table(std::move(src_cols));
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(src_table.alloc_size());
   state.add_global_memory_writes<int8_t>(src_table.alloc_size());
 

--- a/cpp/benchmarks/copying/concatenate.cpp
+++ b/cpp/benchmarks/copying/concatenate.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <benchmarks/common/generate_input.hpp>
@@ -26,7 +26,7 @@ static void bench_concatenate(nvbench::state& state)
   auto column_views  = std::vector<cudf::column_view>(input_columns.begin(), input_columns.end());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int64_t>(num_rows * num_cols);
   state.add_global_memory_writes<int64_t>(num_rows * num_cols);
 
@@ -62,7 +62,7 @@ static void bench_concatenate_strings(nvbench::state& state)
   auto column_views = std::vector<cudf::column_view>(num_cols, input);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const sv = cudf::strings_column_view(input);
   state.add_global_memory_reads<int8_t>(sv.chars_size(stream) * num_cols);
   state.add_global_memory_writes<int64_t>(sv.chars_size(stream) * num_cols);

--- a/cpp/benchmarks/copying/copy_if_else.cpp
+++ b/cpp/benchmarks/copying/copy_if_else.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -38,7 +38,7 @@ static void bench_copy_if_else(nvbench::state& state, nvbench::type_list<DataTyp
   auto const null_bytes    = nulls ? 2 * cudf::bitmask_allocation_size_bytes(num_rows) : 0;
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(bytes_read);
   state.add_global_memory_writes<int8_t>(bytes_written + null_bytes);
 

--- a/cpp/benchmarks/copying/gather.cpp
+++ b/cpp/benchmarks/copying/gather.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ static void bench_gather(nvbench::state& state)
                                             row_count{num_rows});
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(source_table->alloc_size());
   state.add_global_memory_writes<int8_t>(source_table->alloc_size());
 

--- a/cpp/benchmarks/copying/scatter.cpp
+++ b/cpp/benchmarks/copying/scatter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -41,7 +41,7 @@ static void bench_scatter(nvbench::state& state)
                                             row_count{num_rows});
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(source_table->alloc_size());
   state.add_global_memory_writes<int8_t>(target_table->alloc_size());
 

--- a/cpp/benchmarks/copying/shift.cpp
+++ b/cpp/benchmarks/copying/shift.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <benchmarks/common/generate_input.hpp>
@@ -35,7 +35,7 @@ static void bench_shift(nvbench::state& state)
   auto const null_bytes    = use_validity ? 2 * cudf::bitmask_allocation_size_bytes(num_rows) : 0;
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(bytes_read);
   state.add_global_memory_writes<int8_t>(bytes_written + null_bytes);
 

--- a/cpp/benchmarks/decimal/convert_floating.cpp
+++ b/cpp/benchmarks/decimal/convert_floating.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -117,7 +117,7 @@ void bench_cast_decimal(nvbench::state& state, nvbench::type_list<InputType, Out
 
   // Stream
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   // Run benchmark
   auto const mem_stats_logger = cudf::memory_stats_logger();

--- a/cpp/benchmarks/dictionary/concatenate.cpp
+++ b/cpp/benchmarks/dictionary/concatenate.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -44,7 +44,7 @@ static void bench_dictionary_concatenate(nvbench::state& state)
   auto result = cudf::concatenate(views, stream);
   state.add_global_memory_writes<uint8_t>(result->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) { cudf::concatenate(views, stream); });

--- a/cpp/benchmarks/dictionary/concatenate.cpp
+++ b/cpp/benchmarks/dictionary/concatenate.cpp
@@ -14,7 +14,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 #include <vector>

--- a/cpp/benchmarks/dictionary/concatenate.cpp
+++ b/cpp/benchmarks/dictionary/concatenate.cpp
@@ -14,7 +14,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/dictionary/encode.cpp
+++ b/cpp/benchmarks/dictionary/encode.cpp
@@ -11,7 +11,6 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/dictionary/encode.cpp
+++ b/cpp/benchmarks/dictionary/encode.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -30,7 +30,7 @@ static void bench_dictionary_encode(nvbench::state& state)
     cudf::dictionary::encode(input->view(), cudf::data_type{cudf::type_id::INT32}, stream);
   state.add_global_memory_writes<uint8_t>(result->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {

--- a/cpp/benchmarks/dictionary/encode.cpp
+++ b/cpp/benchmarks/dictionary/encode.cpp
@@ -11,7 +11,6 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 static void bench_dictionary_encode(nvbench::state& state)

--- a/cpp/benchmarks/dictionary/match_keys.cpp
+++ b/cpp/benchmarks/dictionary/match_keys.cpp
@@ -13,7 +13,7 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -46,7 +46,7 @@ static void bench_dictionary_match_keys(nvbench::state& state)
 
   state.add_global_memory_reads<uint8_t>(input_bytes);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {

--- a/cpp/benchmarks/dictionary/match_keys.cpp
+++ b/cpp/benchmarks/dictionary/match_keys.cpp
@@ -13,7 +13,6 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 #include <vector>

--- a/cpp/benchmarks/dictionary/match_keys.cpp
+++ b/cpp/benchmarks/dictionary/match_keys.cpp
@@ -13,7 +13,6 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/dictionary/set_keys.cpp
+++ b/cpp/benchmarks/dictionary/set_keys.cpp
@@ -13,7 +13,6 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 static void bench_dictionary_set_keys(nvbench::state& state)

--- a/cpp/benchmarks/dictionary/set_keys.cpp
+++ b/cpp/benchmarks/dictionary/set_keys.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -37,7 +37,7 @@ static void bench_dictionary_set_keys(nvbench::state& state)
   auto result = cudf::dictionary::set_keys(dict_view, new_keys->view(), stream);
   state.add_global_memory_writes<uint8_t>(result->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {

--- a/cpp/benchmarks/dictionary/set_keys.cpp
+++ b/cpp/benchmarks/dictionary/set_keys.cpp
@@ -13,7 +13,6 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/dictionary/sort.cpp
+++ b/cpp/benchmarks/dictionary/sort.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -35,7 +35,7 @@ static void bench_dictionary_sort(nvbench::state& state)
   auto result = cudf::sort(input_table, {}, {}, stream);
   state.add_global_memory_writes<uint8_t>(result->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/dictionary/sort.cpp
+++ b/cpp/benchmarks/dictionary/sort.cpp
@@ -13,7 +13,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/dictionary/sort.cpp
+++ b/cpp/benchmarks/dictionary/sort.cpp
@@ -13,7 +13,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 static void bench_dictionary_sort(nvbench::state& state)

--- a/cpp/benchmarks/filling/repeat.cpp
+++ b/cpp/benchmarks/filling/repeat.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -36,7 +36,7 @@ void nvbench_repeat(nvbench::state& state, nvbench::type_list<TypeParam>)
 
   state.add_global_memory_reads(input_table->alloc_size());
   state.add_global_memory_writes(output->alloc_size());
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/filter/minmax_filter.cpp
+++ b/cpp/benchmarks/filter/minmax_filter.cpp
@@ -15,7 +15,6 @@
 #include <cudf/utilities/error.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/filter/minmax_filter.cpp
+++ b/cpp/benchmarks/filter/minmax_filter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/groupby/group_complex_keys.cpp
+++ b/cpp/benchmarks/groupby/group_complex_keys.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -114,7 +114,7 @@ void run_benchmark_complex_keys(nvbench::state& state)
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   auto const stream           = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     cudf::groupby::groupby gb_obj(keys_table->view());

--- a/cpp/benchmarks/groupby/group_histogram.cpp
+++ b/cpp/benchmarks/groupby/group_histogram.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ void groupby_histogram_helper(nvbench::state& state,
     cudf::make_histogram_aggregation<cudf::groupby_aggregation>());
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto gb_obj       = cudf::groupby::groupby(cudf::table_view({keys->view()}));
     auto const result = gb_obj.aggregate(requests);

--- a/cpp/benchmarks/groupby/group_m2_var_std.cpp
+++ b/cpp/benchmarks/groupby/group_m2_var_std.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ void run_benchmark(nvbench::state& state,
   }
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     auto gb_obj                        = cudf::groupby::groupby(cudf::table_view({keys->view()}));
     [[maybe_unused]] auto const result = gb_obj.aggregate(requests);

--- a/cpp/benchmarks/groupby/group_max.cpp
+++ b/cpp/benchmarks/groupby/group_max.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ void groupby_max_helper(nvbench::state& state,
   }
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto gb_obj       = cudf::groupby::groupby(cudf::table_view({keys_view, keys_view, keys_view}));
     auto const result = gb_obj.aggregate(requests);
@@ -123,7 +123,7 @@ void bench_groupby_max_cardinality(nvbench::state& state, nvbench::type_list<Typ
   auto keys_view = keys->view();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   if (is_streaming) {
     std::vector<cudf::column_view> all_columns = {keys_view, keys_view, keys_view};

--- a/cpp/benchmarks/groupby/group_max_multithreaded.cpp
+++ b/cpp/benchmarks/groupby/group_max_multithreaded.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -71,7 +71,7 @@ void bench_groupby_max_multithreaded(nvbench::state& state, nvbench::type_list<T
       threads.detach_sequence(decltype(num_threads){0}, num_threads, perform_agg);
       threads.wait();
       cudf::detail::join_streams(streams, cudf::get_default_stream());
-      cudf::get_default_stream().synchronize();
+      cudf::get_default_stream().sync();
       timer.stop();
     });
 

--- a/cpp/benchmarks/groupby/group_no_requests.cpp
+++ b/cpp/benchmarks/groupby/group_no_requests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@ static void bench_groupby_no_requests(nvbench::state& state)
 
   state.add_global_memory_reads<nvbench::int8_t>(keys_table->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(*keys_table);
@@ -56,7 +56,7 @@ static void bench_groupby_pre_sorted_no_requests(nvbench::state& state)
   std::vector<cudf::groupby::aggregation_request> requests;
   state.add_global_memory_reads<nvbench::int8_t>(keys_table->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(*sorted_keys, cudf::null_policy::EXCLUDE, cudf::sorted::YES);

--- a/cpp/benchmarks/groupby/group_nth.cpp
+++ b/cpp/benchmarks/groupby/group_nth.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ static void bench_groupby_nth(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int8_t>(vals->alloc_size());
   std::size_t write_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(*sorted_keys, cudf::null_policy::EXCLUDE, cudf::sorted::YES);

--- a/cpp/benchmarks/groupby/group_nunique.cpp
+++ b/cpp/benchmarks/groupby/group_nunique.cpp
@@ -57,7 +57,7 @@ void bench_groupby_nunique(nvbench::state& state, nvbench::type_list<Type>)
   auto const requests = make_aggregation_request_vector(
     *vals, cudf::make_nunique_aggregation<cudf::groupby_aggregation>());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto gb_obj =

--- a/cpp/benchmarks/groupby/group_rank.cpp
+++ b/cpp/benchmarks/groupby/group_rank.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <benchmarks/common/generate_input.hpp>
@@ -43,7 +43,7 @@ static void nvbench_groupby_rank(nvbench::state& state,
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
     cudf::groupby::groupby gb_obj(
       keys, cudf::null_policy::EXCLUDE, is_sorted ? cudf::sorted::YES : cudf::sorted::NO);
     // groupby scan uses sort implementation

--- a/cpp/benchmarks/groupby/group_scan.cpp
+++ b/cpp/benchmarks/groupby/group_scan.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -28,7 +28,7 @@ static void bench_groupby_sum_scan(nvbench::state& state)
   requests[0].values = vals->view();
   requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(cudf::table_view({keys->view(), keys->view(), keys->view()}));
@@ -62,7 +62,7 @@ static void bench_groupby_pre_sorted_sum_scan(nvbench::state& state)
   requests[0].values = vals->view();
   requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(*sorted_keys, cudf::null_policy::EXCLUDE, cudf::sorted::YES);

--- a/cpp/benchmarks/groupby/group_shift.cpp
+++ b/cpp/benchmarks/groupby/group_shift.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ static void bench_groupby_shift(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int8_t>(keys_table->alloc_size());
   state.add_global_memory_writes<nvbench::int8_t>(vals_table->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(keys_table->view());

--- a/cpp/benchmarks/groupby/group_struct_keys.cpp
+++ b/cpp/benchmarks/groupby/group_struct_keys.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,7 +70,7 @@ void bench_groupby_struct_keys(nvbench::state& state)
   // Set up nvbench default stream
   auto const mem_stats_logger = cudf::memory_stats_logger();
   auto stream                 = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(keys_table.view());

--- a/cpp/benchmarks/groupby/group_struct_values.cpp
+++ b/cpp/benchmarks/groupby/group_struct_values.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -52,7 +52,7 @@ static void bench_groupby_min_struct(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int8_t>(values->alloc_size());
   state.add_global_memory_writes<nvbench::int8_t>(values->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { auto result = gb_obj.aggregate(requests); });
@@ -82,7 +82,7 @@ static void bench_groupby_min_struct_scan(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int8_t>(values->alloc_size());
   state.add_global_memory_writes<nvbench::int8_t>(values->alloc_size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto gb_obj = cudf::groupby::groupby(cudf::table_view({keys_view}));

--- a/cpp/benchmarks/groupby/group_sum.cpp
+++ b/cpp/benchmarks/groupby/group_sum.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ static void bench_groupby_basic_sum(nvbench::state& state, nvbench::type_list<Da
   state.add_global_memory_reads<nvbench::int8_t>(vals->alloc_size());
   std::size_t write_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(cudf::table_view({keys->view(), keys->view(), keys->view()}));
@@ -76,7 +76,7 @@ static void bench_groupby_pre_sorted_sum(nvbench::state& state, nvbench::type_li
   state.add_global_memory_reads<nvbench::int8_t>(vals->alloc_size());
   std::size_t write_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::groupby::groupby gb_obj(*sorted_keys, cudf::null_policy::EXCLUDE, cudf::sorted::YES);

--- a/cpp/benchmarks/hashing/hash.cpp
+++ b/cpp/benchmarks/hashing/hash.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -31,7 +31,7 @@ static void bench_hash(nvbench::state& state)
                         profile);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   state.add_global_memory_reads<nvbench::int8_t>(data->alloc_size());
   // memory written depends on used hash

--- a/cpp/benchmarks/hashing/partition.cpp
+++ b/cpp/benchmarks/hashing/partition.cpp
@@ -151,7 +151,7 @@ void run_hash_partition(nvbench::state& state,
                         cudf::size_type num_partitions)
 {
   auto const stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const input_view  = input.view();
   auto const key_begin   = cuda::counting_iterator<cudf::size_type>{0};

--- a/cpp/benchmarks/interop/interop.cpp
+++ b/cpp/benchmarks/interop/interop.cpp
@@ -41,7 +41,7 @@ void BM_to_arrow_device(nvbench::state& state, nvbench::type_list<nvbench::enum_
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::to_arrow_device(table->view(), rmm::cuda_stream_view{launch.get_stream()});
+    cudf::to_arrow_device(table->view(), cuda::stream_ref{launch.get_stream()});
   });
 
   state.add_buffer_size(
@@ -67,7 +67,7 @@ void BM_to_arrow_host(nvbench::state& state, nvbench::type_list<nvbench::enum_ty
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::to_arrow_host(table->view(), rmm::cuda_stream_view{launch.get_stream()});
+    cudf::to_arrow_host(table->view(), cuda::stream_ref{launch.get_stream()});
   });
 
   state.add_buffer_size(
@@ -114,7 +114,7 @@ void BM_from_arrow_device(nvbench::state& state, nvbench::type_list<nvbench::enu
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::from_arrow_device_column(
-      schema.get(), input.get(), rmm::cuda_stream_view{launch.get_stream()});
+      schema.get(), input.get(), cuda::stream_ref{launch.get_stream()});
   });
 
   state.add_buffer_size(
@@ -160,8 +160,7 @@ void BM_from_arrow_host(nvbench::state& state, nvbench::type_list<nvbench::enum_
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::from_arrow_host_column(
-      schema.get(), input.get(), rmm::cuda_stream_view{launch.get_stream()});
+    cudf::from_arrow_host_column(schema.get(), input.get(), cuda::stream_ref{launch.get_stream()});
   });
 
   state.add_buffer_size(

--- a/cpp/benchmarks/interop/interop_stringview.cpp
+++ b/cpp/benchmarks/interop/interop_stringview.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,7 +45,7 @@ void BM_from_arrow_host_stringview(nvbench::state& state)
   state.add_element_count(num_rows, "num_rows");
   state.add_global_memory_reads(total_size);
   state.add_global_memory_writes(total_size);
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   ArrowSchema schema;
   NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRING_VIEW));

--- a/cpp/benchmarks/io/csv/csv_reader_input.cpp
+++ b/cpp/benchmarks/io/csv/csv_reader_input.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -47,7 +47,7 @@ void csv_read_common(DataType const& data_types, io_type const& source_type, nvb
       .dtypes(column_types);
 
   auto const mem_stats_logger = cudf::memory_stats_logger();  // init stats logger
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_options.get_source().filepaths());

--- a/cpp/benchmarks/io/csv/csv_reader_options.cpp
+++ b/cpp/benchmarks/io/csv/csv_reader_options.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ void BM_csv_read_varying_options(
   auto const chunk_row_cnt =
     cudf::util::div_rounding_up_safe(view.num_rows(), static_cast<cudf::size_type>(num_chunks));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                drop_page_cache_if_enabled(read_options.get_source().filepaths());

--- a/cpp/benchmarks/io/csv/csv_writer.cpp
+++ b/cpp/benchmarks/io/csv/csv_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -31,7 +31,7 @@ void BM_csv_write_dtype_io(nvbench::state& state,
   std::size_t encoded_file_size = 0;
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(sink_type);
@@ -71,7 +71,7 @@ void BM_csv_write_varying_options(nvbench::state& state)
   std::size_t encoded_file_size = 0;
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(io_type::HOST_BUFFER);

--- a/cpp/benchmarks/io/cudftable/cudftable_reader.cpp
+++ b/cpp/benchmarks/io/cudftable/cudftable_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,7 +23,7 @@ void cudftable_read_common(cudf::size_type num_rows_to_read,
   auto const data_size = static_cast<size_t>(state.get_int64("data_size"));
   auto source_info     = source_sink.make_source_info();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(

--- a/cpp/benchmarks/io/cudftable/cudftable_writer.cpp
+++ b/cpp/benchmarks/io/cudftable/cudftable_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,7 +20,7 @@ void cudftable_write_common(cudf::table_view const& view, io_type sink_type, nvb
   auto const data_size          = static_cast<size_t>(state.get_int64("data_size"));
   std::size_t encoded_file_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(

--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -111,7 +111,7 @@ cudf::io::source_info cuio_source_sink_pair::make_source_info()
       auto const stream = cudf::get_default_stream();
       d_buffer.resize(h_buffer.size(), stream);
       CUDF_CUDA_TRY(cudaMemcpyAsync(
-        d_buffer.data(), h_buffer.data(), h_buffer.size(), cudaMemcpyDefault, stream.value()));
+        d_buffer.data(), h_buffer.data(), h_buffer.size(), cudaMemcpyDefault, stream.get()));
 
       return cudf::io::source_info(d_buffer);
     }

--- a/cpp/benchmarks/io/fst.cu
+++ b/cpp/benchmarks/io/fst.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,11 +15,11 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -68,7 +68,7 @@ void BM_FST_JSON(nvbench::state& state)
   auto const string_size{cudf::size_type(state.get_int64("string_size"))};
   // Prepare cuda stream for data transfers & kernels
   rmm::cuda_stream stream{};
-  rmm::cuda_stream_view stream_view(stream);
+  cuda::stream_ref stream_view(stream);
 
   auto input_string = make_test_json_data(state);
   auto& d_input     = static_cast<cudf::scalar_type_t<std::string>&>(*input_string);
@@ -109,7 +109,7 @@ void BM_FST_JSON_no_outidx(nvbench::state& state)
   auto const string_size{cudf::size_type(state.get_int64("string_size"))};
   // Prepare cuda stream for data transfers & kernels
   rmm::cuda_stream stream{};
-  rmm::cuda_stream_view stream_view(stream);
+  cuda::stream_ref stream_view(stream);
 
   auto input_string = make_test_json_data(state);
   auto& d_input     = static_cast<cudf::scalar_type_t<std::string>&>(*input_string);
@@ -150,7 +150,7 @@ void BM_FST_JSON_no_out(nvbench::state& state)
   auto const string_size{cudf::size_type(state.get_int64("string_size"))};
   // Prepare cuda stream for data transfers & kernels
   rmm::cuda_stream stream{};
-  rmm::cuda_stream_view stream_view(stream);
+  cuda::stream_ref stream_view(stream);
 
   auto input_string = make_test_json_data(state);
   auto& d_input     = static_cast<cudf::scalar_type_t<std::string>&>(*input_string);
@@ -189,7 +189,7 @@ void BM_FST_JSON_no_str(nvbench::state& state)
   auto const string_size{cudf::size_type(state.get_int64("string_size"))};
   // Prepare cuda stream for data transfers & kernels
   rmm::cuda_stream stream{};
-  rmm::cuda_stream_view stream_view(stream);
+  cuda::stream_ref stream_view(stream);
 
   auto input_string = make_test_json_data(state);
   auto& d_input     = static_cast<cudf::scalar_type_t<std::string>&>(*input_string);

--- a/cpp/benchmarks/io/fst.cu
+++ b/cpp/benchmarks/io/fst.cu
@@ -19,7 +19,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/io/json/json_reader_input.cpp
+++ b/cpp/benchmarks/io/json/json_reader_input.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,7 +29,7 @@ void json_read_common(cudf::io::source_info const& source,
     cudf::io::json_reader_options::builder(source).compression(comptype).lines(true);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_opts.get_source().filepaths());

--- a/cpp/benchmarks/io/json/json_reader_option.cpp
+++ b/cpp/benchmarks/io/json/json_reader_option.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -46,7 +46,7 @@ void BM_json_read_options(nvbench::state& state, nvbench::type_list<nvbench::enu
     cudf::io::json_reader_options::builder(source_sink.make_source_info()).lines(json_lines_bool);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_options.get_source().filepaths());
@@ -122,7 +122,7 @@ void BM_jsonlines_read_options(nvbench::state& state,
 
   size_t const chunk_size = cudf::util::div_rounding_up_safe(source_sink.size(), num_chunks);
   auto mem_stats_logger   = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_options.get_source().filepaths());

--- a/cpp/benchmarks/io/json/json_writer.cpp
+++ b/cpp/benchmarks/io/json/json_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ void json_write_common(cudf::io::json_writer_options const& write_opts,
                        nvbench::state& state)
 {
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                drop_page_cache_if_enabled(write_opts.get_sink().filepaths());

--- a/cpp/benchmarks/io/json/nested_json.cpp
+++ b/cpp/benchmarks/io/json/nested_json.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -115,7 +115,7 @@ std::string generate_json(int num_rows,
   return s;
 }
 
-auto make_test_json_data(cudf::size_type string_size, rmm::cuda_stream_view stream)
+auto make_test_json_data(cudf::size_type string_size, cuda::stream_ref stream)
 {
   // Test input
   std::string input = R"(
@@ -136,8 +136,8 @@ auto make_test_json_data(cudf::size_type string_size, rmm::cuda_stream_view stre
   auto d_scalar         = cudf::strings::repeat_string(d_string_scalar, repeat_times);
 
   auto data = const_cast<char*>(d_scalar->data());
-  CUDF_CUDA_TRY(cudaMemsetAsync(data, '[', 1, stream.value()));
-  CUDF_CUDA_TRY(cudaMemsetAsync(data + d_scalar->size() - 1, ']', 1, stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(data, '[', 1, stream.get()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(data + d_scalar->size() - 1, ']', 1, stream.get()));
 
   return d_scalar;
 }
@@ -153,7 +153,7 @@ void BM_NESTED_JSON(nvbench::state& state)
 
   // Run algorithm
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // Allocate device-side temporary storage & run algorithm
     cudf::io::json::detail::device_parse_nested_json(
@@ -187,7 +187,7 @@ void BM_NESTED_JSON_DEPTH(nvbench::state& state)
 
   // Run algorithm
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // Allocate device-side temporary storage & run algorithm
     cudf::io::json::detail::device_parse_nested_json(

--- a/cpp/benchmarks/io/orc/orc_reader_input.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_input.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ void orc_read_common(cudf::size_type num_rows_to_read,
     cudf::io::orc_reader_options::builder(source_sink.make_source_info()).build();
 
   auto mem_stats_logger = cudf::memory_stats_logger();  // init stats logger
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   if constexpr (is_chunked_read) {
     state.exec(

--- a/cpp/benchmarks/io/orc/orc_reader_options.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_options.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -91,7 +91,7 @@ void BM_orc_read_varying_options(nvbench::state& state,
   auto const chunk_row_cnt = cudf::util::div_rounding_up_unsafe(view.num_rows(), num_chunks);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_options.get_source().filepaths());

--- a/cpp/benchmarks/io/orc/orc_writer.cpp
+++ b/cpp/benchmarks/io/orc/orc_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,7 +51,7 @@ void BM_orc_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enum
   std::size_t encoded_file_size = 0;
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(sink_type);
@@ -102,7 +102,7 @@ void BM_orc_write_io_compression(nvbench::state& state)
   std::size_t encoded_file_size = 0;
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(sink_type);
@@ -148,7 +148,7 @@ void BM_orc_write_statistics(nvbench::state& state,
   std::size_t encoded_file_size = 0;
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(io_type::FILEPATH);

--- a/cpp/benchmarks/io/orc/orc_writer_chunks.cpp
+++ b/cpp/benchmarks/io/orc/orc_writer_chunks.cpp
@@ -46,7 +46,7 @@ void nvbench_orc_write(nvbench::state& state)
 
   size_t encoded_file_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(io_type::VOID);
@@ -104,7 +104,7 @@ void nvbench_orc_chunked_write(nvbench::state& state)
 
   size_t encoded_file_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::timer | nvbench::exec_tag::sync, [&](nvbench::launch& launch, auto& timer) {
       cuio_source_sink_pair source_sink(io_type::VOID);

--- a/cpp/benchmarks/io/parquet/experimental/deletion_vectors/parquet_deletion_vectors.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/deletion_vectors/parquet_deletion_vectors.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -225,7 +225,7 @@ void BM_parquet_deletion_vectors(nvbench::state& state)
   };
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_opts.get_source().filepaths());
@@ -266,7 +266,7 @@ void BM_parquet_chunked_deletion_vectors(nvbench::state& state)
 
   auto num_chunks       = 0;
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                drop_page_cache_if_enabled(read_opts.get_source().filepaths());

--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -52,7 +52,7 @@ std::vector<cudf::size_type> apply_row_group_filters(
   cudf::host_span<cudf::size_type> input_row_group_indices,
   std::unordered_set<hybrid_scan_filter_type> const& filters,
   cudf::io::parquet_reader_options const& options,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Span to track current row group indices
@@ -127,7 +127,7 @@ std::unique_ptr<cudf::table> single_step_materialize(
   hybrid_scan_reader const& reader,
   cudf::host_span<cudf::size_type> current_row_group_indices,
   cudf::io::parquet_reader_options const& options,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const all_column_chunk_byte_ranges =
@@ -146,7 +146,7 @@ std::unique_ptr<cudf::table> single_step_materialize(
 
 std::unique_ptr<cudf::table> hybrid_scan(cudf::io::parquet_reader_options const& options,
                                          std::unordered_set<hybrid_scan_filter_type> const& filters,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   // Input file buffer span

--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.hpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.hpp
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <unordered_set>
 

--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.hpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <unordered_set>
 
@@ -42,5 +42,5 @@ enum class hybrid_scan_filter_type : uint8_t {
  */
 std::unique_ptr<cudf::table> hybrid_scan(cudf::io::parquet_reader_options const& options,
                                          std::unordered_set<hybrid_scan_filter_type> const& filters,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);

--- a/cpp/benchmarks/io/parquet/parquet_reader_chunks.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -50,7 +50,7 @@ void BM_parquet_read_chunks(nvbench::state& state, nvbench::type_list<nvbench::e
     cudf::io::parquet_reader_options::builder(source_sink.make_source_info());
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_opts.get_source().filepaths());
@@ -111,7 +111,7 @@ void BM_parquet_read_subrowgroup_chunks(nvbench::state& state,
     cudf::io::parquet_reader_options::builder(source_sink.make_source_info());
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_opts.get_source().filepaths());

--- a/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
@@ -252,7 +252,7 @@ void BM_parquet_read_filter(nvbench::state& state)
     state.add_global_memory_writes<DataType>(static_cast<size_t>(num_rows * selectivity));
   }
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(

--- a/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -164,7 +164,7 @@ void BM_parquet_reader_construction(nvbench::state& state)
                            .convert_strings_to_categories(false)
                            .build();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(
@@ -211,7 +211,7 @@ void BM_parquet_column_selection(nvbench::state& state)
   auto const read_opts = cudf::io::parquet_reader_options::builder(source_sink.make_source_info())
                            .use_arrow_schema(false)
                            .build();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(
@@ -316,7 +316,7 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
   read_opts.enable_case_sensitive_names(case_sensitive);
   read_opts.set_filter(filter_expr);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {

--- a/cpp/benchmarks/io/parquet/parquet_reader_options.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_options.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -94,7 +94,7 @@ void BM_parquet_read_options(nvbench::state& state,
   auto const chunk_row_cnt = cudf::util::div_rounding_up_unsafe(view.num_rows(), num_chunks);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_options.get_source().filepaths());

--- a/cpp/benchmarks/io/parquet/parquet_reader_strings.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -97,7 +97,7 @@ void BM_parquet_read_file_shape(nvbench::state& state)
     cudf::io::parquet_reader_options::builder(source_sink.make_source_info());
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                drop_page_cache_if_enabled(read_opts.get_source().filepaths());

--- a/cpp/benchmarks/io/parquet/parquet_writer.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,7 +51,7 @@ void BM_parq_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enu
   std::size_t encoded_file_size = 0;
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(sink_type);
@@ -104,7 +104,7 @@ void BM_parq_write_io_compression(nvbench::state& state)
   std::size_t encoded_file_size = 0;
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(sink_type);
@@ -153,7 +153,7 @@ void BM_parq_write_varying_options(nvbench::state& state,
   std::size_t encoded_file_size = 0;
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(io_type::FILEPATH);

--- a/cpp/benchmarks/io/parquet/parquet_writer_chunks.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,7 +51,7 @@ void PQ_write(nvbench::state& state)
   std::size_t encoded_file_size = 0;
   auto const mem_stats_logger   = cudf::memory_stats_logger();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
                cuio_source_sink_pair source_sink(io_type::VOID);
@@ -95,7 +95,7 @@ void PQ_write_chunked(nvbench::state& state)
   auto const mem_stats_logger   = cudf::memory_stats_logger();
   std::size_t encoded_file_size = 0;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::timer | nvbench::exec_tag::sync, [&](nvbench::launch& launch, auto& timer) {
       cuio_source_sink_pair source_sink(io_type::VOID);

--- a/cpp/benchmarks/io/parquet/parquet_writer_dict.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer_dict.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -177,7 +177,7 @@ void BM_parq_write_dict_encoding(nvbench::state& state)
   }();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::timer | nvbench::exec_tag::sync, [&](nvbench::launch&, auto& timer) {
       timer.start();

--- a/cpp/benchmarks/io/parquet/reader_common.cpp
+++ b/cpp/benchmarks/io/parquet/reader_common.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ void parquet_read_common(cudf::size_type num_rows_to_read,
     cudf::io::parquet_reader_options::builder(source_sink.make_source_info());
 
   auto mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       drop_page_cache_if_enabled(read_opts.get_source().filepaths());

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -175,7 +175,7 @@ static void bench_multibyte_split(nvbench::state& state,
   cudf::io::text::parse_options options{range, strip_delimiters};
   std::unique_ptr<cudf::column> output;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     drop_page_cache_if_enabled({file_name});
     output = cudf::io::text::multibyte_split(*source, delim, options);

--- a/cpp/benchmarks/iterator/iterator.cu
+++ b/cpp/benchmarks/iterator/iterator.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -116,7 +116,7 @@ void bench_iterator_cub_raw(nvbench::state& state)
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = column_size * sizeof(T);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
@@ -140,7 +140,7 @@ void bench_iterator_cub_iter(nvbench::state& state)
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = column_size * sizeof(T);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
@@ -164,7 +164,7 @@ void bench_iterator_thrust_raw(nvbench::state& state)
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = column_size * sizeof(T);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
@@ -188,7 +188,7 @@ void bench_iterator_thrust_iter(nvbench::state& state)
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = column_size * sizeof(T);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/join/direct_join.cu
+++ b/cpp/benchmarks/join/direct_join.cu
@@ -60,7 +60,7 @@ void nvbench_direct_inner_join(nvbench::state& state)
   auto const right_keys = cudf::table_view{{right_view}};
 
   auto const input_bytes = estimate_size(left_keys) + estimate_size(right_keys);
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_element_count(input_bytes, "input_bytes");
   state.add_global_memory_reads<nvbench::int8_t>(input_bytes);
 

--- a/cpp/benchmarks/join/filter_join_indices_jit.cu
+++ b/cpp/benchmarks/join/filter_join_indices_jit.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -42,7 +42,7 @@ void filter_join_indices_benchmark(nvbench::state& state,
   cudf::device_span<cudf::size_type const> left_span{left_indices->data(), left_indices->size()};
   cudf::device_span<cudf::size_type const> right_span{right_indices->data(), right_indices->size()};
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto const method = state.get_string("method");
 

--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -109,7 +109,7 @@ void BM_join(state_type& state,
   // Setup join parameters and result table
   std::vector<cudf::size_type> columns_to_join(num_keys);
   std::iota(columns_to_join.begin(), columns_to_join.end(), 0);
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   if constexpr (join_type == join_t::HASH || join_type == join_t::SORT_MERGE) {
     state.add_element_count(join_input_size, "join_input_size");  // number of bytes

--- a/cpp/benchmarks/join/join_dictionary.cpp
+++ b/cpp/benchmarks/join/join_dictionary.cpp
@@ -69,7 +69,7 @@ void BM_join_dictionary(nvbench::state& state, Join join_func)
   state.add_element_count(join_input_size, "join_input_size");
   state.add_global_memory_reads<nvbench::int8_t>(join_input_size);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {

--- a/cpp/benchmarks/join/join_heuristics.cpp
+++ b/cpp/benchmarks/join/join_heuristics.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -131,7 +131,7 @@ void nvbench_join_heuristics(nvbench::state& state,
   auto const input_size = estimate_size(keys);
   state.add_element_count(input_size, "input_size");
   state.add_global_memory_reads<nvbench::int8_t>(input_size);
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     if constexpr (Method == heuristic_method::DISTINCT_COUNT) {

--- a/cpp/benchmarks/join/join_on_int32.cu
+++ b/cpp/benchmarks/join/join_on_int32.cu
@@ -172,7 +172,7 @@ void nvbench_join_on_int32(nvbench::state& state,
   state.add_element_count(input_size, "input_size");
   state.add_global_memory_reads<nvbench::int8_t>(input_size);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     if constexpr (Algo == join_algo::HASH) {

--- a/cpp/benchmarks/join/key_remap_build.cpp
+++ b/cpp/benchmarks/join/key_remap_build.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -95,7 +95,7 @@ void nvbench_key_remap_build(nvbench::state& state,
   state.add_element_count(input_size, "input_size");
   state.add_global_memory_reads<nvbench::int8_t>(input_size);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     cudf::key_remapping remap(

--- a/cpp/benchmarks/join/sort_merge_join.cpp
+++ b/cpp/benchmarks/join/sort_merge_join.cpp
@@ -60,7 +60,7 @@ void nvbench_sort_merge_inner_join(nvbench::state& state,
   auto const join_input_size = estimate_size(build_view) + estimate_size(probe_view);
   state.add_element_count(join_input_size, "join_input_size");
   state.add_global_memory_reads<nvbench::int8_t>(join_input_size);
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   if (use_remap) {
     // Benchmark with key remapping

--- a/cpp/benchmarks/json/json.cu
+++ b/cpp/benchmarks/json/json.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -189,7 +189,7 @@ static void bench_query(nvbench::state& state)
   cudf::strings_column_view scv(input->view());
   size_t num_chars = scv.chars_size(stream);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   // This isn't strictly 100% accurate. a given query isn't necessarily
   // going to visit every single incoming character but in spirit it does.
   state.add_global_memory_reads<nvbench::int8_t>(num_chars);

--- a/cpp/benchmarks/lists/copying/scatter_lists.cu
+++ b/cpp/benchmarks/lists/copying/scatter_lists.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -105,7 +105,7 @@ static void bench_scatter_lists(nvbench::state& state, nvbench::type_list<TypePa
                     g);
   }
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int8_t>(base_size * sizeof(TypeParam) * 2);  // source + scatter_map
   state.add_global_memory_writes<int8_t>(base_size * sizeof(TypeParam));     // target
 

--- a/cpp/benchmarks/lists/set_operations.cpp
+++ b/cpp/benchmarks/lists/set_operations.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,7 +39,7 @@ void nvbench_set_op(nvbench::state& state, BenchFuncPtr bfunc)
   auto const lhs = generate_random_lists(num_rows, depth, null_freq);
   auto const rhs = generate_random_lists(num_rows, depth, null_freq);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     bfunc(cudf::lists_column_view{*lhs},

--- a/cpp/benchmarks/merge/merge.cpp
+++ b/cpp/benchmarks/merge/merge.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -61,7 +61,7 @@ void bench_merge(nvbench::state& state)
   std::vector<cudf::null_order> const null_precedence{};
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = total_rows * 2 * sizeof(int32_t);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/merge/merge_lists.cpp
+++ b/cpp/benchmarks/merge/merge_lists.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 
 void nvbench_merge_list(nvbench::state& state)
 {
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   auto const input1 = create_lists_data(state);
   auto const sorted_input1 =
@@ -24,12 +24,12 @@ void nvbench_merge_list(nvbench::state& state)
   auto const sorted_input2 =
     cudf::sort(*input2, {}, {}, stream, cudf::get_current_device_resource_ref());
 
-  stream.synchronize();
+  stream.sync();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
 
     cudf::merge({*sorted_input1, *sorted_input2},
                 {0},

--- a/cpp/benchmarks/merge/merge_strings.cpp
+++ b/cpp/benchmarks/merge/merge_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ void nvbench_merge_strings(nvbench::state& state)
   auto const lhs        = sorted_lhs->view().column(0);
   auto const rhs        = sorted_rhs->view().column(0);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto chars_size = cudf::strings_column_view(lhs).chars_size(stream) +
                     cudf::strings_column_view(rhs).chars_size(stream);
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read

--- a/cpp/benchmarks/merge/merge_structs.cpp
+++ b/cpp/benchmarks/merge/merge_structs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 
 void nvbench_merge_struct(nvbench::state& state)
 {
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   auto const input1 = create_structs_data(state);
   auto const sorted_input1 =
@@ -24,12 +24,12 @@ void nvbench_merge_struct(nvbench::state& state)
   auto const sorted_input2 =
     cudf::sort(*input2, {}, {}, stream, cudf::get_current_device_resource_ref());
 
-  stream.synchronize();
+  stream.sync();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
 
     cudf::merge({*sorted_input1, *sorted_input2},
                 {0},

--- a/cpp/benchmarks/ndsh/q01.cpp
+++ b/cpp/benchmarks/ndsh/q01.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -56,7 +56,7 @@
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_disc_price(
   cudf::column_view const& discount,
   cudf::column_view const& extendedprice,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto const one = discount.type().id() == cudf::type_id::DECIMAL64
@@ -83,7 +83,7 @@
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_charge(
   cudf::column_view const& tax,
   cudf::column_view const& disc_price,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto const one = tax.type().id() == cudf::type_id::DECIMAL64
@@ -175,7 +175,7 @@ void ndsh_q1(nvbench::state& state)
   }();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q1(state, source); });
   state.add_buffer_size(

--- a/cpp/benchmarks/ndsh/q05.cpp
+++ b/cpp/benchmarks/ndsh/q05.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -63,7 +63,7 @@
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_revenue(
   cudf::column_view const& extendedprice,
   cudf::column_view const& discount,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto const one = cudf::numeric_scalar<double>(1);
@@ -161,7 +161,7 @@ void ndsh_q5(nvbench::state& state)
     scale_factor, {"customer", "orders", "lineitem", "supplier", "nation", "region"}, sources);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { run_ndsh_q5(state, sources); });

--- a/cpp/benchmarks/ndsh/q06.cpp
+++ b/cpp/benchmarks/ndsh/q06.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,7 +45,7 @@
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_revenue(
   cudf::column_view const& extendedprice,
   cudf::column_view const& discount,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto const revenue_type = cudf::data_type{cudf::type_id::FLOAT64};
@@ -129,7 +129,7 @@ void ndsh_q6(nvbench::state& state)
   generate_parquet_data_sources(scale_factor, {"lineitem"}, sources);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { run_ndsh_q6(state, sources); });

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -107,7 +107,7 @@ struct q9_data {
   cudf::column_view const& extendedprice,
   cudf::column_view const& supplycost,
   cudf::column_view const& quantity,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_BENCHMARK_RANGE();
@@ -139,7 +139,7 @@ struct q9_data {
   cudf::column_view const& extendedprice,
   cudf::column_view const& supplycost,
   cudf::column_view const& quantity,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_BENCHMARK_RANGE();
@@ -174,7 +174,7 @@ struct q9_data {
   cudf::column_view const& extendedprice,
   cudf::column_view const& supplycost,
   cudf::column_view const& quantity,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   CUDF_BENCHMARK_RANGE();
@@ -211,7 +211,7 @@ struct q9_data {
   cudf::column_view const& supplycost,
   cudf::column_view const& quantity,
   engine_type engine,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   switch (engine) {
@@ -269,7 +269,7 @@ std::unique_ptr<table_with_names> compute_profit(
   nvbench::state& state,
   engine_type engine,
   q9_data const& data,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto joined_table = join_data(data);

--- a/cpp/benchmarks/ndsh/q10.cpp
+++ b/cpp/benchmarks/ndsh/q10.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -68,7 +68,7 @@
 [[nodiscard]] std::unique_ptr<cudf::column> calculate_revenue(
   cudf::column_view const& extendedprice,
   cudf::column_view const& discount,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto const one = cudf::numeric_scalar<double>(1);
@@ -160,7 +160,7 @@ void ndsh_q10(nvbench::state& state)
     scale_factor, {"customer", "orders", "lineitem", "nation"}, sources);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { run_ndsh_q10(state, sources); });

--- a/cpp/benchmarks/quantiles/quantiles.cpp
+++ b/cpp/benchmarks/quantiles/quantiles.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -41,7 +41,7 @@ static void bench_quantiles(nvbench::state& state)
   });
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/quantiles/tdigest.cpp
+++ b/cpp/benchmarks/quantiles/tdigest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -81,11 +81,11 @@ void bm_tdigest_merge(nvbench::state& state)
       ->release()
       .front());
 
-  stream.synchronize();
+  stream.sync();
 
   state.add_element_count(total_centroids);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {
@@ -133,9 +133,9 @@ void bm_tdigest_reduce(nvbench::state& state)
                 .front());
   auto group_valid_counts = cudf::sequence(num_groups, rpg_scalar, zero);
 
-  stream.synchronize();
+  stream.sync();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch, auto& timer) {

--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -34,7 +34,7 @@ static void reduction_anyall(nvbench::state& state, nvbench::type_list<DataType>
 
   auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
   auto stream            = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_element_count(size);
   state.add_global_memory_reads<DataType>(size);
   state.add_global_memory_writes<nvbench::int8_t>(1);

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ static void reduction_dictionary(nvbench::state& state,
   auto agg = make_reduce_aggregation<kind>();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_element_count(size);
   state.add_global_memory_reads<DataType>(size);
   if (kind == cudf::aggregation::ANY || kind == cudf::aggregation::ALL) {

--- a/cpp/benchmarks/reduction/distinct_count.cpp
+++ b/cpp/benchmarks/reduction/distinct_count.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -38,7 +38,7 @@ static void bench_distinct_count(nvbench::state& state, nvbench::type_list<Type>
   }
 
   auto mem_stats_logger = cudf::memory_stats_logger();  // init stats logger
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::distinct_count(input_table, cudf::null_equality::EQUAL);
   });

--- a/cpp/benchmarks/reduction/histogram.cpp
+++ b/cpp/benchmarks/reduction/histogram.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ static void nvbench_reduction_histogram(nvbench::state& state, nvbench::type_lis
   auto agg                    = cudf::make_histogram_aggregation<cudf::reduce_aggregation>();
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
     auto result = cudf::reduce(*input, *agg, input->type(), stream_view);
   });
   state.add_buffer_size(

--- a/cpp/benchmarks/reduction/minmax.cpp
+++ b/cpp/benchmarks/reduction/minmax.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@ static void reduction_minmax(nvbench::state& state, nvbench::type_list<DataType>
   auto const input_column = create_random_column(input_type, row_count{size}, profile);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_element_count(size);
   state.add_global_memory_reads<DataType>(size);
   state.add_global_memory_writes<DataType>(2);

--- a/cpp/benchmarks/reduction/rank.cpp
+++ b/cpp/benchmarks/reduction/rank.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ static void nvbench_reduction_scan(nvbench::state& state, nvbench::type_list<typ
   std::unique_ptr<cudf::column> result = nullptr;
   auto const mem_stats_logger          = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
     result = cudf::detail::inclusive_dense_rank_scan(
       input, stream_view, cudf::get_current_device_resource_ref());
   });

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -64,7 +64,7 @@ static void reduction(nvbench::state& state, nvbench::type_list<DataType, nvbenc
   }();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_element_count(size);
   state.add_global_memory_reads<DataType>(size);
   state.add_global_memory_writes<DataType>(1);

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,7 +29,7 @@ static void reduction_scan(nvbench::state& state, nvbench::type_list<DataType>)
   auto agg = cudf::make_min_aggregation<cudf::scan_aggregation>();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_element_count(size);
   state.add_global_memory_reads<DataType>(size);
   state.add_global_memory_writes<DataType>(1);

--- a/cpp/benchmarks/reduction/scan_structs.cpp
+++ b/cpp/benchmarks/reduction/scan_structs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ static void nvbench_structs_scan(nvbench::state& state)
   auto const null_policy = static_cast<cudf::null_policy>(state.get_int64("null_policy"));
   auto const stream      = cudf::get_default_stream();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   std::unique_ptr<cudf::column> result = nullptr;
   auto const mem_stats_logger          = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {

--- a/cpp/benchmarks/reduction/segmented_reduce.cpp
+++ b/cpp/benchmarks/reduction/segmented_reduce.cpp
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 #include <memory>

--- a/cpp/benchmarks/reduction/segmented_reduce.cpp
+++ b/cpp/benchmarks/reduction/segmented_reduce.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -115,7 +115,7 @@ void BM_Segmented_Reduction(nvbench::state& state,
   auto const offset_span  = cudf::device_span<cudf::size_type const>{
     offsets_view.template data<cudf::size_type>(), static_cast<std::size_t>(offsets_view.size())};
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(
     nvbench::exec_tag::sync, [input_view, output_type, offset_span, &agg](nvbench::launch& launch) {

--- a/cpp/benchmarks/reduction/segmented_reduce.cpp
+++ b/cpp/benchmarks/reduction/segmented_reduce.cpp
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/reduction/unique_count.cpp
+++ b/cpp/benchmarks/reduction/unique_count.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ void nvbench_unique_count(nvbench::state& state, nvbench::type_list<Type>)
 
   auto input = sorted_table->view();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::unique_count(input, cudf::null_equality::EQUAL);

--- a/cpp/benchmarks/replace/clamp.cpp
+++ b/cpp/benchmarks/replace/clamp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -42,7 +42,7 @@ void bench_clamp(nvbench::state& state, nvbench::type_list<ClampType>)
   }
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = input->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/replace/nans.cpp
+++ b/cpp/benchmarks/replace/nans.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ void bench_replace_nans(nvbench::state& state, nvbench::type_list<FloatingType>)
   auto zero = cudf::make_fixed_width_scalar<FloatingType>(0);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = input->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/replace/nulls.cpp
+++ b/cpp/benchmarks/replace/nulls.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ static void replace_nulls(nvbench::state& state)
   auto const input = input_table->view().column(0);
   auto const repl  = input_table->view().column(1);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto chars_size = cudf::strings_column_view(input).chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read;
   state.add_global_memory_writes<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/reshape/interleave.cpp
+++ b/cpp/benchmarks/reshape/interleave.cpp
@@ -31,7 +31,7 @@ static void bench_interleave(nvbench::state& state)
   auto const source_view = source_table->view();
   auto const stream      = cudf::get_default_stream();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto input_bytes = source_table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(input_bytes);   // all bytes are read
   state.add_global_memory_writes<nvbench::int8_t>(input_bytes);  // all bytes are written

--- a/cpp/benchmarks/reshape/table_to_array.cpp
+++ b/cpp/benchmarks/reshape/table_to_array.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_table_to_array(nvbench::state& state)
   auto span = cudf::device_span<cuda::std::byte>(reinterpret_cast<cuda::std::byte*>(output.data()),
                                                  output.size());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<int32_t>(num_rows * num_cols);   // all bytes are read
   state.add_global_memory_writes<int32_t>(num_rows * num_cols);  // all bytes are written
 

--- a/cpp/benchmarks/rolling/grouped_range_rolling_sum.cu
+++ b/cpp/benchmarks/rolling/grouped_range_rolling_sum.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -88,7 +88,7 @@ void bench_grouped_range_rolling_sum(nvbench::state& state)
   auto req = cudf::make_sum_aggregation<cudf::rolling_aggregation>();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const result =
       cudf::grouped_range_rolling_window(keys->view(),

--- a/cpp/benchmarks/rolling/grouped_rolling_sum.cpp
+++ b/cpp/benchmarks/rolling/grouped_rolling_sum.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -38,7 +38,7 @@ void bench_row_grouped_rolling_sum(nvbench::state& state, nvbench::type_list<Typ
   auto req = cudf::make_sum_aggregation<cudf::rolling_aggregation>();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const result = cudf::grouped_rolling_window(
       keys->view(), vals->view(), preceding_size, following_size, min_periods, *req);

--- a/cpp/benchmarks/rolling/multi_orderby_range_rolling_sum.cpp
+++ b/cpp/benchmarks/rolling/multi_orderby_range_rolling_sum.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -114,7 +114,7 @@ void bench_multi_orderby_range_rolling_sum(nvbench::state& state)
   auto const group_view = group_keys ? group_keys->view() : cudf::table_view{};
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     auto const result =
       cudf::grouped_range_rolling_window(group_view,

--- a/cpp/benchmarks/rolling/range_rolling_sum.cu
+++ b/cpp/benchmarks/rolling/range_rolling_sum.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -77,7 +77,7 @@ void bench_range_rolling_sum(nvbench::state& state)
   auto req = cudf::make_sum_aggregation<cudf::rolling_aggregation>();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const result =
       cudf::grouped_range_rolling_window(cudf::table_view{},

--- a/cpp/benchmarks/rolling/rolling_sum.cpp
+++ b/cpp/benchmarks/rolling/rolling_sum.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ void bench_row_fixed_rolling_sum(nvbench::state& state, nvbench::type_list<Type>
   auto req = cudf::make_sum_aggregation<cudf::rolling_aggregation>();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const result =
       cudf::rolling_window(vals->view(), preceding_size, following_size, min_periods, *req);
@@ -69,7 +69,7 @@ void bench_row_variable_rolling_sum(nvbench::state& state, nvbench::type_list<Ty
     });
     auto buf = rmm::device_buffer(
       data.data(), num_rows * sizeof(cudf::size_type), cudf::get_default_stream());
-    cudf::get_default_stream().synchronize();
+    cudf::get_default_stream().sync();
     return std::make_unique<cudf::column>(cudf::data_type(cudf::type_to_id<cudf::size_type>()),
                                           num_rows,
                                           std::move(buf),
@@ -85,7 +85,7 @@ void bench_row_variable_rolling_sum(nvbench::state& state, nvbench::type_list<Ty
     });
     auto buf = rmm::device_buffer(
       data.data(), num_rows * sizeof(cudf::size_type), cudf::get_default_stream());
-    cudf::get_default_stream().synchronize();
+    cudf::get_default_stream().sync();
     return std::make_unique<cudf::column>(cudf::data_type(cudf::type_to_id<cudf::size_type>()),
                                           num_rows,
                                           std::move(buf),
@@ -96,7 +96,7 @@ void bench_row_variable_rolling_sum(nvbench::state& state, nvbench::type_list<Ty
   auto req = cudf::make_sum_aggregation<cudf::rolling_aggregation>();
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const result =
       cudf::rolling_window(vals->view(), preceding->view(), following->view(), 1, *req);

--- a/cpp/benchmarks/search/contains_scalar.cpp
+++ b/cpp/benchmarks/search/contains_scalar.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ static void nvbench_contains_scalar(nvbench::state& state)
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto const stream_view             = rmm::cuda_stream_view{launch.get_stream()};
+    auto const stream_view             = cuda::stream_ref{launch.get_stream()};
     [[maybe_unused]] auto const result = cudf::contains(*haystack, *needle, stream_view);
   });
   state.add_buffer_size(

--- a/cpp/benchmarks/search/contains_table.cpp
+++ b/cpp/benchmarks/search/contains_table.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,7 +39,7 @@ static void nvbench_contains_table(nvbench::state& state, nvbench::type_list<Typ
   auto mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto const stream_view = rmm::cuda_stream_view{launch.get_stream()};
+    auto const stream_view = cuda::stream_ref{launch.get_stream()};
     [[maybe_unused]] auto const result =
       cudf::contains(haystack->view().column(0), needles->view().column(0), stream_view);
   });

--- a/cpp/benchmarks/search/search.cpp
+++ b/cpp/benchmarks/search/search.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ static void bench_upper_bound_column(nvbench::state& state)
   auto data_table = cudf::sort(cudf::table_view({*column}));
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   // Add memory bandwidth tracking
   state.add_element_count(column_size);
@@ -88,7 +88,7 @@ static void bench_lower_bound_table(nvbench::state& state)
   auto sorted = cudf::sort(*data_table);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   // Add memory bandwidth tracking
   state.add_element_count(column_size * num_columns);
@@ -134,7 +134,7 @@ static void bench_contains(nvbench::state& state)
   }
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   // Add memory bandwidth tracking
   state.add_element_count(column_size);

--- a/cpp/benchmarks/sort/rank.cpp
+++ b/cpp/benchmarks/sort/rank.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ static void bench_rank(nvbench::state& state)
 
   auto input = create_random_column(cudf::type_id::INT32, row_count{n_rows}, profile);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_element_count(n_rows, "n_rows");
   state.add_global_memory_reads<nvbench::int32_t>(n_rows);
   state.add_global_memory_writes<nvbench::int32_t>(n_rows);

--- a/cpp/benchmarks/sort/segmented_sort.cpp
+++ b/cpp/benchmarks/sort/segmented_sort.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ void nvbench_segmented_sort(nvbench::state& state)
                                        cudf::numeric_scalar<int32_t>(0),
                                        cudf::numeric_scalar<int32_t>(row_width));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_element_count(size_bytes, "bytes");
   state.add_global_memory_reads<nvbench::int32_t>(rows * row_width);
   state.add_global_memory_writes<nvbench::int32_t>(rows);

--- a/cpp/benchmarks/sort/segmented_top_k.cpp
+++ b/cpp/benchmarks/sort/segmented_top_k.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ void bench_segmented_top_k(nvbench::state& state, nvbench::type_list<DataType>)
                                        cudf::numeric_scalar<int32_t>(0),
                                        cudf::numeric_scalar<int32_t>(segment));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int32_t>(num_rows);
   state.add_global_memory_writes<nvbench::int32_t>(segments->size() * k);
   auto const mem_stats_logger = cudf::memory_stats_logger();

--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,7 +29,7 @@ static void bench_sort(nvbench::state& state, nvbench::type_list<DataType>)
     create_random_table(cycle_dtypes({data_type}, num_cols), row_count{num_rows}, profile);
   cudf::table_view input{*input_table};
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_table->alloc_size());
   state.add_global_memory_writes<nvbench::int32_t>(num_rows);
   auto const mem_stats_logger = cudf::memory_stats_logger();

--- a/cpp/benchmarks/sort/sort_lists.cpp
+++ b/cpp/benchmarks/sort/sort_lists.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@ void sort_multiple_lists(nvbench::state& state)
   auto const input_table = create_lists_data(state, num_columns, min_val, max_val);
   auto const stream      = cudf::get_default_stream();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
@@ -69,11 +69,11 @@ void sort_lists_of_structs(nvbench::state& state)
   auto const input_table = cudf::table_view{lists_of_structs};
   auto const stream      = cudf::get_default_stream();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
     cudf::sorted_order(input_table, {}, {}, stream, cudf::get_current_device_resource_ref());
   });
 

--- a/cpp/benchmarks/sort/sort_strings.cpp
+++ b/cpp/benchmarks/sort/sort_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ static void bench_sort_strings(nvbench::state& state)
   auto sv    = cudf::strings_column_view(table->view().column(0));
   auto bytes = sv.chars_size(cudf::get_default_stream());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(bytes);
   state.add_global_memory_writes<nvbench::int8_t>(bytes);
 

--- a/cpp/benchmarks/sort/sort_structs.cpp
+++ b/cpp/benchmarks/sort/sort_structs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,7 +17,7 @@ void nvbench_sort_struct(nvbench::state& state)
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    cuda::stream_ref stream_view{launch.get_stream()};
     cudf::sorted_order(*input, {}, {}, stream_view, cudf::get_current_device_resource_ref());
   });
 

--- a/cpp/benchmarks/sort/top_k.cpp
+++ b/cpp/benchmarks/sort/top_k.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ static void bench_top_k(nvbench::state& state, nvbench::type_list<DataType>)
       data_type, distribution_id::UNIFORM, 100, 10'000);
   auto input = create_random_column(data_type, row_count{num_rows}, profile);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input->alloc_size());
   state.add_global_memory_writes<nvbench::int32_t>(k);
   auto const mem_stats_logger = cudf::memory_stats_logger();

--- a/cpp/benchmarks/stream_compaction/apply_boolean_mask.cpp
+++ b/cpp/benchmarks/stream_compaction/apply_boolean_mask.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -63,7 +63,7 @@ void apply_mask_benchmark(nvbench::state& state, nvbench::type_list<DataType>)
   auto mask = create_random_column(cudf::type_id::BOOL8, row_count{n_rows}, profile);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   calculate_bandwidth<DataType>(state);
   auto const mem_stats_logger = cudf::memory_stats_logger();
 

--- a/cpp/benchmarks/stream_compaction/distinct.cpp
+++ b/cpp/benchmarks/stream_compaction/distinct.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ void nvbench_distinct(nvbench::state& state, nvbench::type_list<Type>)
   auto input_column = source_column->view();
   auto input_table  = cudf::table_view({input_column, input_column, input_column, input_column});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
@@ -90,7 +90,7 @@ void nvbench_distinct_list(nvbench::state& state, nvbench::type_list<Type>)
   auto const table = create_random_table(
     {dtype}, table_size_bytes{static_cast<size_t>(size)}, data_profile{builder}, 0);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {

--- a/cpp/benchmarks/stream_compaction/stable_distinct.cpp
+++ b/cpp/benchmarks/stream_compaction/stable_distinct.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -43,7 +43,7 @@ void nvbench_stable_distinct(nvbench::state& state, nvbench::type_list<Type>)
   auto input_column = source_column->view();
   auto input_table  = cudf::table_view({input_column, input_column, input_column, input_column});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
@@ -88,7 +88,7 @@ void nvbench_stable_distinct_list(nvbench::state& state, nvbench::type_list<Type
   auto const table = create_random_table(
     {dtype}, table_size_bytes{static_cast<size_t>(size)}, data_profile{builder}, 0);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {

--- a/cpp/benchmarks/stream_compaction/unique.cpp
+++ b/cpp/benchmarks/stream_compaction/unique.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -55,7 +55,7 @@ void nvbench_unique(nvbench::state& state, nvbench::type_list<Type, nvbench::enu
   auto input_table  = cudf::table_view({input_column, input_column, input_column, input_column});
 
   auto const run_bench = [&](auto const& input) {
-    state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+    state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
     auto const mem_stats_logger = cudf::memory_stats_logger();
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       auto result = cudf::unique(input, {0}, Keep, cudf::null_equality::EQUAL);
@@ -115,7 +115,7 @@ void nvbench_unique_list(nvbench::state& state, nvbench::type_list<Type, nvbench
     {dtype}, table_size_bytes{static_cast<size_t>(size)}, data_profile{builder}, 0);
 
   auto const run_bench = [&](auto const& input) {
-    state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+    state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
     auto const mem_stats_logger = cudf::memory_stats_logger();
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       auto result = cudf::unique(input, {0}, Keep, cudf::null_equality::EQUAL);

--- a/cpp/benchmarks/string/case.cpp
+++ b/cpp/benchmarks/string/case.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -49,7 +49,7 @@ void bench_case(nvbench::state& state)
   }
   auto input = cudf::strings_column_view(col_view);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   state.add_global_memory_reads<nvbench::int8_t>(col_size);
   state.add_global_memory_writes<nvbench::int8_t>(col_size);

--- a/cpp/benchmarks/string/char_types.cpp
+++ b/cpp/benchmarks/string/char_types.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@ static void bench_char_types(nvbench::state& state)
   cudf::strings_column_view input(table->view().column(0));
   auto input_types = cudf::strings::string_character_types::SPACE;
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;

--- a/cpp/benchmarks/string/combine.cpp
+++ b/cpp/benchmarks/string/combine.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ static void bench_combine(nvbench::state& state)
   cudf::string_scalar separator("+");
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;
   state.add_global_memory_writes<nvbench::int8_t>(data_size + (num_rows * separator.size()));

--- a/cpp/benchmarks/string/convert_datetime.cpp
+++ b/cpp/benchmarks/string/convert_datetime.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,7 +39,7 @@ void bench_convert_datetime(nvbench::state& state, nvbench::type_list<DataType>)
   auto sv     = cudf::strings_column_view(s_col->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 

--- a/cpp/benchmarks/string/convert_durations.cpp
+++ b/cpp/benchmarks/string/convert_durations.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ void bench_convert_duration(nvbench::state& state, nvbench::type_list<DataType>)
 
   auto format = std::string{"%D days %H:%M:%S"};
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   if (from_dur) {
     state.add_global_memory_reads<DataType>(num_rows);

--- a/cpp/benchmarks/string/convert_fixed_point.cpp
+++ b/cpp/benchmarks/string/convert_fixed_point.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ void bench_convert_fixed_point(nvbench::state& state, nvbench::type_list<DataTyp
   auto const sv          = cudf::strings_column_view(strings_col->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 

--- a/cpp/benchmarks/string/convert_numerics.cpp
+++ b/cpp/benchmarks/string/convert_numerics.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ void bench_convert_number(nvbench::state& state, nvbench::type_list<NumericType>
   auto const sv          = cudf::strings_column_view(strings_col->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 

--- a/cpp/benchmarks/string/copy.cpp
+++ b/cpp/benchmarks/string/copy.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -31,7 +31,7 @@ static void bench_copy(nvbench::state& state)
   auto const map_view = map_table->view().column(0);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   if (api == "gather") {
     auto result =

--- a/cpp/benchmarks/string/copy_if_else.cpp
+++ b/cpp/benchmarks/string/copy_if_else.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_copy(nvbench::state& state)
   auto const target     = target_table->view().column(0);
   auto const left_right = booleans->view().column(0);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto data_size = target_table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
   state.add_global_memory_writes<nvbench::int8_t>(data_size);  // both columns are similar size

--- a/cpp/benchmarks/string/copy_range.cpp
+++ b/cpp/benchmarks/string/copy_range.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ static void bench_copy_range(nvbench::state& state)
   auto const source = source_tables->view().column(0);
   auto const target = source_tables->view().column(1);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto data_size = source_tables->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
   state.add_global_memory_writes<nvbench::int8_t>(data_size);  // both columns are similar size

--- a/cpp/benchmarks/string/count.cpp
+++ b/cpp/benchmarks/string/count.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,7 +45,7 @@ static void bench_count(nvbench::state& state)
 
   auto prog = cudf::strings::regex_program::create(patterns[pattern_index]);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/string/experimental/stringview_compare.cu
+++ b/cpp/benchmarks/string/experimental/stringview_compare.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -215,7 +215,7 @@ struct compare_sv {
  * Creates an ArrowBinaryView vector and data buffer from a strings column.
  */
 std::pair<rmm::device_uvector<ArrowBinaryView>, rmm::device_buffer> create_sv_array(
-  cudf::strings_column_view const& input, rmm::cuda_stream_view stream)
+  cudf::strings_column_view const& input, cuda::stream_ref stream)
 {
   auto const d_strings = cudf::column_device_view::create(input.parent(), stream);
   auto d_offsets =
@@ -250,7 +250,7 @@ std::pair<rmm::device_uvector<ArrowBinaryView>, rmm::device_buffer> create_sv_ar
         }));
     auto longer_strings = cudf::strings::detail::make_strings_column(
       indices, indices + input.size(), stream, cudf::get_current_device_resource_ref());
-    stream.synchronize();
+    stream.sync();
     auto const sv = cudf::strings_column_view(longer_strings->view());
     return std::pair{std::move(longer_strings), sv};
   }();
@@ -274,7 +274,7 @@ std::pair<rmm::device_uvector<ArrowBinaryView>, rmm::device_buffer> create_sv_ar
   rmm::device_buffer data_buffer(longer_chars_size, stream);
   auto const chars_data = longer_strings.chars_begin(stream);
   CUDF_CUDA_TRY(cudaMemcpyAsync(
-    data_buffer.data(), chars_data, longer_chars_size, cudaMemcpyDefault, stream.value()));
+    data_buffer.data(), chars_data, longer_chars_size, cudaMemcpyDefault, stream.get()));
 
   return std::pair{std::move(d_items), std::move(data_buffer)};
 }
@@ -285,7 +285,7 @@ std::pair<rmm::device_uvector<ArrowBinaryView>, rmm::device_buffer> gather_sv_ar
   rmm::device_buffer const& data,
   MapIterator begin,
   cudf::size_type map_size,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto output   = rmm::device_uvector<ArrowBinaryView>(map_size, stream);
   auto d_output = output.data();
@@ -356,7 +356,7 @@ static void BM_sv_hash(nvbench::state& state)
   auto const column = create_random_column(cudf::type_id::STRING, row_count{num_rows}, profile);
   auto col_view     = column->view();
   auto stream       = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_writes(num_rows * sizeof(cudf::hash_value_type));
   auto output = rmm::device_uvector<cudf::hash_value_type>(num_rows, stream);
   auto begin  = cuda::counting_iterator<cudf::size_type>{0};
@@ -398,7 +398,7 @@ static void BM_sv_starts(nvbench::state& state)
   auto const column = create_random_column(cudf::type_id::STRING, row_count{num_rows}, profile);
   auto col_view     = column->view();
   auto stream       = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_writes(num_rows * sizeof(bool));
   auto output = rmm::device_uvector<bool>(num_rows, stream);
   auto begin  = cuda::counting_iterator<cudf::size_type>{0};
@@ -454,7 +454,7 @@ static void BM_sv_sort(nvbench::state& state)
 
   auto col_view = column->view();
   auto stream   = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_writes(num_rows * sizeof(cudf::size_type));
 
   // indices are the keys that are sorted (not inplace)
@@ -468,12 +468,12 @@ static void BM_sv_sort(nvbench::state& state)
     auto const d_chars          = reinterpret_cast<char const*>(data_buffer.data());
     auto comparator             = compare_arrow_sv{d_items.data(), d_chars};
     cub::DeviceMergeSort::SortKeysCopy(
-      nullptr, tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.value());
+      nullptr, tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.get());
     auto tmp_stg = rmm::device_buffer(tmp_bytes, stream);
     state.add_global_memory_reads(num_rows * sizeof(ArrowBinaryView) + data_buffer.size());
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cub::DeviceMergeSort::SortKeysCopy(
-        tmp_stg.data(), tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.value());
+        tmp_stg.data(), tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.get());
     });
   } else {
     auto d_strings = cudf::column_device_view::create(col_view, stream);
@@ -481,12 +481,12 @@ static void BM_sv_sort(nvbench::state& state)
     state.add_global_memory_reads(col_size);
     auto comparator = compare_sv{*d_strings};
     cub::DeviceMergeSort::SortKeysCopy(
-      nullptr, tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.value());
+      nullptr, tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.get());
     auto tmp_stg = rmm::device_buffer(tmp_bytes, stream);
     state.add_global_memory_reads(col_size);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cub::DeviceMergeSort::SortKeysCopy(
-        tmp_stg.data(), tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.value());
+        tmp_stg.data(), tmp_bytes, in_keys, out_keys, num_rows, comparator, stream.get());
     });
   }
 }
@@ -508,7 +508,7 @@ static void BM_sv_gather(nvbench::state& state)
   auto map_view = map->view();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   if (std::getenv(BM_ARROWSTRINGVIEW)) {
     auto [d_items, data_buffer] = create_sv_array(col_view, stream);

--- a/cpp/benchmarks/string/extract.cpp
+++ b/cpp/benchmarks/string/extract.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -50,7 +50,7 @@ static void bench_extract(nvbench::state& state)
   cudf::strings_column_view strings_view(input->get_column(0).view());
   auto prog = cudf::strings::regex_program::create(pattern);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto data_size = input->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;

--- a/cpp/benchmarks/string/factory.cpp
+++ b/cpp/benchmarks/string/factory.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_factory(nvbench::state& state)
   auto stream    = cudf::get_default_stream();
   auto d_strings = cudf::strings::create_string_vector_from_column(sv);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   state.add_global_memory_writes<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/string/filter.cpp
+++ b/cpp/benchmarks/string/filter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ static void bench_filter(nvbench::state& state)
   auto const input  = cudf::strings_column_view(column->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
 

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -32,7 +32,7 @@ static void bench_find_string(nvbench::state& state)
   auto targets_col   = cudf::make_column_from_scalar(target, num_rows);
   auto const targets = cudf::strings_column_view(targets_col->view());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = col->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   if (api == "find") {
@@ -102,7 +102,7 @@ static void bench_find_string_skewed(nvbench::state& state)
 
   auto target = cudf::string_scalar(skewed_string_target_substring);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = col->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   state.add_global_memory_writes<nvbench::int8_t>(input.size());

--- a/cpp/benchmarks/string/find_instance.cpp
+++ b/cpp/benchmarks/string/find_instance.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@ static void bench_find_string(nvbench::state& state)
   auto const input  = cudf::strings_column_view(column->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.add_global_memory_reads<nvbench::int8_t>(column->alloc_size());
   state.add_global_memory_writes<nvbench::int32_t>(input.size());
 

--- a/cpp/benchmarks/string/find_multiple.cpp
+++ b/cpp/benchmarks/string/find_multiple.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ static void bench_find_string(nvbench::state& state)
   }
   cudf::test::strings_column_wrapper targets(h_targets.begin(), h_targets.end());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = col->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   if (api == "find") {

--- a/cpp/benchmarks/string/intcast.cpp
+++ b/cpp/benchmarks/string/intcast.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ void bench_intcast(nvbench::state& state)
   auto const numbers   = cudf::strings::cast_to_integer(sv, data_type, endian);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   if (from_num) {

--- a/cpp/benchmarks/string/join_strings.cpp
+++ b/cpp/benchmarks/string/join_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@ static void bench_join(nvbench::state& state)
   std::string_view separator(":");
   std::string_view narep("null");
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto const data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/string/lengths.cpp
+++ b/cpp/benchmarks/string/lengths.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ static void bench_lengths(nvbench::state& state)
     create_random_table({cudf::type_id::STRING}, row_count{num_rows}, table_profile);
   cudf::strings_column_view input(table->view().column(0));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;

--- a/cpp/benchmarks/string/like.cpp
+++ b/cpp/benchmarks/string/like.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,7 +39,7 @@ static void bench_like(nvbench::state& state)
   auto input   = cudf::strings_column_view(col->view());
   auto pattern = std::string_view(patterns[ptn_idx]);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto const data_size = col->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;

--- a/cpp/benchmarks/string/make_strings_column.cu
+++ b/cpp/benchmarks/string/make_strings_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,8 +27,7 @@ using string_index_pair = cuda::std::pair<char const*, cudf::size_type>;
 
 template <bool batch_construction>
 std::vector<std::unique_ptr<cudf::column>> make_strings_columns(
-  std::vector<cudf::device_span<string_index_pair const>> const& input,
-  rmm::cuda_stream_view stream)
+  std::vector<cudf::device_span<string_index_pair const>> const& input, cuda::stream_ref stream)
 {
   if constexpr (batch_construction) {
     return cudf::make_strings_column_batch(input, stream);
@@ -77,7 +76,7 @@ static void BM_make_strings_column_batch(nvbench::state& state)
     input.emplace_back(input_data.back());
   }
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     [[maybe_unused]] auto const output = make_strings_columns<true>(input, stream);
   });

--- a/cpp/benchmarks/string/repeat_strings.cpp
+++ b/cpp/benchmarks/string/repeat_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,7 +30,7 @@ static void bench_repeat(nvbench::state& state)
   auto const input = cudf::strings_column_view(table->view().column(0));
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
 

--- a/cpp/benchmarks/string/replace.cpp
+++ b/cpp/benchmarks/string/replace.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -33,7 +33,7 @@ static void bench_replace(nvbench::state& state)
   cudf::strings_column_view input(column->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   state.add_global_memory_writes<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/string/reverse.cpp
+++ b/cpp/benchmarks/string/reverse.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,7 +24,7 @@ static void bench_reverse(nvbench::state& state)
     create_random_table({cudf::type_id::STRING}, row_count{num_rows}, table_profile);
   cudf::strings_column_view input(table->view().column(0));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto const data_size = table->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;

--- a/cpp/benchmarks/string/slice.cpp
+++ b/cpp/benchmarks/string/slice.cpp
@@ -38,7 +38,7 @@ static void bench_slice(nvbench::state& state)
     cudf::test::fixed_width_column_wrapper<cudf::size_type>(stops_itr, stops_itr + num_rows);
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   // gather some throughput statistics as well
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read

--- a/cpp/benchmarks/string/split.cpp
+++ b/cpp/benchmarks/string/split.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -28,7 +28,7 @@ static void bench_split(nvbench::state& state)
   cudf::strings_column_view input(column->view());
   cudf::string_scalar target("+");
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;

--- a/cpp/benchmarks/string/split_re.cpp
+++ b/cpp/benchmarks/string/split_re.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ static void bench_split_re(nvbench::state& state)
   auto const column = create_random_column(cudf::type_id::STRING, row_count{num_rows}, profile);
   cudf::strings_column_view input(column->view());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   // gather some throughput statistics as well
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;

--- a/cpp/benchmarks/string/translate.cpp
+++ b/cpp/benchmarks/string/translate.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -38,7 +38,7 @@ static void bench_translate(nvbench::state& state)
                  [](auto idx) -> entry_type { return entry_type{'!' + idx, '~' - idx}; });
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
   state.add_global_memory_writes<nvbench::int8_t>(data_size);

--- a/cpp/benchmarks/string/url_decode.cu
+++ b/cpp/benchmarks/string/url_decode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -65,7 +65,7 @@ static void bench_url_decode(nvbench::state& state)
   auto input  = cudf::strings_column_view(column->view());
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto const data_size = column->alloc_size();
   state.add_global_memory_reads<nvbench::int8_t>(data_size);
 

--- a/cpp/benchmarks/text/deduplicate.cpp
+++ b/cpp/benchmarks/text/deduplicate.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@ static void bench_suffix_array(nvbench::state& state)
     create_random_table({cudf::type_id::STRING}, row_count{num_rows}, strings_profile);
   cudf::strings_column_view input(strings_table->view().column(0));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);
@@ -55,7 +55,7 @@ static void bench_resolve_duplicates(nvbench::state& state)
   cudf::strings_column_view input2(strings_table->view().column(1));
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto sa1 = nvtext::build_suffix_array(input1, 0);
   auto sa2 = nvtext::build_suffix_array(input2, 0);

--- a/cpp/benchmarks/text/edit_distance.cpp
+++ b/cpp/benchmarks/text/edit_distance.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_edit_distance_utf8(nvbench::state& state)
   auto sv1    = cudf::strings_column_view(input1.view());
   auto sv2    = cudf::strings_column_view(input2.view());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   state.add_global_memory_reads<nvbench::int8_t>(input1.alloc_size() + input2.alloc_size());
   // output are integers (one per row)
@@ -98,7 +98,7 @@ static void bench_edit_distance_ascii(nvbench::state& state)
                                   0,
                                   {offsets->view()});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto sv1          = cudf::strings_column_view(input1);
   auto sv2          = cudf::strings_column_view(input2);

--- a/cpp/benchmarks/text/hash_ngrams.cpp
+++ b/cpp/benchmarks/text/hash_ngrams.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ static void bench_hash_ngrams(nvbench::state& state)
     create_random_table({cudf::type_id::STRING}, row_count{num_rows}, strings_profile);
   cudf::strings_column_view input(strings_table->view().column(0));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/jaccard.cpp
+++ b/cpp/benchmarks/text/jaccard.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_jaccard(nvbench::state& state)
   cudf::strings_column_view input2(input_table->view().column(1));
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto chars_size = input1.chars_size(stream) + input2.chars_size(stream);
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/minhash.cpp
+++ b/cpp/benchmarks/text/minhash.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ static void bench_minhash(nvbench::state& state)
   auto const parameters_a = param_table->view().column(0);
   auto const parameters_b = param_table->view().column(1);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/ngrams.cpp
+++ b/cpp/benchmarks/text/ngrams.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@ static void bench_ngrams(nvbench::state& state)
   cudf::strings_column_view input(column->view());
   auto const separator = cudf::string_scalar("_");
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/normalize.cpp
+++ b/cpp/benchmarks/text/normalize.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@ static void bench_normalize(nvbench::state& state)
   auto const column = create_random_column(cudf::type_id::STRING, row_count{num_rows}, profile);
   cudf::strings_column_view input(column->view());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/replace.cpp
+++ b/cpp/benchmarks/text/replace.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -41,7 +41,7 @@ static void bench_replace(nvbench::state& state)
   cudf::test::strings_column_wrapper targets({"one", "two", "sevén", "zero"});
   cudf::test::strings_column_wrapper replacements({"1", "2", "7", "0"});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = view.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/subword.cpp
+++ b/cpp/benchmarks/text/subword.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ static void bench_wordpiece_tokenizer(nvbench::state& state)
     cudf::test::strings_column_wrapper({"", "[UNK]", "This", "is", "a", "test"});
   auto const vocab = nvtext::load_wordpiece_vocabulary(cudf::strings_column_view(vocabulary));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);
   auto out_size = num_rows * (max_words > 0 ? std::min(max_words, num_words) : num_words);

--- a/cpp/benchmarks/text/tokenize.cpp
+++ b/cpp/benchmarks/text/tokenize.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -31,7 +31,7 @@ static void bench_tokenize(nvbench::state& state)
   auto const column = create_random_column(cudf::type_id::STRING, row_count{num_rows}, profile);
   cudf::strings_column_view input(column->view());
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
 
   auto chars_size = input.chars_size(cudf::get_default_stream());
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/text/vocab.cpp
+++ b/cpp/benchmarks/text/vocab.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -56,7 +56,7 @@ static void bench_vocab_tokenize(nvbench::state& state)
     return static_cast<cudf::scalar_type_t<cudf::size_type>*>(count.get())->value(stream);
   }();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   auto chars_size =
     input.chars_size(stream) + cudf::strings_column_view(vocab_col->view()).chars_size(stream);
   state.add_global_memory_reads<nvbench::int8_t>(chars_size);

--- a/cpp/benchmarks/transform/encode.cpp
+++ b/cpp/benchmarks/transform/encode.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 
@@ -37,7 +37,7 @@ static void bench_encode(nvbench::state& state, nvbench::type_list<DataType>)
   state.add_global_memory_reads<uint8_t>(alloc_size);
   state.add_global_memory_writes<cudf::size_type>(num_rows);
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
 

--- a/cpp/benchmarks/transform/encode.cpp
+++ b/cpp/benchmarks/transform/encode.cpp
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 

--- a/cpp/benchmarks/transform/encode.cpp
+++ b/cpp/benchmarks/transform/encode.cpp
@@ -14,7 +14,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-
 #include <nvbench/nvbench.cuh>
 
 template <typename DataType>

--- a/cpp/benchmarks/transform/transform.cpp
+++ b/cpp/benchmarks/transform/transform.cpp
@@ -16,9 +16,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/transform/transform.cpp
+++ b/cpp/benchmarks/transform/transform.cpp
@@ -17,7 +17,6 @@
 #include <cudf/utilities/error.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
 
 #include <nvbench/nvbench.cuh>
 #include <nvbench/types.cuh>

--- a/cpp/benchmarks/transpose/transpose.cpp
+++ b/cpp/benchmarks/transpose/transpose.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -31,7 +31,7 @@ void bench_transpose(nvbench::state& state)
   auto input       = input_table.view();
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   // Collect memory statistics.
   auto const bytes_read = static_cast<uint64_t>(input.num_columns()) * input.num_rows() *

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -192,7 +192,7 @@ void type_dispatcher_benchmark(nvbench::state& state)
   }
 
   auto stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
 
   auto const data_size = source_size * n_cols * 2 * sizeof(TypeParam);
   state.add_global_memory_reads<nvbench::int8_t>(data_size);

--- a/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
+++ b/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
@@ -114,7 +114,7 @@ prefixed with an underscore.
 
 ```c++
 template <typename IteratorType>
-void algorithm_function(int x, rmm::cuda_stream_view s, rmm::device_async_resource_ref mr)
+void algorithm_function(int x, cuda::stream_ref s, rmm::device_async_resource_ref mr)
 {
   ...
 }
@@ -379,7 +379,7 @@ following function that copies device data to a host `std::vector`.
 
 ```c++
 template <typename T>
-std::vector<T> make_std_vector_async(device_span<T const> v, rmm::cuda_stream_view stream)
+std::vector<T> make_std_vector_async(device_span<T const> v, cuda::stream_ref stream)
 ```
 
 ### When to use `host_span` vs `std::span`
@@ -560,7 +560,7 @@ libcudf throws under different circumstances, see the [section on error handling
 libcudf is in the process of adding support for asynchronous execution using
 CUDA streams. In order to facilitate the usage of streams, all new libcudf APIs
 that allocate device memory or execute a kernel should accept an
-`rmm::cuda_stream_view` parameter at the end with a default value of
+`cuda::stream_ref` parameter at the end with a default value of
 `cudf::get_default_stream()`.  There is one exception to this rule: if the API
 also accepts a memory resource parameter, the stream parameter should be placed
 just *before* the memory resource. This API should then forward the call to a
@@ -579,18 +579,18 @@ For example:
 ```c++
 // cpp/include/cudf/header.hpp
 void external_function(...,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 // cpp/include/cudf/detail/header.hpp
 namespace detail{
-void external_function(..., rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+void external_function(..., cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 } // namespace detail
 
 // cudf/src/implementation.cpp
 namespace detail{
 // Use the stream parameter in the detail implementation.
-void external_function(..., rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr){
+void external_function(..., cuda::stream_ref stream, rmm::device_async_resource_ref mr){
   // Implementation uses the stream with async APIs.
   rmm::device_buffer buff(..., stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(...,stream.value()));
@@ -599,7 +599,7 @@ void external_function(..., rmm::cuda_stream_view stream, rmm::device_async_reso
 }
 } // namespace detail
 
-void external_function(..., rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+void external_function(..., cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE(); // Generates an NVTX range for the lifetime of this function.
   detail::external_function(..., stream, mr);
@@ -800,7 +800,7 @@ Similar to a `device_vector`, allocates a contiguous set of elements in device m
 differences:
 - As an optimization, elements are uninitialized and no synchronization occurs at construction.
 This limits the types `T` to trivially copyable types.
-- All operations are stream ordered (i.e., they accept a `cuda_stream_view` specifying the stream
+- All operations are stream ordered (i.e., they accept a `cuda::stream_ref` specifying the stream
 on which the operation is performed). This improves safety when using non-default streams.
 - `device_uvector.hpp` does not include any `__device__` code, unlike `thrust/device_vector.hpp`,
   which means `device_uvector`s can be used in `.cpp` files, rather than just in `.cu` files.

--- a/cpp/doxygen/developer_guide/DOCUMENTATION.md
+++ b/cpp/doxygen/developer_guide/DOCUMENTATION.md
@@ -214,7 +214,7 @@ Also, \@copydoc is useful when documenting a `detail` function that differs only
      */
     std::vector<size_type> segmented_count_set_bits(bitmask_type const* bitmask,
                                                     std::vector<size_type> const& indices,
-                                                    rmm::cuda_stream_view stream = cudf::get_default_stream());
+                                                    cuda::stream_ref stream = cudf::get_default_stream());
 
 Note, you must specify the whole signature of the function, including optional parameters, so that doxygen will be able to locate it.
 

--- a/cpp/examples/billion_rows/brc.cpp
+++ b/cpp/examples/billion_rows/brc.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -71,7 +71,7 @@ int main(int argc, char const** argv)
   //
   // result      = cudf::sort_by_key(result->view(), result->view().select({0}), {}, {}, stream);
 
-  stream.synchronize();
+  stream.sync();
 
   elapsed = std::chrono::steady_clock::now() - start;
   std::cout << "Number of keys: " << result->num_rows() << std::endl;

--- a/cpp/examples/billion_rows/brc_chunks.cpp
+++ b/cpp/examples/billion_rows/brc_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -25,7 +25,7 @@ using elapsed_t = std::chrono::duration<double>;
 std::unique_ptr<cudf::table> load_chunk(std::string const& input_file,
                                         std::size_t start,
                                         std::size_t size,
-                                        rmm::cuda_stream_view stream)
+                                        cuda::stream_ref stream)
 {
   cudf::io::csv_reader_options in_opts =
     cudf::io::csv_reader_options::builder(cudf::io::source_info{input_file})
@@ -93,7 +93,7 @@ int main(int argc, char const** argv)
 
   // now aggregate the aggregate results
   auto results = compute_final_aggregates(agg_data, stream);
-  stream.synchronize();
+  stream.sync();
 
   elapsed_t elapsed = std::chrono::steady_clock::now() - start;
   std::cout << "Number of keys: " << results->num_rows() << std::endl;

--- a/cpp/examples/billion_rows/brc_pipeline.cpp
+++ b/cpp/examples/billion_rows/brc_pipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -29,7 +29,7 @@ using result_t   = std::unique_ptr<cudf::table>;
 std::unique_ptr<cudf::table> load_chunk(std::string const& input_file,
                                         std::size_t start,
                                         std::size_t size,
-                                        rmm::cuda_stream_view stream)
+                                        cuda::stream_ref stream)
 {
   cudf::io::csv_reader_options in_opts =
     cudf::io::csv_reader_options::builder(cudf::io::source_info{input_file})
@@ -47,7 +47,7 @@ std::unique_ptr<cudf::table> load_chunk(std::string const& input_file,
 struct chunk_fn {
   std::string input_file;
   std::vector<result_t>& agg_data;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   std::vector<byte_range> byte_ranges{};
   bool first_range{};
@@ -137,7 +137,7 @@ int main(int argc, char const** argv)
   }
 
   // in case some kernels are still running on the default stream
-  stream.synchronize();
+  stream.sync();
 
   // combine each thread's agg data into a single vector
   std::vector<result_t> agg_data(divider);
@@ -149,7 +149,7 @@ int main(int argc, char const** argv)
 
   // now aggregate the aggregate results
   auto results = compute_final_aggregates(agg_data, stream);
-  stream.synchronize();
+  stream.sync();
 
   elapsed_t elapsed = std::chrono::steady_clock::now() - start;
   std::cout << "Number of keys: " << results->num_rows() << std::endl;

--- a/cpp/examples/billion_rows/groupby_results.cpp
+++ b/cpp/examples/billion_rows/groupby_results.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::table> compute_results(
   cudf::column_view const& cities,
   cudf::column_view const& temperatures,
   std::vector<std::unique_ptr<cudf::groupby_aggregation>>&& aggregations,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto groupby_obj      = cudf::groupby::groupby(cudf::table_view({cities}));
   auto aggregation_reqs = std::vector<cudf::groupby::aggregation_request>{};
@@ -37,7 +37,7 @@ std::unique_ptr<cudf::table> compute_results(
 }
 
 std::unique_ptr<cudf::table> compute_final_aggregates(
-  std::vector<std::unique_ptr<cudf::table>>& agg_data, rmm::cuda_stream_view stream)
+  std::vector<std::unique_ptr<cudf::table>>& agg_data, cuda::stream_ref stream)
 {
   // first combine all the results into a vectors of columns
   std::vector<cudf::column_view> min_cols, max_cols, sum_cols, count_cols;

--- a/cpp/examples/billion_rows/groupby_results.hpp
+++ b/cpp/examples/billion_rows/groupby_results.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <vector>
 
@@ -30,7 +30,7 @@ std::unique_ptr<cudf::table> compute_results(
   cudf::column_view const& cities,
   cudf::column_view const& temperatures,
   std::vector<std::unique_ptr<cudf::groupby_aggregation>>&& aggregations,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Produce the final aggregations from sub-aggregate results
@@ -41,4 +41,4 @@ std::unique_ptr<cudf::table> compute_results(
  */
 std::unique_ptr<cudf::table> compute_final_aggregates(
   std::vector<std::unique_ptr<cudf::table>>& agg_data,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());

--- a/cpp/examples/billion_rows/groupby_results.hpp
+++ b/cpp/examples/billion_rows/groupby_results.hpp
@@ -10,7 +10,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <vector>
 

--- a/cpp/examples/hybrid_scan_io/common_utils.cpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,12 +9,12 @@
 #include <cudf/table/equality.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <filesystem>
 #include <string>
@@ -66,7 +66,7 @@ std::unique_ptr<cudf::table> combine_tables(std::unique_ptr<cudf::table> filter_
 
 void check_tables_equal(cudf::table_view const& lhs_table,
                         cudf::table_view const& rhs_table,
-                        rmm::cuda_stream_view stream)
+                        cuda::stream_ref stream)
 {
   auto const tables_equal =
     cudf::tables_equal(lhs_table, rhs_table, cudf::null_equality::EQUAL, stream);
@@ -78,7 +78,7 @@ std::vector<io_source> extract_input_sources(std::string const& paths,
                                              int32_t input_multiplier,
                                              int32_t thread_count,
                                              io_source_type io_source_type,
-                                             rmm::cuda_stream_view stream)
+                                             cuda::stream_ref stream)
 {
   // Get the delimited paths to directory and/or files.
   std::vector<std::string> const delimited_paths = [&]() {
@@ -147,6 +147,6 @@ std::vector<io_source> extract_input_sources(std::string const& paths,
     parquet_files.end(),
     std::back_inserter(input_sources),
     [&](auto const& file_name) { return io_source{file_name, io_source_type, stream}; });
-  stream.synchronize();
+  stream.sync();
   return input_sources;
 }

--- a/cpp/examples/hybrid_scan_io/common_utils.cpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.cpp
@@ -14,7 +14,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <filesystem>
 #include <string>

--- a/cpp/examples/hybrid_scan_io/common_utils.hpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,12 +13,12 @@
 #include <cudf/io/types.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <string>
 #include <vector>
@@ -74,7 +74,7 @@ std::unique_ptr<cudf::table> combine_tables(std::unique_ptr<cudf::table> filter_
  */
 void check_tables_equal(cudf::table_view const& lhs_table,
                         cudf::table_view const& rhs_table,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream());
+                        cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Function to process comma delimited input paths string to parquet files and/or dirs
@@ -97,4 +97,4 @@ void check_tables_equal(cudf::table_view const& lhs_table,
                                                            int32_t input_multiplier,
                                                            int32_t thread_count,
                                                            io_source_type io_source_type,
-                                                           rmm::cuda_stream_view stream);
+                                                           cuda::stream_ref stream);

--- a/cpp/examples/hybrid_scan_io/common_utils.hpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.hpp
@@ -18,7 +18,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <string>
 #include <vector>

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_composer.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_composer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -102,7 +102,7 @@ std::vector<cudf::size_type> apply_row_group_filters(
   cudf::host_span<cudf::size_type> input_row_group_indices,
   cudf::io::parquet_reader_options const& options,
   bool verbose,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   // Span to track current row group indices
   auto current_row_group_indices = cudf::host_span<cudf::size_type>(input_row_group_indices);
@@ -226,7 +226,7 @@ std::unique_ptr<cudf::table> single_step_materialize(
   cudf::host_span<cudf::size_type> current_row_group_indices,
   cudf::io::parquet_reader_options const& options,
   bool verbose,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (verbose) { std::cout << "READER: Single step materialize...\n"; }
@@ -273,7 +273,7 @@ std::unique_ptr<cudf::table> two_step_materialize(
   cudf::host_span<cudf::size_type> current_row_group_indices,
   cudf::io::parquet_reader_options const& options,
   bool verbose,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Check whether to prune filter column data pages
@@ -379,7 +379,7 @@ std::unique_ptr<cudf::table> hybrid_scan(
   std::optional<cudf::ast::operation const> filter_expression,
   std::unordered_set<hybrid_scan_filter_type> const& filters,
   bool verbose,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -434,7 +434,7 @@ std::unique_ptr<cudf::table> inline hybrid_scan(
   std::optional<cudf::ast::operation const> filter_expression,
   std::unordered_set<hybrid_scan_filter_type> const& filters,
   bool verbose,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   static_assert(single_step_read or use_page_index,
@@ -449,7 +449,7 @@ template std::unique_ptr<cudf::table> hybrid_scan<true, false>(
   std::optional<cudf::ast::operation const>,
   std::unordered_set<hybrid_scan_filter_type> const&,
   bool,
-  rmm::cuda_stream_view,
+  cuda::stream_ref,
   rmm::device_async_resource_ref);
 
 template std::unique_ptr<cudf::table> hybrid_scan<true, true>(
@@ -457,7 +457,7 @@ template std::unique_ptr<cudf::table> hybrid_scan<true, true>(
   std::optional<cudf::ast::operation const>,
   std::unordered_set<hybrid_scan_filter_type> const&,
   bool,
-  rmm::cuda_stream_view,
+  cuda::stream_ref,
   rmm::device_async_resource_ref);
 
 template std::unique_ptr<cudf::table> hybrid_scan<false, true>(
@@ -465,5 +465,5 @@ template std::unique_ptr<cudf::table> hybrid_scan<false, true>(
   std::optional<cudf::ast::operation const>,
   std::unordered_set<hybrid_scan_filter_type> const&,
   bool,
-  rmm::cuda_stream_view,
+  cuda::stream_ref,
   rmm::device_async_resource_ref);

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_composer.hpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_composer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <thread>
@@ -55,7 +54,7 @@ std::unique_ptr<cudf::table> hybrid_scan(
   std::optional<cudf::ast::operation const> filter_expression,
   std::unordered_set<hybrid_scan_filter_type> const& filters,
   bool verbose,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 /**

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_composer.hpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_composer.hpp
@@ -15,7 +15,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <thread>

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_io.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_io.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ namespace {
  */
 cudf::io::table_with_metadata read_parquet(io_source const& io_source,
                                            cudf::ast::operation const& filter_expression,
-                                           rmm::cuda_stream_view stream)
+                                           cuda::stream_ref stream)
 {
   auto source_info = io_source.get_source_info();
   auto options =
@@ -117,7 +117,7 @@ int main(int argc, char const** argv)
   // Create filter expression
   auto const column_reference = cudf::ast::column_name_reference(column_name);
   auto scalar                 = cudf::string_scalar(literal_value, true, stream);
-  stream.synchronize();
+  stream.sync();
   auto literal = cudf::ast::literal(scalar);
   auto filter_expression =
     cudf::ast::operation(cudf::ast::ast_operator::EQUAL, column_reference, literal);

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_two_step.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_two_step.cpp
@@ -157,7 +157,7 @@ int main(int argc, char const** argv)
   // Create filter expressions (one per thread; reused circularly if needed)
   auto const column_reference = cudf::ast::column_name_reference(column_name);
   auto scalar                 = cudf::string_scalar(literal_value, true, default_stream);
-  default_stream.synchronize();
+  default_stream.sync();
   auto literal = cudf::ast::literal(scalar);
 
   std::vector<cudf::ast::operation> filter_expressions;

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_pipeline.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_pipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,7 +70,7 @@ enum class split_strategy : uint8_t {
  * @return Unique pointer to the resultant concatenated table.
  */
 std::unique_ptr<cudf::table> concatenate_tables(std::vector<std::unique_ptr<cudf::table>> tables,
-                                                rmm::cuda_stream_view stream)
+                                                cuda::stream_ref stream)
 {
   if (tables.size() == 1) { return std::move(tables[0]); }
 
@@ -89,7 +89,7 @@ std::unique_ptr<cudf::table> concatenate_tables(std::vector<std::unique_ptr<cudf
  * @param io_source io source to read
  * @return cudf::io::table_with_metadata
  */
-cudf::io::table_with_metadata read_parquet(io_source const& io_source, rmm::cuda_stream_view stream)
+cudf::io::table_with_metadata read_parquet(io_source const& io_source, cuda::stream_ref stream)
 {
   auto source_info = io_source.get_source_info();
   auto options     = cudf::io::parquet_reader_options::builder(source_info).build();
@@ -103,7 +103,7 @@ struct hybrid_scan_fn {
   cudf::host_span<cudf::size_type const> row_groups_indices;
   bool use_page_index;
   cudf::io::parquet_reader_options const& options;
-  rmm::cuda_stream_view const stream;
+  cuda::stream_ref const stream;
   rmm::device_async_resource_ref const mr;
   void operator()() const
   {

--- a/cpp/examples/hybrid_scan_io/io_source.cpp
+++ b/cpp/examples/hybrid_scan_io/io_source.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,9 +8,9 @@
 #include <cudf/io/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 #include <filesystem>
@@ -41,7 +41,7 @@ io_source_type get_io_source_type(std::string name)
   }
 }
 
-io_source::io_source(std::string_view file_path, io_source_type type, rmm::cuda_stream_view stream)
+io_source::io_source(std::string_view file_path, io_source_type type, cuda::stream_ref stream)
   : pinned_buffer({pinned_memory_resource(), stream}), d_buffer{0, stream}
 {
   std::string const file_name{file_path};
@@ -76,7 +76,7 @@ io_source::io_source(std::string_view file_path, io_source_type type, rmm::cuda_
       file.read(h_buffer.data(), file_size);
       d_buffer.resize(file_size, stream);
       CUDF_CUDA_TRY(cudaMemcpyAsync(
-        d_buffer.data(), h_buffer.data(), file_size, cudaMemcpyDefault, stream.value()));
+        d_buffer.data(), h_buffer.data(), file_size, cudaMemcpyDefault, stream.get()));
 
       source_info = cudf::io::source_info(d_buffer);
       break;

--- a/cpp/examples/hybrid_scan_io/io_source.cpp
+++ b/cpp/examples/hybrid_scan_io/io_source.cpp
@@ -10,7 +10,7 @@
 
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 
 #include <filesystem>

--- a/cpp/examples/hybrid_scan_io/io_source.hpp
+++ b/cpp/examples/hybrid_scan_io/io_source.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,10 +7,10 @@
 
 #include <cudf/io/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 #include <string>
@@ -46,7 +46,7 @@ rmm::host_async_resource_ref pinned_memory_resource();
  */
 template <typename T>
 struct pinned_allocator : public std::allocator<T> {
-  pinned_allocator(rmm::host_async_resource_ref _mr, rmm::cuda_stream_view _stream)
+  pinned_allocator(rmm::host_async_resource_ref _mr, cuda::stream_ref _stream)
     : mr{_mr}, stream{_stream}
   {
   }
@@ -54,7 +54,7 @@ struct pinned_allocator : public std::allocator<T> {
   T* allocate(std::size_t n)
   {
     auto ptr = mr.allocate(stream, n * sizeof(T), alignof(T));
-    stream.synchronize();
+    stream.sync();
     return static_cast<T*>(ptr);
   }
 
@@ -65,7 +65,7 @@ struct pinned_allocator : public std::allocator<T> {
 
  private:
   rmm::host_async_resource_ref mr;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 };
 
 /**
@@ -74,7 +74,7 @@ struct pinned_allocator : public std::allocator<T> {
  */
 class io_source {
  public:
-  io_source(std::string_view file_path, io_source_type io_type, rmm::cuda_stream_view stream);
+  io_source(std::string_view file_path, io_source_type io_type, cuda::stream_ref stream);
 
   // Get the internal source info
   [[nodiscard]] cudf::io::source_info get_source_info() const { return source_info; }

--- a/cpp/examples/hybrid_scan_io/io_source.hpp
+++ b/cpp/examples/hybrid_scan_io/io_source.hpp
@@ -10,7 +10,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 
 #include <string>

--- a/cpp/examples/hybrid_scan_io/io_utils.cpp
+++ b/cpp/examples/hybrid_scan_io/io_utils.cpp
@@ -7,8 +7,9 @@
 #include <cudf/io/parquet_io_utils.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 /**
  * @file io_utils.cpp
@@ -33,7 +34,7 @@ std::tuple<std::vector<rmm::device_buffer>,
            std::future<void>>
 fetch_byte_ranges_async(cudf::io::datasource& datasource,
                         cudf::host_span<cudf::io::text::byte_range_info const> byte_ranges,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr)
 {
   // Using libcudf utility but may have custom implementation in the future

--- a/cpp/examples/hybrid_scan_io/io_utils.cpp
+++ b/cpp/examples/hybrid_scan_io/io_utils.cpp
@@ -9,7 +9,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file io_utils.cpp

--- a/cpp/examples/hybrid_scan_io/io_utils.hpp
+++ b/cpp/examples/hybrid_scan_io/io_utils.hpp
@@ -8,9 +8,10 @@
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <future>
 #include <tuple>
@@ -55,5 +56,5 @@ std::tuple<std::vector<rmm::device_buffer>,
            std::future<void>>
 fetch_byte_ranges_async(cudf::io::datasource& datasource,
                         cudf::host_span<cudf::io::text::byte_range_info const> byte_ranges,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         rmm::device_async_resource_ref mr);

--- a/cpp/examples/hybrid_scan_io/io_utils.hpp
+++ b/cpp/examples/hybrid_scan_io/io_utils.hpp
@@ -11,7 +11,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <future>
 #include <tuple>

--- a/cpp/examples/parquet_inspect/parquet_inspect.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <filesystem>
 #include <iostream>
@@ -90,7 +90,7 @@ int main(int argc, char const** argv)
     write_page_metadata(metadata, output_filepath, stream);
   }
 
-  stream.synchronize();
+  stream.sync();
 
   return 0;
 }

--- a/cpp/examples/parquet_inspect/parquet_inspect.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect.cpp
@@ -8,7 +8,6 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
-#include <cuda/stream_ref>
 
 #include <filesystem>
 #include <iostream>

--- a/cpp/examples/parquet_inspect/parquet_inspect.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect.cpp
@@ -8,7 +8,6 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
-
 #include <filesystem>
 #include <iostream>
 #include <string>

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
@@ -22,7 +22,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <filesystem>
 #include <fstream>

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,13 +16,13 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <filesystem>
 #include <fstream>
@@ -40,9 +40,7 @@ namespace {
  * given column index
  */
 [[nodiscard]] auto compute_page_row_counts_and_offsets(
-  cudf::io::parquet::FileMetaData const& metadata,
-  cudf::size_type col_idx,
-  rmm::cuda_stream_view stream)
+  cudf::io::parquet::FileMetaData const& metadata, cudf::size_type col_idx, cuda::stream_ref stream)
 {
   auto const num_colchunks = metadata.row_groups.front().columns.size();
 
@@ -116,7 +114,7 @@ namespace {
  *
  * @return A unique pointer to a column
  */
-auto make_index_column(cudf::size_type num_rows, rmm::cuda_stream_view stream)
+auto make_index_column(cudf::size_type num_rows, cuda::stream_ref stream)
 {
   std::vector<cudf::size_type> data(num_rows);
   std::iota(data.begin(), data.end(), 0);
@@ -138,7 +136,7 @@ auto make_index_column(cudf::size_type num_rows, rmm::cuda_stream_view stream)
  * @return A unique pointer to a column
  */
 template <typename T>
-auto make_column(cudf::host_span<T const> host_data, rmm::cuda_stream_view stream)
+auto make_column(cudf::host_span<T const> host_data, cuda::stream_ref stream)
 {
   auto device_buffer = rmm::device_buffer(host_data.data(), host_data.size() * sizeof(T), stream);
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<T>()},
@@ -165,7 +163,7 @@ auto make_page_data_list_column(cudf::host_span<T const> data,
                                 cudf::host_span<cudf::size_type const> col_page_offsets,
                                 cudf::size_type num_row_groups,
                                 cudf::size_type num_pages_this_column,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   CUDF_EXPECTS(col_page_offsets.size() == num_row_groups + 1,
                "Mismatch between offsets and number of row groups");
@@ -237,7 +235,7 @@ std::tuple<cudf::io::parquet::FileMetaData, bool> read_parquet_file_metadata(
 
 void write_rowgroup_metadata(cudf::io::parquet::FileMetaData const& metadata,
                              std::string const& output_filepath,
-                             rmm::cuda_stream_view stream)
+                             cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
 
@@ -318,7 +316,7 @@ void write_rowgroup_metadata(cudf::io::parquet::FileMetaData const& metadata,
 
 void write_page_metadata(cudf::io::parquet::FileMetaData const& metadata,
                          std::string const& output_filepath,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   CUDF_FUNC_RANGE();
 
@@ -349,7 +347,7 @@ void write_page_metadata(cudf::io::parquet::FileMetaData const& metadata,
       columns.emplace_back(make_page_data_list_column<int64_t>(
         page_byte_offsets, col_page_offsets, num_row_groups, num_pages_this_column, stream));
 
-      stream.synchronize();
+      stream.sync();
     });
 
   CUDF_EXPECTS(columns.size() == (num_columns * output_cols_per_column) + 1,

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,12 +9,12 @@
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 /**
  * @file parquet_inspect_utils.hpp
@@ -49,7 +49,7 @@ std::tuple<cudf::io::parquet::FileMetaData, bool> read_parquet_file_metadata(
  */
 void write_rowgroup_metadata(cudf::io::parquet::FileMetaData const& metadata,
                              std::string const& output_filepath,
-                             rmm::cuda_stream_view stream);
+                             cuda::stream_ref stream);
 
 /**
  * @brief Writes page metadata to a parquet file
@@ -60,4 +60,4 @@ void write_rowgroup_metadata(cudf::io::parquet::FileMetaData const& metadata,
  */
 void write_page_metadata(cudf::io::parquet::FileMetaData const& metadata,
                          std::string const& output_filepath,
-                         rmm::cuda_stream_view stream);
+                         cuda::stream_ref stream);

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
@@ -14,7 +14,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file parquet_inspect_utils.hpp

--- a/cpp/examples/parquet_io/common_utils.cpp
+++ b/cpp/examples/parquet_io/common_utils.cpp
@@ -14,7 +14,7 @@
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <chrono>
 #include <iomanip>

--- a/cpp/examples/parquet_io/common_utils.cpp
+++ b/cpp/examples/parquet_io/common_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,10 +10,11 @@
 #include <cudf/table/equality.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+
+#include <cuda/stream_ref>
 
 #include <chrono>
 #include <iomanip>
@@ -85,7 +86,7 @@ bool get_boolean(std::string input)
 
 void check_tables_equal(cudf::table_view const& lhs_table,
                         cudf::table_view const& rhs_table,
-                        rmm::cuda_stream_view stream)
+                        cuda::stream_ref stream)
 {
   auto const tables_equal =
     cudf::tables_equal(lhs_table, rhs_table, cudf::null_equality::EQUAL, stream);
@@ -94,7 +95,7 @@ void check_tables_equal(cudf::table_view const& lhs_table,
 }
 
 std::unique_ptr<cudf::table> concatenate_tables(std::vector<std::unique_ptr<cudf::table>> tables,
-                                                rmm::cuda_stream_view stream)
+                                                cuda::stream_ref stream)
 {
   if (tables.size() == 1) { return std::move(tables[0]); }
 

--- a/cpp/examples/parquet_io/common_utils.hpp
+++ b/cpp/examples/parquet_io/common_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,12 +8,12 @@
 #include <cudf/io/types.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <string>
 
@@ -64,7 +64,7 @@ cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool 
  */
 void check_tables_equal(cudf::table_view const& lhs_table,
                         cudf::table_view const& rhs_table,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream());
+                        cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Concatenate a vector of tables and return the resultant table
@@ -75,7 +75,7 @@ void check_tables_equal(cudf::table_view const& lhs_table,
  * @return Unique pointer to the resultant concatenated table.
  */
 std::unique_ptr<cudf::table> concatenate_tables(std::vector<std::unique_ptr<cudf::table>> tables,
-                                                rmm::cuda_stream_view stream);
+                                                cuda::stream_ref stream);
 
 /**
  * @brief Returns a string containing current date and time

--- a/cpp/examples/parquet_io/common_utils.hpp
+++ b/cpp/examples/parquet_io/common_utils.hpp
@@ -13,7 +13,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <string>
 

--- a/cpp/examples/parquet_io/io_source.cpp
+++ b/cpp/examples/parquet_io/io_source.cpp
@@ -10,7 +10,7 @@
 
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 
 #include <filesystem>

--- a/cpp/examples/parquet_io/io_source.cpp
+++ b/cpp/examples/parquet_io/io_source.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,9 +8,9 @@
 #include <cudf/io/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 #include <filesystem>
@@ -41,7 +41,7 @@ io_source_type get_io_source_type(std::string name)
   }
 }
 
-io_source::io_source(std::string_view file_path, io_source_type type, rmm::cuda_stream_view stream)
+io_source::io_source(std::string_view file_path, io_source_type type, cuda::stream_ref stream)
   : pinned_buffer({pinned_memory_resource(), stream}), d_buffer{0, stream}
 {
   std::string const file_name{file_path};
@@ -76,7 +76,7 @@ io_source::io_source(std::string_view file_path, io_source_type type, rmm::cuda_
       file.read(h_buffer.data(), file_size);
       d_buffer.resize(file_size, stream);
       CUDF_CUDA_TRY(cudaMemcpyAsync(
-        d_buffer.data(), h_buffer.data(), file_size, cudaMemcpyDefault, stream.value()));
+        d_buffer.data(), h_buffer.data(), file_size, cudaMemcpyDefault, stream.get()));
 
       source_info = cudf::io::source_info(d_buffer);
       break;

--- a/cpp/examples/parquet_io/io_source.hpp
+++ b/cpp/examples/parquet_io/io_source.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,10 +7,10 @@
 
 #include <cudf/io/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 #include <string>
@@ -46,7 +46,7 @@ rmm::host_async_resource_ref pinned_memory_resource();
  */
 template <typename T>
 struct pinned_allocator : public std::allocator<T> {
-  pinned_allocator(rmm::host_async_resource_ref _mr, rmm::cuda_stream_view _stream)
+  pinned_allocator(rmm::host_async_resource_ref _mr, cuda::stream_ref _stream)
     : mr{_mr}, stream{_stream}
   {
   }
@@ -54,7 +54,7 @@ struct pinned_allocator : public std::allocator<T> {
   T* allocate(std::size_t n)
   {
     auto ptr = mr.allocate(stream, n * sizeof(T), alignof(T));
-    stream.synchronize();
+    stream.sync();
     return static_cast<T*>(ptr);
   }
 
@@ -65,7 +65,7 @@ struct pinned_allocator : public std::allocator<T> {
 
  private:
   rmm::host_async_resource_ref mr;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 };
 
 /**
@@ -74,7 +74,7 @@ struct pinned_allocator : public std::allocator<T> {
  */
 class io_source {
  public:
-  io_source(std::string_view file_path, io_source_type io_type, rmm::cuda_stream_view stream);
+  io_source(std::string_view file_path, io_source_type io_type, cuda::stream_ref stream);
 
   // Get the internal source info
   [[nodiscard]] cudf::io::source_info get_source_info() const { return source_info; }

--- a/cpp/examples/parquet_io/io_source.hpp
+++ b/cpp/examples/parquet_io/io_source.hpp
@@ -10,7 +10,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/host_vector.h>
 
 #include <string>

--- a/cpp/examples/parquet_io/parquet_io_multithreaded.cpp
+++ b/cpp/examples/parquet_io/parquet_io_multithreaded.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ struct read_fn {
   std::vector<table_t>& tables;
   int const thread_id;
   int const thread_count;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   void operator()()
   {
@@ -136,7 +136,7 @@ std::vector<table_t> read_parquet_multithreaded(std::vector<io_source> const& in
   if (read_mode == read_mode::CONCATENATE_ALL) {
     auto stream    = stream_pool.get_stream();
     auto final_tbl = concatenate_tables(std::move(tables), stream);
-    stream.synchronize();
+    stream.sync();
     tables.clear();
     tables.emplace_back(std::move(final_tbl));
   }
@@ -151,7 +151,7 @@ struct write_fn {
   std::string const& output_path;
   std::vector<cudf::table_view> const& table_views;
   int const thread_id;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   void operator()()
   {
@@ -246,7 +246,7 @@ std::vector<io_source> extract_input_sources(std::string const& paths,
                                              int32_t input_multiplier,
                                              int32_t thread_count,
                                              io_source_type io_source_type,
-                                             rmm::cuda_stream_view stream)
+                                             cuda::stream_ref stream)
 {
   // Get the delimited paths to directory and/or files.
   std::vector<std::string> const delimited_paths = [&]() {
@@ -316,7 +316,7 @@ std::vector<io_source> extract_input_sources(std::string const& paths,
     parquet_files.end(),
     std::back_inserter(input_sources),
     [&](auto const& file_name) { return io_source{file_name, io_source_type, stream}; });
-  stream.synchronize();
+  stream.sync();
   return input_sources;
 }
 
@@ -387,7 +387,7 @@ int32_t main(int argc, char const** argv)
       [&] {
         std::ignore = read_parquet_multithreaded<read_mode::NO_CONCATENATE>(
           input_sources, thread_count, stream_pool);
-        default_stream.synchronize();
+        default_stream.sync();
       },
       num_reads);
 
@@ -399,7 +399,7 @@ int32_t main(int argc, char const** argv)
     // read_mode::CONCATENATE_THREADS returns a vector of `thread_count` tables
     auto const tables = read_parquet_multithreaded<read_mode::CONCATENATE_THREAD>(
       input_sources, thread_count, stream_pool);
-    default_stream.synchronize();
+    default_stream.sync();
 
     // Construct a vector of table views for write_parquet_multithreaded
     auto const table_views = [&tables]() {
@@ -423,7 +423,7 @@ int32_t main(int argc, char const** argv)
     benchmark(
       [&] {
         write_parquet_multithreaded(output_path, table_views, thread_count, stream_pool);
-        default_stream.synchronize();
+        default_stream.sync();
       },
       1);
 
@@ -441,7 +441,7 @@ int32_t main(int argc, char const** argv)
     auto const transcoded_table = std::move(read_parquet_multithreaded<read_mode::CONCATENATE_ALL>(
                                               written_pq_sources, thread_count, stream_pool)
                                               .back());
-    default_stream.synchronize();
+    default_stream.sync();
 
     // Check if the tables are identical
     check_tables_equal(input_table->view(), transcoded_table->view(), default_stream);

--- a/cpp/examples/string_transforms/common.hpp
+++ b/cpp/examples/string_transforms/common.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -109,23 +109,23 @@ int main(int argc, char const** argv)
   std::chrono::duration<double> elapsed_cold{};
   {
     // warmup pass
-    stream.synchronize();
+    stream.sync();
     auto start_cold = std::chrono::steady_clock::now();
     nvtxRangePush("transform cold");
     auto [result_cold, input_indices_cold] = transform(table_view);
-    stream.synchronize();
+    stream.sync();
     nvtxRangePop();
     elapsed_cold = std::chrono::steady_clock::now() - start_cold;
   }
 
-  stream.synchronize();
+  stream.sync();
 
   auto start = std::chrono::steady_clock::now();
   nvtxRangePush("transform warm");
   auto [result, input_indices] = transform(table_view);
 
   // ensure transform operation completes and the wall-time is only for the transform computation
-  stream.synchronize();
+  stream.sync();
   nvtxRangePop();
 
   std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - start;

--- a/cpp/examples/string_transforms/compute_checksum_jit.cpp
+++ b/cpp/examples/string_transforms/compute_checksum_jit.cpp
@@ -8,7 +8,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <array>
 #include <utility>
@@ -16,7 +16,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto udf = R"***(

--- a/cpp/examples/string_transforms/compute_checksum_jit.cpp
+++ b/cpp/examples/string_transforms/compute_checksum_jit.cpp
@@ -8,7 +8,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <utility>
@@ -16,7 +16,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto udf = R"***(

--- a/cpp/examples/string_transforms/extract_email_jit.cpp
+++ b/cpp/examples/string_transforms/extract_email_jit.cpp
@@ -8,7 +8,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/transform.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <array>
 #include <utility>
@@ -16,7 +16,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto udf = R"***(

--- a/cpp/examples/string_transforms/extract_email_jit.cpp
+++ b/cpp/examples/string_transforms/extract_email_jit.cpp
@@ -8,7 +8,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/transform.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <utility>
@@ -16,7 +16,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto udf = R"***(

--- a/cpp/examples/string_transforms/extract_email_precompiled.cpp
+++ b/cpp/examples/string_transforms/extract_email_precompiled.cpp
@@ -14,12 +14,12 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto emails      = table.column(1);

--- a/cpp/examples/string_transforms/extract_email_precompiled.cpp
+++ b/cpp/examples/string_transforms/extract_email_precompiled.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,12 +14,12 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto emails      = table.column(1);

--- a/cpp/examples/string_transforms/format_phone_jit.cpp
+++ b/cpp/examples/string_transforms/format_phone_jit.cpp
@@ -8,8 +8,9 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/transform.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <array>
 #include <utility>
@@ -17,7 +18,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   /// Convert a phone number to E.164 international phone format

--- a/cpp/examples/string_transforms/format_phone_jit.cpp
+++ b/cpp/examples/string_transforms/format_phone_jit.cpp
@@ -10,7 +10,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <utility>
@@ -18,7 +18,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   /// Convert a phone number to E.164 international phone format

--- a/cpp/examples/string_transforms/format_phone_precompiled.cpp
+++ b/cpp/examples/string_transforms/format_phone_precompiled.cpp
@@ -19,12 +19,12 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto country_code    = table.column(2);

--- a/cpp/examples/string_transforms/format_phone_precompiled.cpp
+++ b/cpp/examples/string_transforms/format_phone_precompiled.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,13 +17,14 @@
 #include <cudf/strings/replace_re.hpp>
 #include <cudf/strings/strip.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto country_code    = table.column(2);

--- a/cpp/examples/string_transforms/localize_phone_jit.cpp
+++ b/cpp/examples/string_transforms/localize_phone_jit.cpp
@@ -9,8 +9,9 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/transform.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <array>
 #include <utility>
@@ -18,7 +19,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto const udf = R"***(

--- a/cpp/examples/string_transforms/localize_phone_jit.cpp
+++ b/cpp/examples/string_transforms/localize_phone_jit.cpp
@@ -11,7 +11,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <utility>
@@ -19,7 +19,7 @@
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto const udf = R"***(

--- a/cpp/examples/string_transforms/localize_phone_precompiled.cpp
+++ b/cpp/examples/string_transforms/localize_phone_precompiled.cpp
@@ -19,12 +19,12 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto country_code   = table.column(2);

--- a/cpp/examples/string_transforms/localize_phone_precompiled.cpp
+++ b/cpp/examples/string_transforms/localize_phone_precompiled.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,13 +17,14 @@
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
   auto mr     = cudf::get_current_device_resource_ref();
 
   auto country_code   = table.column(2);

--- a/cpp/examples/strings/common.hpp
+++ b/cpp/examples/strings/common.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -80,7 +80,7 @@ int main(int argc, char const** argv)
   std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - st;
   std::cout << "Wall time: " << elapsed.count() << " seconds\n";
   auto const scv = cudf::strings_column_view(result->view());
-  std::cout << "Output size " << scv.chars_size(rmm::cuda_stream_default) << " bytes\n";
+  std::cout << "Output size " << scv.chars_size(cuda::stream_ref{}) << " bytes\n";
 
   return 0;
 }

--- a/cpp/examples/strings/common.hpp
+++ b/cpp/examples/strings/common.hpp
@@ -80,7 +80,7 @@ int main(int argc, char const** argv)
   std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - st;
   std::cout << "Wall time: " << elapsed.count() << " seconds\n";
   auto const scv = cudf::strings_column_view(result->view());
-  std::cout << "Output size " << scv.chars_size(cuda::stream_ref{}) << " bytes\n";
+  std::cout << "Output size " << scv.chars_size(cuda::stream_ref{cudaStreamLegacy}) << " bytes\n";
 
   return 0;
 }

--- a/cpp/examples/strings/custom_optimized.cu
+++ b/cpp/examples/strings/custom_optimized.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,10 +8,10 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime.h>
 #include <nvtx3/nvToolsExt.h>
 #include <thrust/scan.h>
@@ -111,7 +111,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
 
   auto const d_names        = cudf::column_device_view::create(names, stream);
   auto const d_visibilities = cudf::column_device_view::create(visibilities, stream);
@@ -125,8 +125,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
   auto offsets = rmm::device_uvector<cudf::size_type>(names.size() + 1, stream);
 
   // compute output sizes
-  sizes_kernel<<<blocks, block_size, 0, stream.value()>>>(
-    *d_names, *d_visibilities, offsets.data());
+  sizes_kernel<<<blocks, block_size, 0, stream.get()>>>(*d_names, *d_visibilities, offsets.data());
 
   // convert sizes to offsets (in place)
   thrust::exclusive_scan(
@@ -140,7 +139,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
   auto chars = rmm::device_uvector<char>(output_size, stream);
 
   // build chars output
-  redact_kernel<<<blocks, block_size, 0, stream.value()>>>(
+  redact_kernel<<<blocks, block_size, 0, stream.get()>>>(
     *d_names, *d_visibilities, offsets.data(), chars.data());
 
   // create column from offsets vector (move only)
@@ -151,7 +150,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
     names.size(), std::move(offsets_column), chars.release(), 0, rmm::device_buffer{});
 
   // wait for all of the above to finish
-  stream.synchronize();
+  stream.sync();
 
   nvtxRangePop();
   return result;

--- a/cpp/examples/strings/custom_optimized.cu
+++ b/cpp/examples/strings/custom_optimized.cu
@@ -11,7 +11,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime.h>
 #include <nvtx3/nvToolsExt.h>
 #include <thrust/scan.h>
@@ -111,7 +111,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
 
   auto const d_names        = cudf::column_device_view::create(names, stream);
   auto const d_visibilities = cudf::column_device_view::create(visibilities, stream);

--- a/cpp/examples/strings/custom_prealloc.cu
+++ b/cpp/examples/strings/custom_prealloc.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -75,7 +75,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
 
   auto const d_names        = cudf::column_device_view::create(names, stream);
   auto const d_visibilities = cudf::column_device_view::create(visibilities, stream);
@@ -95,12 +95,12 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
   auto str_ptrs = rmm::device_uvector<cudf::string_view>(names.size(), stream);
 
   // build the output strings
-  redact_kernel<<<blocks, block_size, 0, stream.value()>>>(*d_names,
-                                                           *d_visibilities,
-                                                           d_redaction.value(),
-                                                           working_memory.data(),
-                                                           offsets,
-                                                           str_ptrs.data());
+  redact_kernel<<<blocks, block_size, 0, stream.get()>>>(*d_names,
+                                                         *d_visibilities,
+                                                         d_redaction.value(),
+                                                         working_memory.data(),
+                                                         offsets,
+                                                         str_ptrs.data());
 
   // create strings column from the string_pairs;
   // this copies all the individual strings into a single output column
@@ -108,7 +108,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
   // temporary memory cleanup cost here for str_ptrs and working_memory
 
   // wait for all of the above to finish
-  stream.synchronize();
+  stream.sync();
 
   nvtxRangePop();
   return result;

--- a/cpp/examples/strings/custom_prealloc.cu
+++ b/cpp/examples/strings/custom_prealloc.cu
@@ -75,7 +75,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
 
   auto const d_names        = cudf::column_device_view::create(names, stream);
   auto const d_visibilities = cudf::column_device_view::create(visibilities, stream);

--- a/cpp/examples/strings/custom_with_malloc.cu
+++ b/cpp/examples/strings/custom_with_malloc.cu
@@ -111,7 +111,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = cuda::stream_ref{};
+  auto stream = cuda::stream_ref{cudaStreamLegacy};
 
   set_malloc_heap_size();  // to illustrate adjusting the malloc heap
 

--- a/cpp/examples/strings/custom_with_malloc.cu
+++ b/cpp/examples/strings/custom_with_malloc.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -111,7 +111,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities)
 {
   // all device memory operations and kernel functions will run on this stream
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{};
 
   set_malloc_heap_size();  // to illustrate adjusting the malloc heap
 
@@ -129,7 +129,7 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
 
   auto result = [&] {
     // build the output strings
-    redact_kernel<<<blocks, block_size, 0, stream.value()>>>(
+    redact_kernel<<<blocks, block_size, 0, stream.get()>>>(
       *d_names, *d_visibilities, d_redaction.value(), str_ptrs->data());
     // create strings column from the string_view vector
     // this copies all the individual strings into a single output column
@@ -137,12 +137,12 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
   }();
 
   // free the individual temporary memory pointers
-  free_kernel<<<blocks, block_size, 0, stream.value()>>>(
+  free_kernel<<<blocks, block_size, 0, stream.get()>>>(
     d_redaction.value(), str_ptrs->data(), names.size());
   delete str_ptrs;
 
   // wait for all of the above to finish
-  stream.synchronize();
+  stream.sync();
 
   nvtxRangePop();
   return result;


### PR DESCRIPTION
## Description
This split batch migrates libcudf benchmarks, examples, and developer documentation from `rmm::cuda_stream_view` to `cuda::stream_ref`.

This follows the core libcudf API migration in https://github.com/NVIDIA/cudf/pull/23691 and should be merged after that PR.

Contributes to https://github.com/NVIDIA/cudf/issues/23636

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
