### PR TITLE
Fix invalid device context error in ValidIfTest.ExplicitMemoryResourcesEmptyRange

### DIFF
--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -48,21 +48,20 @@ TEST_F(ValidIfTest, ExplicitMemoryResourcesEmptyRange)
   auto harness = cudf::test::memory_resource_test_harness{this->mr()};
   auto stream  = cudf::get_default_stream();
 
+  // No harness.synchronize inside the scope: empty range has no GPU operations pending.
   auto actual = [&] {
     auto current_scope = harness.fail_on_current_device_resource_use();
-    auto result        = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
-                                         cuda::counting_iterator<cudf::size_type>{0},
-                                         odds_valid{},
-                                         stream,
-                                         harness.resources());
-    harness.synchronize(stream);
-    return result;
+    return cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+                                  cuda::counting_iterator<cudf::size_type>{0},
+                                  odds_valid{},
+                                  stream,
+                                  harness.resources());
   }();
 
   EXPECT_EQ(0u, actual.first.size());
   EXPECT_EQ(nullptr, actual.first.data());
   EXPECT_EQ(0, actual.second);
-  harness.expect_no_live_allocations(stream);
+  // total == 0 implies value == 0; no sync needed since no allocations were ever made.
   EXPECT_EQ(0, harness.output_mr().get_bytes_counter().total);
   EXPECT_EQ(0, harness.temporary_mr().get_bytes_counter().total);
 }


### PR DESCRIPTION
## Description
Fixes the BITMASK_TEST `ValidIfTest.ExplicitMemoryResourcesEmptyRange` failure when run with the cuda memory resource:

```
$ gtests/BITMASK_TEST --gtest_filter=ValidIfTest.ExplicitMemoryResourcesEmptyRange --rmm_mode=cuda
Note: Google Test filter = ValidIfTest.ExplicitMemoryResourcesEmptyRange
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ValidIfTest
[ RUN      ] ValidIfTest.ExplicitMemoryResourcesEmptyRange
unknown file: Failure
C++ exception with description "/cudf/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/__driver/driver_api.h:664 invalid device context(201): Failed to synchronize a stream" thrown in the test body.

[  FAILED  ] ValidIfTest.ExplicitMemoryResourcesEmptyRange (3 ms)
```

The `ExplicitMemoryResourcesEmptyRange` test was calling `harness.synchronize(stream)` and   `harness.expect_no_live_allocations(stream)` — both of which invoke `cuda::stream_ref::sync()` (which uses the CUDA driver API `cuStreamSynchronize`). Unlike the runtime API, the driver API requires an active CUDA context. For the empty-range case, `valid_if` makes no GPU calls at all (zero-size buffer, no kernel), so the context is never initialized, causing `CUDA_ERROR_INVALID_CONTEXT (201)`.

The fix removes both sync calls — they're unnecessary because an empty range produces no GPU work and no allocations. The existing `.total == 0` counter assertions are stricter than what `expect_no_live_allocations` checked `.value == 0`, so test coverage is preserved.
 
Error introduced by #23490

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
