### PR TITLE
Fix version guards in tests for set sorted hints

### DIFF
--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -16,6 +16,7 @@ from cudf_polars.testing.asserts import (
 )
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
+    POLARS_VERSION_LT_138,
 )
 
 
@@ -58,9 +59,9 @@ def is_sorted(request):
 @pytest.fixture
 def xfail_if_sorted(is_sorted, request):
     # See https://github.com/NVIDIA/cudf/pull/20791#issuecomment-3750528419
-    if is_sorted and POLARS_VERSION_LT_136:
+    if is_sorted and POLARS_VERSION_LT_138:
         request.applymarker(
-            pytest.mark.xfail(reason="See https://github.com/pola-rs/polars/pull/24981")
+            pytest.mark.xfail(reason="set_sorted lowers to unsupported hint ir")
         )
 
 

--- a/python/cudf_polars/tests/test_mapfunction.py
+++ b/python/cudf_polars/tests/test_mapfunction.py
@@ -20,7 +20,7 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
-from cudf_polars.utils.versions import POLARS_VERSION_LT_140
+from cudf_polars.utils.versions import POLARS_VERSION_LT_138
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -127,7 +127,7 @@ def test_unique_hash():
 def test_set_sorted_then_inner_join(
     engine: pl.GPUEngine, request: pytest.FixtureRequest
 ):
-    if POLARS_VERSION_LT_140:
+    if POLARS_VERSION_LT_138:
         request.applymarker(
             pytest.mark.xfail(reason="set_sorted lowers to unsupported hint ir")
         )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Fix nightly tests https://github.com/NVIDIA/cudf/actions/runs/32106621381/job/95617300260#step:13:4850
```
FAILED tests/expressions/test_agg.py::test_agg[no_nulls-min-Int32-sorted-in-memory] - polars.exceptions.ComputeError: 'cuda' conversion failed: NotImplementedError: ('Query execution with GPU not possible: unsupported operations.\nThe errors were:\n- NotImplementedError: hint ir', [NotImplementedError('hint ir')])
FAILED tests/expressions/test_agg.py::test_agg[no_nulls-min-Int32-sorted-dask] - polars.exceptions.ComputeError: 'cuda' conversion failed: NotImplementedError: ('Query execution with GPU not possible: unsupported operations.\nThe errors were:\n- NotImplementedError: hint ir', [NotImplementedError('hint ir')])
FAILED tests/expressions/test_agg.py::test_agg[nulls-min-Int32-sorted-spmd-small] - polars.exceptions.ComputeError: 'cuda' conversion failed: NotImplementedError: ('Query execution with GPU not possible: unsupported operations.\nThe errors were:\n- NotImplementedError: hint ir', [NotImplementedError('hint ir')])
```

- Follows up https://github.com/NVIDIA/cudf/pull/23663
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
