### PR TITLE
Optimize DICT32 transcode via batched keys and index shift

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -297,7 +297,8 @@ ConfigureNVBench(
 # * parquet reader benchmark ----------------------------------------------------------------------
 ConfigureNVBench(
   PARQUET_READER_NVBENCH io/parquet/parquet_reader_input.cpp io/parquet/parquet_reader_encoding.cpp
-  io/parquet/parquet_reader_options.cpp io/parquet/reader_common.cpp
+  io/parquet/parquet_reader_options.cpp io/parquet/parquet_reader_dict.cpp
+  io/parquet/reader_common.cpp
 )
 
 # ##################################################################################################

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -296,12 +296,8 @@ ConfigureNVBench(
 # ##################################################################################################
 # * parquet reader benchmark ----------------------------------------------------------------------
 ConfigureNVBench(
-  PARQUET_READER_NVBENCH
-  io/parquet/parquet_reader_input.cpp
-  io/parquet/parquet_reader_encoding.cpp
-  io/parquet/parquet_reader_options.cpp
-  io/parquet/parquet_reader_dict.cpp
-  io/parquet/reader_common.cpp
+  PARQUET_READER_NVBENCH io/parquet/parquet_reader_input.cpp io/parquet/parquet_reader_encoding.cpp
+  io/parquet/parquet_reader_options.cpp io/parquet/reader_common.cpp
 )
 
 # ##################################################################################################

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -296,8 +296,11 @@ ConfigureNVBench(
 # ##################################################################################################
 # * parquet reader benchmark ----------------------------------------------------------------------
 ConfigureNVBench(
-  PARQUET_READER_NVBENCH io/parquet/parquet_reader_input.cpp io/parquet/parquet_reader_encoding.cpp
-  io/parquet/parquet_reader_options.cpp io/parquet/parquet_reader_dict.cpp
+  PARQUET_READER_NVBENCH
+  io/parquet/parquet_reader_input.cpp
+  io/parquet/parquet_reader_encoding.cpp
+  io/parquet/parquet_reader_options.cpp
+  io/parquet/parquet_reader_dict.cpp
   io/parquet/reader_common.cpp
 )
 

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -160,11 +160,11 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
 /**
  * @brief Remap each row's dictionary index onto the deduplicated key space (in place).
  *
- * If output_dict_columns is set, the transcode fast path copies the dictionary indices as is on
- * Parquet, into a new INT32 column. These indices (d_indices) were indexing the keys for the local
- * row group. This function shifts the indices into the chunk's region of the stacked
- * (non-deduplicated) key space, and remaps them onto the deduplicated key space spanning all row
- * groups. Remapping is done in place. Used in-lieu of `cudf::dictionary::detail::concatenate`.
+ * Each row's decoded index is local to its own row group's dictionary. This shifts that index into
+ * the row group's region of the stacked (non-deduplicated) key space, then translates it through
+ * `stacked_to_unique` -- the position-to-index map produced by encoding the stacked keys -- so it
+ * points at the correct entry in the compact, unique keys column. Done in place, in one pass over
+ * the rows, in lieu of `cudf::dictionary::detail::concatenate`.
  *
  * @param d_indices Device pointer to the INT32 index buffer, mutated in place
  * @param num_rows Number of index values
@@ -185,7 +185,7 @@ void remap_dict_indices_by_chunk(int32_t* d_indices,
     rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator{num_rows},
-    [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(size_type row) {
+    [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(size_type row) -> void {
       // Chunk owning `row` is the last offset <= row.
       auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
       auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
@@ -306,12 +306,12 @@ void reader_impl::assemble_dict_transcoded_columns(
     return all_keys->view();
   };
 
-  // For each eligible input column, collect its chunks in row-group order, build a per-chunk
-  // DICTIONARY32 segment (local 0-based indices + per-chunk keys column), and concatenate.
+  // For each eligible input column, collect its chunks in row-group order and assemble a
+  // DICTIONARY32 output.
   //
   // A single-row-group column takes a zero-copy fast path (keys + decoded indices stapled
   // together). A multi-row-group column stacks the per-chunk keys, deduplicates them, and remaps
-  // the decoded indices onto the compact key space in place,  avoiding
+  // the decoded indices onto the compact key space in place -- avoiding
   // `cudf::dictionary::detail::concatenate` and its redundant per-chunk index copy.
   std::for_each(
     cuda::counting_iterator<size_t>{0},

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -13,13 +13,21 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/dictionary/detail/encode.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/reduction/detail/distinct_count.hpp>
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 #include <cuda/iterator>
+
+#include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
 
 #include <algorithm>
 #include <functional>
@@ -151,6 +159,44 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
   return cudf::strings::detail::make_strings_column(begin, begin + entry_count, stream, mr);
 }
 
+/**
+ * @brief Remap each row's dictionary index onto the deduplicated key space (in place).
+ *
+ * Row `r` belongs to the chunk whose row range contains it; its local index is first shifted into
+ * that chunk's region of the stacked (non-deduplicated) key space, then translated through
+ * `stacked_to_unique` -- the position->index map produced by encoding the stacked keys -- so it
+ * points at the correct entry in the compact, unique keys column. This lets multi-row-group
+ * assembly avoid `cudf::dictionary::detail::concatenate`, which would re-copy the already-contiguous
+ * per-chunk indices into a fresh buffer. Defined as a free function because extended `__device__`
+ * lambdas cannot appear in a private member function.
+ *
+ * @param d_indices Device pointer to the INT32 index buffer, mutated in place
+ * @param num_rows Number of index values
+ * @param row_offsets Per-chunk row boundaries `[offsets[k], offsets[k+1])`, size num_chunks+1
+ * @param key_prefix Per-chunk key-prefix offsets into the stacked key space, size num_chunks+1
+ * @param stacked_to_unique Map from stacked-key position to compact unique-key index
+ * @param stream CUDA stream used for the kernel launch
+ */
+void remap_dict_indices_by_chunk(int32_t* d_indices,
+                                 size_type num_rows,
+                                 cudf::device_span<size_type const> row_offsets,
+                                 cudf::device_span<size_type const> key_prefix,
+                                 cudf::device_span<int32_t const> stacked_to_unique,
+                                 rmm::cuda_stream_view stream)
+{
+  thrust::for_each(rmm::exec_policy_nosync(stream),
+                   thrust::make_counting_iterator(size_type{0}),
+                   thrust::make_counting_iterator(num_rows),
+                   [row_offsets, key_prefix, stacked_to_unique, d_indices] __device__(size_type row) {
+                     // Chunk owning `row` is the last offset <= row.
+                     auto const it = thrust::upper_bound(
+                       thrust::seq, row_offsets.begin(), row_offsets.end(), row);
+                     auto const k = static_cast<size_type>(it - row_offsets.begin() - 1);
+                     auto const stacked_pos = key_prefix[k] + d_indices[row];
+                     d_indices[row]         = stacked_to_unique[stacked_pos];
+                   });
+}
+
 }  // namespace
 
 void reader_impl::prepare_dict_transcode(read_mode mode)
@@ -247,6 +293,23 @@ void reader_impl::assemble_dict_transcoded_columns(
 
   auto const& pass = *_pass_itm_data;
 
+  // Batched keys: every string chunk's dictionary entries live contiguously in
+  // `pass.str_dict_index` (each `chunk.str_dict_index` is a pointer into that one buffer). So all
+  // per-chunk keys can be materialized by a single `make_strings_column` instead of one launch per
+  // chunk. Build that column lazily on first multi-row-group use -- columns that all take the
+  // single-row-group fast path never need it -- and hand out zero-copy slices below.
+  std::unique_ptr<column> all_keys;
+  auto ensure_all_keys = [&]() -> column_view {
+    if (all_keys == nullptr) {
+      all_keys =
+        make_keys_column_from_index_pairs(pass.str_dict_index.data(),
+                                          static_cast<size_type>(pass.str_dict_index.size()),
+                                          _stream,
+                                          get_current_device_resource_ref());
+    }
+    return all_keys->view();
+  };
+
   // For each eligible input column, collect its chunks in row-group order, build a per-chunk
   // DICTIONARY32 segment (local 0-based indices + per-chunk keys column), and concatenate.
   //
@@ -321,13 +384,14 @@ void reader_impl::assemble_dict_transcoded_columns(
         // Keys were not distinct: fall through to the multi-row-group path, which deduplicates.
       }
 
-      // Multi-row-group path: the indices buffer is shared (aliased) by per-chunk DICTIONARY32
-      // views below via the parent's offset/size, so it must stay alive until concatenate
-      // completes.
-      column_view const indices_view{indices_owner->view()};
+      // Multi-row-group path (dedup-and-shift): stack every chunk's keys, deduplicate the (small)
+      // key set once, then remap each row's index onto the compact key space IN PLACE. This avoids
+      // `cudf::dictionary::detail::concatenate`, which would re-copy the already-contiguous per-chunk
+      // indices (`indices_owner`) into a fresh buffer -- an O(num_rows) copy the transcode does not
+      // need. Only the keys (O(total_keys)) are deduplicated; the row-sized index work is one pass.
+      auto const num_row_vals = static_cast<size_type>(indices_owner->size());
 
-      // Per-chunk boundaries along the row axis: chunk k occupies rows
-      // [chunk_row_offsets[k], chunk_row_offsets[k+1]).
+      // Per-chunk row boundaries: chunk k occupies rows [chunk_row_offsets[k], chunk_row_offsets[k+1]).
       std::vector<size_type> chunk_row_offsets(chunk_indices.size() + 1, 0);
       std::transform(
         chunk_indices.begin(),
@@ -336,58 +400,59 @@ void reader_impl::assemble_dict_transcoded_columns(
         [&](size_t chunk_idx) { return static_cast<size_type>(pass.chunks[chunk_idx].num_rows); });
       std::inclusive_scan(
         chunk_row_offsets.begin() + 1, chunk_row_offsets.end(), chunk_row_offsets.begin() + 1);
-      CUDF_EXPECTS(chunk_row_offsets.back() == indices_view.size(),
+      CUDF_EXPECTS(chunk_row_offsets.back() == num_row_vals,
                    "Row counts on pass chunks must sum to the indices column size");
 
-      // Pre-compute null counts for all segments in a single kernel launch. Building the
-      // column_views below requires a per-segment null count, and calling null_count(begin, end)
-      // inside the loop would launch one kernel per chunk. Batch them here instead.
-      std::vector<size_type> seg_null_counts(chunk_indices.size(), 0);
-      if (indices_view.nullable()) {
-        std::vector<size_type> indices_pairs;
-        indices_pairs.reserve(chunk_indices.size() * 2);
-        for (size_t k = 0; k < chunk_indices.size(); ++k) {
-          indices_pairs.push_back(chunk_row_offsets[k]);
-          indices_pairs.push_back(chunk_row_offsets[k + 1]);
-        }
-        seg_null_counts =
-          cudf::detail::segmented_null_count(indices_view.null_mask(), indices_pairs, _stream);
-      }
+      // Per-chunk key prefix offsets into the stacked key space: chunk k's keys occupy
+      // [key_prefix[k], key_prefix[k+1]).
+      std::vector<size_type> key_prefix(chunk_indices.size() + 1, 0);
+      std::inclusive_scan(chunk_key_counts.begin(), chunk_key_counts.end(), key_prefix.begin() + 1);
 
-      // Build a per-chunk DICTIONARY32 *view* that aliases the shared decoded INT32 buffer (no
-      // copy): keys = this chunk's STRING column, indices = `indices_view`. The row range, null
-      // mask, and null count must all live on the *parent* view (via offset/size), not the indices
-      // child, because `get_indices_annotated()` rebuilds the indices from the child's `head()`
-      // plus the parent's offset/size/null_mask -- anything set on the child is ignored. A wrong
-      // null count (e.g. a hardcoded 0) would silently turn nulls into a valid index once
-      // `cudf::detail::concatenate` remaps the indices against the unified keys.
-      std::vector<std::unique_ptr<column>> seg_keys_owners(chunk_indices.size());
-      std::vector<column_view> dict_segment_views(chunk_indices.size());
-      std::transform(
-        cuda::counting_iterator<size_t>{0},
-        cuda::counting_iterator{chunk_indices.size()},
-        dict_segment_views.begin(),
-        [&](size_t k) {
-          auto const chunk_idx = chunk_indices[k];
-          auto const& chunk    = pass.chunks[chunk_idx];
+      // Stack keys: concatenate every chunk's key slice from the batched `all_keys` (not yet
+      // deduplicated). `all_keys` owns the data and outlives this concatenate, so the slices stay
+      // valid. Chunk `k`'s entries occupy `[key_offset, key_offset + chunk_key_counts[k])` in
+      // `pass.str_dict_index`, where `key_offset` is recovered from the chunk's stored pointer.
+      auto const keys_base = ensure_all_keys();
+      std::vector<column_view> key_slices(chunk_indices.size());
+      std::transform(cuda::counting_iterator<size_t>{0},
+                     cuda::counting_iterator{chunk_indices.size()},
+                     key_slices.begin(),
+                     [&](size_t k) {
+                       auto const& chunk     = pass.chunks[chunk_indices[k]];
+                       auto const key_offset = static_cast<size_type>(chunk.str_dict_index -
+                                                                      pass.str_dict_index.data());
+                       return cudf::detail::slice(
+                         keys_base, key_offset, key_offset + chunk_key_counts[k], _stream);
+                     });
+      auto const stacked_keys =
+        cudf::detail::concatenate(key_slices, _stream, get_current_device_resource_ref());
 
-          seg_keys_owners[k] = make_keys_column_from_index_pairs(
-            chunk.str_dict_index, chunk_key_counts[k], _stream, get_current_device_resource_ref());
+      // Deduplicate the stacked keys. `encode` yields the compact unique keys (on `_mr`, the output
+      // keys child) plus an INT32 map from each stacked-key position to its compact index.
+      auto encoded          = cudf::dictionary::detail::encode(
+        stacked_keys->view(), data_type{type_id::INT32}, _stream, _mr);
+      auto encoded_contents  = encoded->release();
+      auto stacked_to_unique = std::move(encoded_contents.children[0]);  // INT32 map (keep for kernel)
+      auto unique_keys       = std::move(encoded_contents.children[1]);  // compact keys, owned on _mr
 
-          auto const seg_begin = chunk_row_offsets[k];
-          auto const seg_end   = chunk_row_offsets[k + 1];
-          auto const seg_rows  = seg_end - seg_begin;
-          return column_view{data_type{type_id::DICTIONARY32},
-                             seg_rows,
-                             nullptr,                   // dictionary parent holds no data
-                             indices_view.null_mask(),  // shared with indices_view
-                             seg_null_counts[k],
-                             seg_begin,  // reslices shared indices child + null mask
-                             {indices_view, seg_keys_owners[k]->view()}};
-        });
+      // Remap every row's index onto the compact key space in place. Null rows carry a zero index
+      // (fill_pruned_offsets); the shift keeps them in range and the null mask (carried by
+      // `indices_owner`) still nullifies them in `decode`.
+      auto const d_row_offsets = cudf::detail::make_device_uvector_async(
+        chunk_row_offsets, _stream, get_current_device_resource_ref());
+      auto const d_key_prefix = cudf::detail::make_device_uvector_async(
+        key_prefix, _stream, get_current_device_resource_ref());
+      remap_dict_indices_by_chunk(
+        indices_owner->mutable_view().data<int32_t>(),
+        num_row_vals,
+        cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
+        cudf::device_span<size_type const>{d_key_prefix.data(), d_key_prefix.size()},
+        cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
+                                         static_cast<std::size_t>(stacked_to_unique->size())},
+        _stream);
 
-      // `cudf::detail::concatenate` deduplicates + sorts keys and recomputes indices.
-      out_columns[out_idx] = cudf::detail::concatenate(dict_segment_views, _stream, _mr);
+      out_columns[out_idx] = cudf::make_dictionary_column(
+        std::move(unique_keys), std::move(indices_owner), _stream, _mr);
     });
 }
 

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <iterator>
 #include <numeric>
 #include <vector>
 
@@ -307,6 +306,28 @@ void reader_impl::assemble_dict_transcoded_columns(
     return all_keys->view();
   };
 
+  // Pre-pass 1: Map each chunk to its dictionary page's key count.
+  // Chunks without a dictionary page keep a count of 0.
+  std::vector<size_type> chunk_dict_key_counts(pass.chunks.size(), 0);
+  for (auto const& page : pass.pages) {
+    if ((page.flags & PAGEINFO_FLAGS_DICTIONARY) == 0) { continue; }
+    auto const chunk_idx = page.chunk_idx;
+    if (chunk_idx < 0 or static_cast<size_t>(chunk_idx) >= pass.chunks.size()) { continue; }
+    if (pass.chunks[chunk_idx].dict_page == nullptr) { continue; }
+    chunk_dict_key_counts[chunk_idx] = static_cast<size_type>(page.num_input_values);
+  }
+
+  // Pre-pass 2: Bucket chunk indices by their source input-column ordinal. Because
+  // `pass.chunks` is laid out row-group-major, appending in index order yields each column's chunks
+  // already in row-group order.
+  std::vector<std::vector<size_t>> chunks_by_input_col(_input_columns.size());
+  for (size_t c = 0; c < pass.chunks.size(); ++c) {
+    auto const col = pass.chunks[c].src_col_index;
+    if (col >= 0 and static_cast<size_t>(col) < _input_columns.size()) {
+      chunks_by_input_col[col].push_back(c);
+    }
+  }
+
   // For each eligible input column, collect its chunks in row-group order and assemble a
   // DICTIONARY32 output.
   //
@@ -320,13 +341,8 @@ void reader_impl::assemble_dict_transcoded_columns(
     [&](size_t i) {
       if (not _dict_transcode_eligible[i]) { return; }
 
-      // Gather chunk indices for this input column in row-group order.
-      std::vector<size_t> chunk_indices;
-      chunk_indices.reserve(pass.chunks.size() / std::max<size_t>(_input_columns.size(), 1));
-      std::copy_if(cuda::counting_iterator<size_t>{0},
-                   cuda::counting_iterator{pass.chunks.size()},
-                   std::back_inserter(chunk_indices),
-                   [&](size_t c) { return pass.chunks[c].src_col_index == static_cast<int>(i); });
+      // This column's chunks, in row-group order (bucketed in pre-pass 2 above).
+      auto const& chunk_indices = chunks_by_input_col[i];
       if (chunk_indices.empty()) { return; }
 
       // `out_columns` is indexed by output-buffer (root column) ordinal, not input-column
@@ -336,22 +352,12 @@ void reader_impl::assemble_dict_transcoded_columns(
       // column, so `nesting[0]` is the correct, and only, output-buffer index to use.
       auto const out_idx = static_cast<size_t>(_input_columns[i].nesting[0]);
 
-      // Per-chunk key counts from the dictionary page's `num_input_values`, mirrored back to
-      // host when `pass.pages` was copied by `decode_page_headers`.
-      std::vector<size_type> chunk_key_counts(chunk_indices.size(), 0);
+      // Per-chunk key counts, looked up from the pre-pass 1 map.
+      std::vector<size_type> chunk_key_counts(chunk_indices.size());
       std::transform(chunk_indices.begin(),
                      chunk_indices.end(),
                      chunk_key_counts.begin(),
-                     [&](size_t chunk_idx) -> size_type {
-                       if (pass.chunks[chunk_idx].dict_page == nullptr) { return 0; }
-                       for (auto const& page : pass.pages) {
-                         if (page.chunk_idx == static_cast<int32_t>(chunk_idx) and
-                             (page.flags & PAGEINFO_FLAGS_DICTIONARY) != 0) {
-                           return static_cast<size_type>(page.num_input_values);
-                         }
-                       }
-                       return size_type{0};
-                     });
+                     [&](size_t chunk_idx) { return chunk_dict_key_counts[chunk_idx]; });
 
       auto& indices_col = out_columns[out_idx];
       CUDF_EXPECTS(indices_col != nullptr and indices_col->type().id() == type_id::INT32,

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -7,11 +7,10 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/concatenate.hpp>
-#include <cudf/detail/copy.hpp>
-#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
+#include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/dictionary/detail/encode.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
@@ -157,6 +156,30 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
 }
 
 /**
+ * @brief Gathers one column's stacked keys out of the shared `pass.str_dict_index` buffer.
+ *
+ * Maps a stacked-key position in `[0, total_keys)` to its `string_index_pair`: it finds the owning
+ * chunk `k` (the last key-prefix boundary `<=` the position), then indexes into that chunk's base
+ * offset within `pass.str_dict_index`. Fed through a counting-transform iterator, this lets a
+ * strided (multi-string-column) column materialize its stacked keys in a single
+ * `make_strings_column` pass -- fusing the per-chunk build and `concatenate` into one gather.
+ */
+struct stacked_key_gather_fn {
+  string_index_pair const* str_dict_index;
+  cudf::device_span<size_type const> key_counts_prefix;  ///< size num_chunks + 1
+  cudf::device_span<size_type const> key_base_offsets;   ///< size num_chunks
+
+  __device__ string_index_pair operator()(size_type stacked_pos) const
+  {
+    auto const it = thrust::upper_bound(
+      thrust::seq, key_counts_prefix.begin(), key_counts_prefix.end(), stacked_pos);
+    auto const k     = static_cast<size_type>(it - key_counts_prefix.begin() - 1);
+    auto const local = stacked_pos - key_counts_prefix[k];
+    return str_dict_index[key_base_offsets[k] + local];
+  }
+};
+
+/**
  * @brief Remap each row's dictionary index onto the deduplicated key space (in place).
  *
  * Each row's decoded index is local to its own row group's dictionary. This shifts that index into
@@ -165,33 +188,30 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
  * points at the correct entry in the compact, unique keys column. Done in place, in one pass over
  * the rows, in lieu of `cudf::dictionary::detail::concatenate`.
  *
- * @param d_indices Device pointer to the INT32 index buffer, mutated in place
- * @param num_rows Number of index values
+ * @param indices INT32 index buffer (one entry per row), mutated in place
  * @param row_offsets Per-chunk row boundaries `[offsets[k], offsets[k+1])`, size num_chunks+1
  * @param key_counts_prefix Per-chunk key-prefix offsets into the stacked key space, size
  * num_chunks+1
  * @param stacked_to_unique Map from stacked-key position to compact unique-key index
  * @param stream CUDA stream used for the kernel launch
  */
-void remap_dict_indices_by_chunk(int32_t* d_indices,
-                                 size_type num_rows,
+void remap_dict_indices_by_chunk(cudf::device_span<int32_t> indices,
                                  cudf::device_span<size_type const> row_offsets,
                                  cudf::device_span<size_type const> key_counts_prefix,
                                  cudf::device_span<int32_t const> stacked_to_unique,
                                  rmm::cuda_stream_view stream)
 {
-  thrust::for_each(rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
-                   cuda::counting_iterator<size_type>{0},
-                   cuda::counting_iterator{num_rows},
-                   [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(
-                     size_type row) -> void {
-                     // Chunk owning `row` is the last offset <= row.
-                     auto const it = thrust::upper_bound(
-                       thrust::seq, row_offsets.begin(), row_offsets.end(), row);
-                     auto const k           = static_cast<size_type>(it - row_offsets.begin() - 1);
-                     auto const stacked_pos = key_counts_prefix[k] + d_indices[row];
-                     d_indices[row]         = stacked_to_unique[stacked_pos];
-                   });
+  thrust::for_each(
+    rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
+    cuda::counting_iterator<size_type>{0},
+    cuda::counting_iterator{static_cast<size_type>(indices.size())},
+    [row_offsets, key_counts_prefix, stacked_to_unique, indices] __device__(size_type row) -> void {
+      // Chunk owning `row` is the last offset <= row.
+      auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
+      auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
+      auto const stacked_pos = key_counts_prefix[k] + indices[row];
+      indices[row]           = stacked_to_unique[stacked_pos];
+    });
 }
 
 }  // namespace
@@ -290,21 +310,7 @@ void reader_impl::assemble_dict_transcoded_columns(
 
   auto const& pass = *_pass_itm_data;
 
-  // Every string chunk's dictionary entries live contiguously in one buffer in
-  // `pass.str_dict_index` (each `chunk.str_dict_index` is a pointer into that one buffer).
-  // Materialize all keys into a single column using `make_strings_column` (contains duplicates).
-  // All keys stores keys of all columns, and not just column i.
-  std::unique_ptr<column> all_keys;
-  auto ensure_all_keys = [&]() -> column_view {
-    if (all_keys == nullptr) {
-      all_keys =
-        make_keys_column_from_index_pairs(pass.str_dict_index.data(),
-                                          static_cast<size_type>(pass.str_dict_index.size()),
-                                          _stream,
-                                          get_current_device_resource_ref());
-    }
-    return all_keys->view();
-  };
+  // Keys are materialized per eligible column.
 
   // Pre-pass 1: Map each chunk to its dictionary page's key count.
   // Chunks without a dictionary page keep a count of 0.
@@ -396,7 +402,9 @@ void reader_impl::assemble_dict_transcoded_columns(
 
       // Per-chunk row boundaries: chunk k occupies rows [chunk_row_offsets[k],
       // chunk_row_offsets[k+1]).
-      std::vector<size_type> chunk_row_offsets(chunk_indices.size() + 1, 0);
+      auto chunk_row_offsets =
+        cudf::detail::make_pinned_vector_async<size_type>(chunk_indices.size() + 1, _stream);
+      chunk_row_offsets[0] = 0;
       std::transform(
         chunk_indices.begin(),
         chunk_indices.end(),
@@ -409,27 +417,22 @@ void reader_impl::assemble_dict_transcoded_columns(
 
       // Per-chunk key prefix offsets into the stacked key space: chunk k's keys occupy
       // [key_counts_prefix[k], key_counts_prefix[k+1]).
-      std::vector<size_type> key_counts_prefix(chunk_indices.size() + 1, 0);
+      auto key_counts_prefix =
+        cudf::detail::make_pinned_vector_async<size_type>(chunk_indices.size() + 1, _stream);
+      key_counts_prefix[0] = 0;
       std::inclusive_scan(
         chunk_key_counts.begin(), chunk_key_counts.end(), key_counts_prefix.begin() + 1);
       auto const total_keys = key_counts_prefix.back();
 
-      // Stack this column's per-chunk keys, sliced out of the batched keys view
-      // `all_string_column_keys` -- a view of the caller-scoped owning column `all_keys`, which
-      // outlives this block, so any view into it stays valid. Chunk `k`'s entries occupy
-      // `[key_offset, key_offset + chunk_key_counts[k])` in `pass.str_dict_index`, where
-      // `key_offset` is recovered from the chunk's stored pointer into that buffer.
-      //
-      // When those per-chunk ranges are already contiguous in `all_string_column_keys` -- e.g. a
-      // single string column, whose chunks are laid out consecutively -- the stacked keys are just
-      // one zero-copy sub-range of it, so the per-chunk gather (`concatenate`) is skipped entirely.
-      // Otherwise (multiple string columns interleaved row-group-major) the strided slices are
-      // concatenated into one contiguous column.
-      auto const all_string_column_keys = ensure_all_keys();
-      auto const key_offset_of          = [&](size_t k) {
+      // Per-chunk base offsets: where chunk k's keys begin in the shared `pass.str_dict_index`.
+      auto const key_offset_of = [&](size_t k) {
         return static_cast<size_type>(pass.chunks[chunk_indices[k]].str_dict_index -
                                       pass.str_dict_index.data());
       };
+
+      // The per-chunk key ranges are contiguous in `pass.str_dict_index` iff this is the only
+      // eligible string column: chunks are laid out row-group-major, so a second string column
+      // interleaves its chunks between this one's.
       bool contiguous = true;
       for (size_t k = 0; k + 1 < chunk_indices.size(); ++k) {
         if (key_offset_of(k + 1) != key_offset_of(k) + chunk_key_counts[k]) {
@@ -438,53 +441,78 @@ void reader_impl::assemble_dict_transcoded_columns(
         }
       }
 
-      std::unique_ptr<column> stacked_keys_owner;  // holds the gathered keys in the strided case
-      column_view const stacked_keys = [&] {
-        if (contiguous) {
-          auto const first = key_offset_of(0);
-          return cudf::detail::slice(all_string_column_keys, first, first + total_keys, _stream);
-        }
-        std::vector<column_view> key_slices(chunk_indices.size());
+      // Device copies of the per-chunk row/key boundaries, reused by the strided key gather below
+      // and by `remap_dict_indices_by_chunk`.
+      auto const d_row_offsets = cudf::detail::make_device_uvector_async(
+        chunk_row_offsets, _stream, get_current_device_resource_ref());
+      auto const d_key_counts_prefix = cudf::detail::make_device_uvector_async(
+        key_counts_prefix, _stream, get_current_device_resource_ref());
+
+      // Host source for the strided gather's per-chunk base offsets. Declared at iteration scope
+      // (populated only in the strided branch) so it outlives its async copy until the synchronize.
+      auto key_base_offsets = cudf::detail::make_pinned_vector_async<size_type>(0, _stream);
+
+      // Stack this column's per-chunk keys into one STRING column, materialized per column so each
+      // `make_strings_column` stays within the 2 GiB string-offset limit.
+      //
+      // Contiguous (single eligible string column): one `make_strings_column` over the contiguous
+      // entry range -- no gather, no concatenate. Strided (multiple string columns): a single
+      // gathered `make_strings_column` that pulls each stacked position from the correct place in
+      // `pass.str_dict_index` via a counting-transform iterator, fusing what would otherwise be a
+      // per-chunk build followed by `concatenate` into one pass -- one copy of the key bytes
+      // instead of two.
+      std::unique_ptr<column> stacked_keys_owner;
+      if (contiguous) {
+        stacked_keys_owner =
+          make_keys_column_from_index_pairs(pass.chunks[chunk_indices[0]].str_dict_index,
+                                            total_keys,
+                                            _stream,
+                                            get_current_device_resource_ref());
+      } else {
+        key_base_offsets.resize(chunk_indices.size());
         std::transform(cuda::counting_iterator<size_t>{0},
                        cuda::counting_iterator{chunk_indices.size()},
-                       key_slices.begin(),
-                       [&](size_t k) {
-                         return cudf::detail::slice(all_string_column_keys,
-                                                    key_offset_of(k),
-                                                    key_offset_of(k) + chunk_key_counts[k],
-                                                    _stream);
-                       });
-        stacked_keys_owner =
-          cudf::detail::concatenate(key_slices, _stream, get_current_device_resource_ref());
-        return stacked_keys_owner->view();
-      }();
+                       key_base_offsets.begin(),
+                       [&](size_t k) { return key_offset_of(k); });
+        auto const d_key_base_offsets = cudf::detail::make_device_uvector_async(
+          key_base_offsets, _stream, get_current_device_resource_ref());
+
+        auto const keys_begin = cudf::detail::make_counting_transform_iterator(
+          size_type{0},
+          stacked_key_gather_fn{pass.str_dict_index.data(),
+                                cudf::device_span<size_type const>{d_key_counts_prefix.data(),
+                                                                   d_key_counts_prefix.size()},
+                                cudf::device_span<size_type const>{d_key_base_offsets.data(),
+                                                                   d_key_base_offsets.size()}});
+        stacked_keys_owner = cudf::strings::detail::make_strings_column(
+          keys_begin, keys_begin + total_keys, _stream, get_current_device_resource_ref());
+      }
+      column_view const stacked_keys = stacked_keys_owner->view();
 
       // Deduplicate the stacked keys. `encode` yields the compact unique keys (on `_mr`, the output
       // keys child) plus an INT32 map from each stacked-key position to its compact index.
       auto encoded =
         cudf::dictionary::detail::encode(stacked_keys, data_type{type_id::INT32}, _stream, _mr);
-      auto encoded_contents = encoded->release();
-      auto stacked_to_unique =
-        std::move(encoded_contents.children[0]);                   // INT32 map (keep for kernel)
-      auto unique_keys = std::move(encoded_contents.children[1]);  // compact keys, owned on _mr
+      auto encoded_contents  = encoded->release();
+      auto stacked_to_unique = std::move(
+        encoded_contents.children[dictionary_column_view::indices_column_index]);  // INT32 map
+      auto unique_keys = std::move(
+        encoded_contents
+          .children[dictionary_column_view::keys_column_index]);  // compact keys, owned on _mr
 
       // Remap every row's index onto the compact key space in place. Null rows carry a zero index
       // (fill_pruned_offsets); the shift keeps them in range and the null mask (carried by
       // `indices_owner`) still nullifies them in `decode`.
-      //
-      // These H2D copies are synchronous
-      auto const d_row_offsets = cudf::detail::make_device_uvector(
-        chunk_row_offsets, _stream, get_current_device_resource_ref());
-      auto const d_key_counts_prefix = cudf::detail::make_device_uvector(
-        key_counts_prefix, _stream, get_current_device_resource_ref());
       remap_dict_indices_by_chunk(
-        indices_owner->mutable_view().data<int32_t>(),
-        num_row_vals,
+        cudf::device_span<int32_t>{indices_owner->mutable_view().data<int32_t>(),
+                                   static_cast<std::size_t>(num_row_vals)},
         cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
         cudf::device_span<size_type const>{d_key_counts_prefix.data(), d_key_counts_prefix.size()},
         cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
                                          static_cast<std::size_t>(stacked_to_unique->size())},
         _stream);
+
+      _stream.sync();
 
       out_columns[out_idx] = cudf::make_dictionary_column(
         std::move(unique_keys), std::move(indices_owner), _stream, _mr);

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -406,30 +406,57 @@ void reader_impl::assemble_dict_transcoded_columns(
       std::vector<size_type> key_counts_prefix(chunk_indices.size() + 1, 0);
       std::inclusive_scan(
         chunk_key_counts.begin(), chunk_key_counts.end(), key_counts_prefix.begin() + 1);
+      auto const total_keys = key_counts_prefix.back();
 
-      // Stack keys: concatenate every chunk's key slice from the batched `all_keys` (not yet
-      // deduplicated). `all_keys` owns the data and outlives this concatenate, so the slices stay
-      // valid. Chunk `k`'s entries occupy `[key_offset, key_offset + chunk_key_counts[k])` in
-      // `pass.str_dict_index`, where `key_offset` is recovered from the chunk's stored pointer.
-      auto const all_keys_column = ensure_all_keys();
-      std::vector<column_view> key_slices(chunk_indices.size());
-      std::transform(cuda::counting_iterator<size_t>{0},
-                     cuda::counting_iterator{chunk_indices.size()},
-                     key_slices.begin(),
-                     [&](size_t k) {
-                       auto const& chunk = pass.chunks[chunk_indices[k]];
-                       auto const key_offset =
-                         static_cast<size_type>(chunk.str_dict_index - pass.str_dict_index.data());
-                       return cudf::detail::slice(
-                         all_keys_column, key_offset, key_offset + chunk_key_counts[k], _stream);
-                     });
-      auto const stacked_keys =
-        cudf::detail::concatenate(key_slices, _stream, get_current_device_resource_ref());
+      // Stack this column's per-chunk keys, sliced out of the batched `all_string_column_keys`.
+      // Chunk `k`'s entries occupy `[key_offset, key_offset + chunk_key_counts[k])` in
+      // `pass.str_dict_index`, where `key_offset` is recovered from the chunk's stored pointer into
+      // that buffer. `all_string_column_keys` (owned by the caller-scoped `all_string_column_keys`)
+      // outlives this block, so any view into it stays valid.
+      //
+      // When those per-chunk ranges are already contiguous in `all_keys` -- e.g. a single string
+      // column, whose chunks are laid out consecutively -- the stacked keys are just one zero-copy
+      // sub-range of `all_keys`, so the per-chunk gather (`concatenate`) is skipped entirely.
+      // Otherwise (multiple string columns interleaved row-group-major) the strided slices are
+      // concatenated into one contiguous column.
+      auto const all_string_column_keys = ensure_all_keys();
+      auto const key_offset_of          = [&](size_t k) {
+        return static_cast<size_type>(pass.chunks[chunk_indices[k]].str_dict_index -
+                                      pass.str_dict_index.data());
+      };
+      bool contiguous = true;
+      for (size_t k = 0; k + 1 < chunk_indices.size(); ++k) {
+        if (key_offset_of(k + 1) != key_offset_of(k) + chunk_key_counts[k]) {
+          contiguous = false;
+          break;
+        }
+      }
+
+      std::unique_ptr<column> stacked_keys_owner;  // holds the gathered keys in the strided case
+      column_view const stacked_keys = [&] {
+        if (contiguous) {
+          auto const first = key_offset_of(0);
+          return cudf::detail::slice(all_string_column_keys, first, first + total_keys, _stream);
+        }
+        std::vector<column_view> key_slices(chunk_indices.size());
+        std::transform(cuda::counting_iterator<size_t>{0},
+                       cuda::counting_iterator{chunk_indices.size()},
+                       key_slices.begin(),
+                       [&](size_t k) {
+                         return cudf::detail::slice(all_string_column_keys,
+                                                    key_offset_of(k),
+                                                    key_offset_of(k) + chunk_key_counts[k],
+                                                    _stream);
+                       });
+        stacked_keys_owner =
+          cudf::detail::concatenate(key_slices, _stream, get_current_device_resource_ref());
+        return stacked_keys_owner->view();
+      }();
 
       // Deduplicate the stacked keys. `encode` yields the compact unique keys (on `_mr`, the output
       // keys child) plus an INT32 map from each stacked-key position to its compact index.
-      auto encoded = cudf::dictionary::detail::encode(
-        stacked_keys->view(), data_type{type_id::INT32}, _stream, _mr);
+      auto encoded =
+        cudf::dictionary::detail::encode(stacked_keys, data_type{type_id::INT32}, _stream, _mr);
       auto encoded_contents = encoded->release();
       auto stacked_to_unique =
         std::move(encoded_contents.children[0]);                   // INT32 map (keep for kernel)

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -181,17 +181,18 @@ void remap_dict_indices_by_chunk(int32_t* d_indices,
                                  cudf::device_span<int32_t const> stacked_to_unique,
                                  rmm::cuda_stream_view stream)
 {
-  thrust::for_each(
-    rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
-    cuda::counting_iterator<size_type>{0},
-    cuda::counting_iterator{num_rows},
-    [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(size_type row) -> void {
-      // Chunk owning `row` is the last offset <= row.
-      auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
-      auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
-      auto const stacked_pos = key_counts_prefix[k] + d_indices[row];
-      d_indices[row]         = stacked_to_unique[stacked_pos];
-    });
+  thrust::for_each(rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
+                   cuda::counting_iterator<size_type>{0},
+                   cuda::counting_iterator{num_rows},
+                   [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(
+                     size_type row) -> void {
+                     // Chunk owning `row` is the last offset <= row.
+                     auto const it = thrust::upper_bound(
+                       thrust::seq, row_offsets.begin(), row_offsets.end(), row);
+                     auto const k           = static_cast<size_type>(it - row_offsets.begin() - 1);
+                     auto const stacked_pos = key_counts_prefix[k] + d_indices[row];
+                     d_indices[row]         = stacked_to_unique[stacked_pos];
+                   });
 }
 
 }  // namespace
@@ -355,7 +356,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       auto& indices_col = out_columns[out_idx];
       CUDF_EXPECTS(indices_col != nullptr and indices_col->type().id() == type_id::INT32,
                    "Expected INT32 indices column for dict-transcoded flat string column");
-      // Claim ownership of the indices column. (output_columns vectoris now empty.)
+      // Claim ownership of the indices column; the `out_idx` entry in `out_columns` is now empty.
       auto indices_owner = std::move(indices_col);
 
       // Single row group fast path: the Parquet dictionary page's entries become the keys as-is,
@@ -382,7 +383,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       }
 
       // Multi-row-group path (dedup-and-shift): stack every chunk's keys into a single column,
-      // deduplicate the ( key set once, then remap each row's index onto the compact key space in
+      // deduplicate the key set once, then remap each row's index onto the compact key space in
       // place. This avoids `cudf::dictionary::detail::concatenate`, which would re-copy the
       // already-contiguous per-chunk indices (`indices_owner`) into a fresh buffer.
       auto const num_row_vals = static_cast<size_type>(indices_owner->size());
@@ -407,15 +408,15 @@ void reader_impl::assemble_dict_transcoded_columns(
         chunk_key_counts.begin(), chunk_key_counts.end(), key_counts_prefix.begin() + 1);
       auto const total_keys = key_counts_prefix.back();
 
-      // Stack this column's per-chunk keys, sliced out of the batched `all_string_column_keys`.
-      // Chunk `k`'s entries occupy `[key_offset, key_offset + chunk_key_counts[k])` in
-      // `pass.str_dict_index`, where `key_offset` is recovered from the chunk's stored pointer into
-      // that buffer. `all_string_column_keys` (owned by the caller-scoped `all_string_column_keys`)
-      // outlives this block, so any view into it stays valid.
+      // Stack this column's per-chunk keys, sliced out of the batched keys view
+      // `all_string_column_keys` -- a view of the caller-scoped owning column `all_keys`, which
+      // outlives this block, so any view into it stays valid. Chunk `k`'s entries occupy
+      // `[key_offset, key_offset + chunk_key_counts[k])` in `pass.str_dict_index`, where
+      // `key_offset` is recovered from the chunk's stored pointer into that buffer.
       //
-      // When those per-chunk ranges are already contiguous in `all_keys` -- e.g. a single string
-      // column, whose chunks are laid out consecutively -- the stacked keys are just one zero-copy
-      // sub-range of `all_keys`, so the per-chunk gather (`concatenate`) is skipped entirely.
+      // When those per-chunk ranges are already contiguous in `all_string_column_keys` -- e.g. a
+      // single string column, whose chunks are laid out consecutively -- the stacked keys are just
+      // one zero-copy sub-range of it, so the per-chunk gather (`concatenate`) is skipped entirely.
       // Otherwise (multiple string columns interleaved row-group-major) the strided slices are
       // concatenated into one contiguous column.
       auto const all_string_column_keys = ensure_all_keys();

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -158,11 +158,8 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
 /**
  * @brief Gathers one column's stacked keys out of the shared `pass.str_dict_index` buffer.
  *
- * Maps a stacked-key position in `[0, total_keys)` to its `string_index_pair`: it finds the owning
- * chunk `k` (the last key-prefix boundary `<=` the position), then indexes into that chunk's base
- * offset within `pass.str_dict_index`. Fed through a counting-transform iterator, this lets a
- * strided (multi-string-column) column materialize its stacked keys in a single
- * `make_strings_column` pass -- fusing the per-chunk build and `concatenate` into one gather.
+ * Maps a stacked-key position in `[0, total_keys)` to its `string_index_pair`.
+ * Fed through a counting-transform iterator.
  */
 struct stacked_key_gather_fn {
   string_index_pair const* str_dict_index;
@@ -182,11 +179,9 @@ struct stacked_key_gather_fn {
 /**
  * @brief Remap each row's dictionary index onto the deduplicated key space (in place).
  *
- * Each row's decoded index is local to its own row group's dictionary. This shifts that index into
- * the row group's region of the stacked (non-deduplicated) key space, then translates it through
- * `stacked_to_unique` -- the position-to-index map produced by encoding the stacked keys -- so it
- * points at the correct entry in the compact, unique keys column. Done in place, in one pass over
- * the rows, in lieu of `cudf::dictionary::detail::concatenate`.
+ * Each input row's decoded index is local to its own row group's dictionary. This function shifts
+ * that index to point at the correct entry in the compact, unique keys column. Done in place, in
+ * one pass over the rows, in lieu of `cudf::dictionary::detail::concatenate`.
  *
  * @param indices INT32 index buffer (one entry per row), mutated in place
  * @param row_offsets Per-chunk row boundaries `[offsets[k], offsets[k+1])`, size num_chunks+1
@@ -456,11 +451,11 @@ void reader_impl::assemble_dict_transcoded_columns(
       // `make_strings_column` stays within the 2 GiB string-offset limit.
       //
       // Contiguous (single eligible string column): one `make_strings_column` over the contiguous
-      // entry range -- no gather, no concatenate. Strided (multiple string columns): a single
-      // gathered `make_strings_column` that pulls each stacked position from the correct place in
-      // `pass.str_dict_index` via a counting-transform iterator, fusing what would otherwise be a
-      // per-chunk build followed by `concatenate` into one pass -- one copy of the key bytes
-      // instead of two.
+      // entry range.
+      //
+      // Strided (multiple string columns): a single gather `make_strings_column` that pulls each
+      // stacked position from the correct place in `pass.str_dict_index` via a counting-transform
+      // iterator.
       std::unique_ptr<column> stacked_keys_owner;
       if (contiguous) {
         stacked_keys_owner =

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -26,7 +26,6 @@
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
-#include <thrust/iterator/counting_iterator.h>
 
 #include <algorithm>
 #include <functional>
@@ -183,9 +182,9 @@ void remap_dict_indices_by_chunk(int32_t* d_indices,
                                  rmm::cuda_stream_view stream)
 {
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
-    thrust::make_counting_iterator(size_type{0}),
-    thrust::make_counting_iterator(num_rows),
+    rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
+    cuda::counting_iterator<size_type>{0},
+    cuda::counting_iterator{num_rows},
     [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(size_type row) {
       // Chunk owning `row` is the last offset <= row.
       auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -204,6 +204,11 @@ void remap_dict_indices_by_chunk(cudf::device_span<int32_t> indices,
       // Chunk owning `row` is the last offset <= row.
       auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
       auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
+      // If the chunk has no keys, the index is 0.
+      if (key_counts_prefix[k] == key_counts_prefix[k + 1]) {
+        indices[row] = 0;
+        return;
+      }
       auto const stacked_pos = key_counts_prefix[k] + indices[row];
       indices[row]           = stacked_to_unique[stacked_pos];
     });

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -204,7 +204,7 @@ void remap_dict_indices_by_chunk(cudf::device_span<int32_t> indices,
       // Chunk owning `row` is the last offset <= row.
       auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
       auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
-      // If the chunk has no keys, the index is 0.
+      // Guard for all-null case.
       if (key_counts_prefix[k] == key_counts_prefix[k + 1]) {
         indices[row] = 0;
         return;
@@ -433,13 +433,10 @@ void reader_impl::assemble_dict_transcoded_columns(
       // The per-chunk key ranges are contiguous in `pass.str_dict_index` iff this is the only
       // eligible string column: chunks are laid out row-group-major, so a second string column
       // interleaves its chunks between this one's.
-      bool contiguous = true;
-      for (size_t k = 0; k + 1 < chunk_indices.size(); ++k) {
-        if (key_offset_of(k + 1) != key_offset_of(k) + chunk_key_counts[k]) {
-          contiguous = false;
-          break;
-        }
-      }
+      auto const contiguous = std::all_of(
+        cuda::counting_iterator<size_t>{0},
+        cuda::counting_iterator{chunk_indices.size() - 1},
+        [&](size_t k) { return key_offset_of(k + 1) == key_offset_of(k) + chunk_key_counts[k]; });
 
       // Device copies of the per-chunk row/key boundaries, reused by the strided key gather below
       // and by `remap_dict_indices_by_chunk`.

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -23,7 +23,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -162,39 +161,38 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
 /**
  * @brief Remap each row's dictionary index onto the deduplicated key space (in place).
  *
- * Row `r` belongs to the chunk whose row range contains it; its local index is first shifted into
- * that chunk's region of the stacked (non-deduplicated) key space, then translated through
- * `stacked_to_unique` -- the position->index map produced by encoding the stacked keys -- so it
- * points at the correct entry in the compact, unique keys column. This lets multi-row-group
- * assembly avoid `cudf::dictionary::detail::concatenate`, which would re-copy the already-contiguous
- * per-chunk indices into a fresh buffer. Defined as a free function because extended `__device__`
- * lambdas cannot appear in a private member function.
+ * If output_dict_columns is set, the transcode fast path copies the dictionary indices as is on
+ * Parquet, into a new INT32 column. These indices (d_indices) were indexing the keys for the local
+ * row group. This function shifts the indices into the chunk's region of the stacked
+ * (non-deduplicated) key space, and remaps them onto the deduplicated key space spanning all row
+ * groups. Remapping is done in place. Used in-lieu of `cudf::dictionary::detail::concatenate`.
  *
  * @param d_indices Device pointer to the INT32 index buffer, mutated in place
  * @param num_rows Number of index values
  * @param row_offsets Per-chunk row boundaries `[offsets[k], offsets[k+1])`, size num_chunks+1
- * @param key_prefix Per-chunk key-prefix offsets into the stacked key space, size num_chunks+1
+ * @param key_counts_prefix Per-chunk key-prefix offsets into the stacked key space, size
+ * num_chunks+1
  * @param stacked_to_unique Map from stacked-key position to compact unique-key index
  * @param stream CUDA stream used for the kernel launch
  */
 void remap_dict_indices_by_chunk(int32_t* d_indices,
                                  size_type num_rows,
                                  cudf::device_span<size_type const> row_offsets,
-                                 cudf::device_span<size_type const> key_prefix,
+                                 cudf::device_span<size_type const> key_counts_prefix,
                                  cudf::device_span<int32_t const> stacked_to_unique,
                                  rmm::cuda_stream_view stream)
 {
-  thrust::for_each(rmm::exec_policy_nosync(stream),
-                   thrust::make_counting_iterator(size_type{0}),
-                   thrust::make_counting_iterator(num_rows),
-                   [row_offsets, key_prefix, stacked_to_unique, d_indices] __device__(size_type row) {
-                     // Chunk owning `row` is the last offset <= row.
-                     auto const it = thrust::upper_bound(
-                       thrust::seq, row_offsets.begin(), row_offsets.end(), row);
-                     auto const k = static_cast<size_type>(it - row_offsets.begin() - 1);
-                     auto const stacked_pos = key_prefix[k] + d_indices[row];
-                     d_indices[row]         = stacked_to_unique[stacked_pos];
-                   });
+  thrust::for_each(
+    rmm::exec_policy_nosync(stream),
+    thrust::make_counting_iterator(size_type{0}),
+    thrust::make_counting_iterator(num_rows),
+    [row_offsets, key_counts_prefix, stacked_to_unique, d_indices] __device__(size_type row) {
+      // Chunk owning `row` is the last offset <= row.
+      auto const it = thrust::upper_bound(thrust::seq, row_offsets.begin(), row_offsets.end(), row);
+      auto const k  = static_cast<size_type>(it - row_offsets.begin() - 1);
+      auto const stacked_pos = key_counts_prefix[k] + d_indices[row];
+      d_indices[row]         = stacked_to_unique[stacked_pos];
+    });
 }
 
 }  // namespace
@@ -293,11 +291,10 @@ void reader_impl::assemble_dict_transcoded_columns(
 
   auto const& pass = *_pass_itm_data;
 
-  // Batched keys: every string chunk's dictionary entries live contiguously in
-  // `pass.str_dict_index` (each `chunk.str_dict_index` is a pointer into that one buffer). So all
-  // per-chunk keys can be materialized by a single `make_strings_column` instead of one launch per
-  // chunk. Build that column lazily on first multi-row-group use -- columns that all take the
-  // single-row-group fast path never need it -- and hand out zero-copy slices below.
+  // Every string chunk's dictionary entries live contiguously in one buffer in
+  // `pass.str_dict_index` (each `chunk.str_dict_index` is a pointer into that one buffer).
+  // Materialize all keys into a single column using `make_strings_column` (contains duplicates).
+  // All keys stores keys of all columns, and not just column i.
   std::unique_ptr<column> all_keys;
   auto ensure_all_keys = [&]() -> column_view {
     if (all_keys == nullptr) {
@@ -313,10 +310,10 @@ void reader_impl::assemble_dict_transcoded_columns(
   // For each eligible input column, collect its chunks in row-group order, build a per-chunk
   // DICTIONARY32 segment (local 0-based indices + per-chunk keys column), and concatenate.
   //
-  // IMPORTANT: Each segment carries row-group-local indices into its own keys column. We do NOT
-  // pre-shift indices into a global keyspace, because `cudf::dictionary::detail::concatenate`
-  // already re-maps the indices using `compute_children_offsets_fn`. Pre-shifting would cause
-  // double-offsetting and out-of-bounds reads in the `dispatch_compute_indices` kernel.
+  // A single-row-group column takes a zero-copy fast path (keys + decoded indices stapled
+  // together). A multi-row-group column stacks the per-chunk keys, deduplicates them, and remaps
+  // the decoded indices onto the compact key space in place,  avoiding
+  // `cudf::dictionary::detail::concatenate` and its redundant per-chunk index copy.
   std::for_each(
     cuda::counting_iterator<size_t>{0},
     cuda::counting_iterator{_input_columns.size()},
@@ -336,7 +333,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       // ordinal: a nested struct/list column contributes one entry to `_output_buffers` but one
       // entry per leaf to `_input_columns`, so `i` and the corresponding root index can diverge
       // as soon as any nested column precedes this one. Eligibility requires a flat (depth-1)
-      // column, so `nesting[0]` is the correct, and only, output-buffer index to use here.
+      // column, so `nesting[0]` is the correct, and only, output-buffer index to use.
       auto const out_idx = static_cast<size_t>(_input_columns[i].nesting[0]);
 
       // Per-chunk key counts from the dictionary page's `num_input_values`, mirrored back to
@@ -359,6 +356,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       auto& indices_col = out_columns[out_idx];
       CUDF_EXPECTS(indices_col != nullptr and indices_col->type().id() == type_id::INT32,
                    "Expected INT32 indices column for dict-transcoded flat string column");
+      // Claim ownership of the indices column. (output_columns vectoris now empty.)
       auto indices_owner = std::move(indices_col);
 
       // Single row group fast path: the Parquet dictionary page's entries become the keys as-is,
@@ -384,14 +382,14 @@ void reader_impl::assemble_dict_transcoded_columns(
         // Keys were not distinct: fall through to the multi-row-group path, which deduplicates.
       }
 
-      // Multi-row-group path (dedup-and-shift): stack every chunk's keys, deduplicate the (small)
-      // key set once, then remap each row's index onto the compact key space IN PLACE. This avoids
-      // `cudf::dictionary::detail::concatenate`, which would re-copy the already-contiguous per-chunk
-      // indices (`indices_owner`) into a fresh buffer -- an O(num_rows) copy the transcode does not
-      // need. Only the keys (O(total_keys)) are deduplicated; the row-sized index work is one pass.
+      // Multi-row-group path (dedup-and-shift): stack every chunk's keys into a single column,
+      // deduplicate the ( key set once, then remap each row's index onto the compact key space in
+      // place. This avoids `cudf::dictionary::detail::concatenate`, which would re-copy the
+      // already-contiguous per-chunk indices (`indices_owner`) into a fresh buffer.
       auto const num_row_vals = static_cast<size_type>(indices_owner->size());
 
-      // Per-chunk row boundaries: chunk k occupies rows [chunk_row_offsets[k], chunk_row_offsets[k+1]).
+      // Per-chunk row boundaries: chunk k occupies rows [chunk_row_offsets[k],
+      // chunk_row_offsets[k+1]).
       std::vector<size_type> chunk_row_offsets(chunk_indices.size() + 1, 0);
       std::transform(
         chunk_indices.begin(),
@@ -404,49 +402,51 @@ void reader_impl::assemble_dict_transcoded_columns(
                    "Row counts on pass chunks must sum to the indices column size");
 
       // Per-chunk key prefix offsets into the stacked key space: chunk k's keys occupy
-      // [key_prefix[k], key_prefix[k+1]).
-      std::vector<size_type> key_prefix(chunk_indices.size() + 1, 0);
-      std::inclusive_scan(chunk_key_counts.begin(), chunk_key_counts.end(), key_prefix.begin() + 1);
+      // [key_counts_prefix[k], key_counts_prefix[k+1]).
+      std::vector<size_type> key_counts_prefix(chunk_indices.size() + 1, 0);
+      std::inclusive_scan(
+        chunk_key_counts.begin(), chunk_key_counts.end(), key_counts_prefix.begin() + 1);
 
       // Stack keys: concatenate every chunk's key slice from the batched `all_keys` (not yet
       // deduplicated). `all_keys` owns the data and outlives this concatenate, so the slices stay
       // valid. Chunk `k`'s entries occupy `[key_offset, key_offset + chunk_key_counts[k])` in
       // `pass.str_dict_index`, where `key_offset` is recovered from the chunk's stored pointer.
-      auto const keys_base = ensure_all_keys();
+      auto const all_keys_column = ensure_all_keys();
       std::vector<column_view> key_slices(chunk_indices.size());
       std::transform(cuda::counting_iterator<size_t>{0},
                      cuda::counting_iterator{chunk_indices.size()},
                      key_slices.begin(),
                      [&](size_t k) {
-                       auto const& chunk     = pass.chunks[chunk_indices[k]];
-                       auto const key_offset = static_cast<size_type>(chunk.str_dict_index -
-                                                                      pass.str_dict_index.data());
+                       auto const& chunk = pass.chunks[chunk_indices[k]];
+                       auto const key_offset =
+                         static_cast<size_type>(chunk.str_dict_index - pass.str_dict_index.data());
                        return cudf::detail::slice(
-                         keys_base, key_offset, key_offset + chunk_key_counts[k], _stream);
+                         all_keys_column, key_offset, key_offset + chunk_key_counts[k], _stream);
                      });
       auto const stacked_keys =
         cudf::detail::concatenate(key_slices, _stream, get_current_device_resource_ref());
 
       // Deduplicate the stacked keys. `encode` yields the compact unique keys (on `_mr`, the output
       // keys child) plus an INT32 map from each stacked-key position to its compact index.
-      auto encoded          = cudf::dictionary::detail::encode(
+      auto encoded = cudf::dictionary::detail::encode(
         stacked_keys->view(), data_type{type_id::INT32}, _stream, _mr);
-      auto encoded_contents  = encoded->release();
-      auto stacked_to_unique = std::move(encoded_contents.children[0]);  // INT32 map (keep for kernel)
-      auto unique_keys       = std::move(encoded_contents.children[1]);  // compact keys, owned on _mr
+      auto encoded_contents = encoded->release();
+      auto stacked_to_unique =
+        std::move(encoded_contents.children[0]);                   // INT32 map (keep for kernel)
+      auto unique_keys = std::move(encoded_contents.children[1]);  // compact keys, owned on _mr
 
       // Remap every row's index onto the compact key space in place. Null rows carry a zero index
       // (fill_pruned_offsets); the shift keeps them in range and the null mask (carried by
       // `indices_owner`) still nullifies them in `decode`.
       auto const d_row_offsets = cudf::detail::make_device_uvector_async(
         chunk_row_offsets, _stream, get_current_device_resource_ref());
-      auto const d_key_prefix = cudf::detail::make_device_uvector_async(
-        key_prefix, _stream, get_current_device_resource_ref());
+      auto const d_key_counts_prefix = cudf::detail::make_device_uvector_async(
+        key_counts_prefix, _stream, get_current_device_resource_ref());
       remap_dict_indices_by_chunk(
         indices_owner->mutable_view().data<int32_t>(),
         num_row_vals,
         cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
-        cudf::device_span<size_type const>{d_key_prefix.data(), d_key_prefix.size()},
+        cudf::device_span<size_type const>{d_key_counts_prefix.data(), d_key_counts_prefix.size()},
         cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
                                          static_cast<std::size_t>(stacked_to_unique->size())},
         _stream);

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -471,9 +471,11 @@ void reader_impl::assemble_dict_transcoded_columns(
       // Remap every row's index onto the compact key space in place. Null rows carry a zero index
       // (fill_pruned_offsets); the shift keeps them in range and the null mask (carried by
       // `indices_owner`) still nullifies them in `decode`.
-      auto const d_row_offsets = cudf::detail::make_device_uvector_async(
+      //
+      // These H2D copies are synchronous
+      auto const d_row_offsets = cudf::detail::make_device_uvector(
         chunk_row_offsets, _stream, get_current_device_resource_ref());
-      auto const d_key_counts_prefix = cudf::detail::make_device_uvector_async(
+      auto const d_key_counts_prefix = cudf::detail::make_device_uvector(
         key_counts_prefix, _stream, get_current_device_resource_ref());
       remap_dict_indices_by_chunk(
         indices_owner->mutable_view().data<int32_t>(),

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -520,9 +520,8 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 
 // Two flat, low-cardinality string columns across multiple row groups. Their per-row-group
 // dictionaries interleave in the reader's shared key buffer (`pass.str_dict_index`), so each
-// column's keys are strided within it -- exercising the multi-column (concatenate) branch of the
-// multi-row-group assembly, as opposed to the single-column contiguous fast path. Both columns
-// must transcode to DICTIONARY32 and decode back to their (distinct) inputs.
+// column's keys are strided within it. Both columns must transcode to DICTIONARY32
+// and decode back to their (distinct) inputs.
 TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 {
   auto col_a = make_low_cardinality_strings();                   // default seed

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -58,9 +58,9 @@ std::string make_value_string(int value)
   return std::string{utf8_prefixes[value % utf8_prefixes.size()]} + "_" + std::to_string(value);
 }
 
-cudf::test::strings_column_wrapper make_low_cardinality_strings()
+cudf::test::strings_column_wrapper make_low_cardinality_strings(unsigned int col_seed = seed)
 {
-  std::mt19937 engine(seed);
+  std::mt19937 engine(col_seed);
   std::uniform_int_distribution<int> value_dist(0, cardinality - 1);
   std::bernoulli_distribution null_dist(null_probability);
 
@@ -516,4 +516,33 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
   // Check if the decoded column is equal to the original input.
   auto const decoded = cudf::dictionary::decode(dict_view);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
+}
+
+// Two flat, low-cardinality string columns across multiple row groups. Their per-row-group
+// dictionaries interleave in the reader's shared key buffer (`pass.str_dict_index`), so each
+// column's keys are strided within it -- exercising the multi-column (concatenate) branch of the
+// multi-row-group assembly, as opposed to the single-column contiguous fast path. Both columns
+// must transcode to DICTIONARY32 and decode back to their (distinct) inputs.
+TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
+{
+  auto col_a = make_low_cardinality_strings();                  // default seed
+  auto col_b = make_low_cardinality_strings(seed ^ 0xBEEF01u);  // distinct data
+
+  auto const input_tbl = cudf::table_view{{col_a, col_b}};
+  auto const filepath  = temp_env->get_temp_filepath("MultiStringColumnsDictTranscode.parquet");
+  write_parquet(input_tbl, filepath);  // row_group_size rows/group -> multiple row groups
+
+  auto const read_table = read_parquet_as_dict(filepath).tbl;
+  ASSERT_EQ(read_table->num_rows(), num_rows);
+  ASSERT_EQ(read_table->num_columns(), 2);
+
+  auto const read_a = read_table->view().column(0);
+  auto const read_b = read_table->view().column(1);
+  ASSERT_EQ(read_a.type().id(), cudf::type_id::DICTIONARY32);
+  ASSERT_EQ(read_b.type().id(), cudf::type_id::DICTIONARY32);
+
+  auto const decoded_a = cudf::dictionary::decode(cudf::dictionary_column_view(read_a));
+  auto const decoded_b = cudf::dictionary::decode(cudf::dictionary_column_view(read_b));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_a, decoded_a->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_b, decoded_b->view());
 }

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -168,11 +168,9 @@ void write_parquet_adaptive(cudf::table_view const& input,
   cudf::io::write_parquet(options);
 }
 
-// A flat, low-cardinality string column in which one entire row group is all-null while every other
-// row group is normal low-cardinality data. Under `dictionary_policy::ALWAYS` the all-null row
-// group is still dictionary-encoded, but its dictionary carries zero entries -- so its chunk
-// contributes rows but no keys (`chunk_key_counts[k] == 0`), the degenerate case the transcode
-// assembly must tolerate.
+// Build a  flat, low-cardinality string column in which one entire row group is all-null while
+// every other row group is normal low-cardinality data. The column is returned as a DICTIONARY32
+// column when `output_dict_columns` is enabled.
 cudf::test::strings_column_wrapper make_strings_with_null_row_group()
 {
   std::mt19937 engine(seed);
@@ -507,9 +505,7 @@ TEST_F(ParquetReaderDictTest, MultiColumnMixedEligibility)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(key_col, read_key);
 }
 
-// A low-cardinality flat string column spanning multiple row groups must transcode to a
-// DICTIONARY32 with unique keys. Check if deduplication works correctly by checking for unique
-// keys.
+// Test to check if keys across multiple row groups are unique.
 TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 {
   auto input_col = make_low_cardinality_strings();
@@ -538,10 +534,7 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
 }
 
-// Two flat, low-cardinality string columns across multiple row groups. Their per-row-group
-// dictionaries interleave in the reader's shared key buffer (`pass.str_dict_index`), so each
-// column's keys are strided within it. Both columns must transcode to DICTIONARY32
-// and decode back to their (distinct) inputs.
+// Test to check if keys across multiple string columns are unique.
 TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 {
   auto col_a = make_low_cardinality_strings();  // default seed
@@ -578,8 +571,7 @@ TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 
 // An otherwise-eligible flat string column with one entirely-null row group. That row group has no
 // dictionary entries, so its chunk contributes rows but zero keys.The reader must return a
-// DICTIONARY32 column with deduplicated keys that decodes back to the original input -- nulls
-// included -- without going out of range or corrupting the surviving row groups' indices.
+// DICTIONARY32 column with deduplicated keys that decodes back to the original input.
 TEST_F(ParquetReaderDictTest, NullRowGroupDictTranscode)
 {
   auto input_col = make_strings_with_null_row_group();

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -525,7 +525,7 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 // must transcode to DICTIONARY32 and decode back to their (distinct) inputs.
 TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 {
-  auto col_a = make_low_cardinality_strings();                  // default seed
+  auto col_a = make_low_cardinality_strings();                   // default seed
   auto col_b = make_low_cardinality_strings(seed ^ 0xBE'EF01u);  // distinct data
 
   auto const input_tbl = cudf::table_view{{col_a, col_b}};
@@ -540,6 +540,16 @@ TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
   auto const read_b = read_table->view().column(1);
   ASSERT_EQ(read_a.type().id(), cudf::type_id::DICTIONARY32);
   ASSERT_EQ(read_b.type().id(), cudf::type_id::DICTIONARY32);
+
+  // Keys must be deduplicated in both columns -- the strided multi-column branch must produce
+  // unique keys (no larger than the cardinality) just like the contiguous single-column path.
+  for (auto const& read_col : {read_a, read_b}) {
+    auto const keys = cudf::dictionary_column_view(read_col).keys();
+    auto const num_distinct =
+      cudf::distinct_count(keys, cudf::null_policy::INCLUDE, cudf::nan_policy::NAN_IS_VALID);
+    EXPECT_EQ(num_distinct, keys.size());
+    EXPECT_LE(keys.size(), cardinality);
+  }
 
   auto const decoded_a = cudf::dictionary::decode(cudf::dictionary_column_view(read_a));
   auto const decoded_b = cudf::dictionary::decode(cudf::dictionary_column_view(read_b));

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -168,6 +168,26 @@ void write_parquet_adaptive(cudf::table_view const& input,
   cudf::io::write_parquet(options);
 }
 
+// A flat, low-cardinality string column in which one entire row group is all-null while every other
+// row group is normal low-cardinality data. Under `dictionary_policy::ALWAYS` the all-null row
+// group is still dictionary-encoded, but its dictionary carries zero entries -- so its chunk
+// contributes rows but no keys (`chunk_key_counts[k] == 0`), the degenerate case the transcode
+// assembly must tolerate.
+cudf::test::strings_column_wrapper make_strings_with_null_row_group()
+{
+  std::mt19937 engine(seed);
+  std::uniform_int_distribution<int> value_dist(0, cardinality - 1);
+
+  auto const null_row_group = 2;  // every row in this row group is null
+  std::vector<std::string> strings(num_rows);
+  std::vector<bool> valids(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    strings[i] = make_value_string(value_dist(engine));
+    valids[i]  = (i / row_group_size) != null_row_group;
+  }
+  return cudf::test::strings_column_wrapper(strings.begin(), strings.end(), valids.begin());
+}
+
 }  // namespace
 
 struct ParquetReaderDictTest : public cudf::test::BaseFixture {};
@@ -524,8 +544,8 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 // and decode back to their (distinct) inputs.
 TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 {
-  auto col_a = make_low_cardinality_strings();                   // default seed
-  auto col_b = make_low_cardinality_strings(seed ^ 0xBE'EF01u);  // distinct data
+  auto col_a = make_low_cardinality_strings();  // default seed
+  auto col_b = make_low_cardinality_strings(seed ^ 0xBE'EF01u);
 
   auto const input_tbl = cudf::table_view{{col_a, col_b}};
   auto const filepath  = temp_env->get_temp_filepath("MultiStringColumnsDictTranscode.parquet");
@@ -554,4 +574,36 @@ TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
   auto const decoded_b = cudf::dictionary::decode(cudf::dictionary_column_view(read_b));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_a, decoded_a->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_b, decoded_b->view());
+}
+
+// An otherwise-eligible flat string column with one entirely-null row group. That row group has no
+// dictionary entries, so its chunk contributes rows but zero keys.The reader must return a
+// DICTIONARY32 column with deduplicated keys that decodes back to the original input -- nulls
+// included -- without going out of range or corrupting the surviving row groups' indices.
+TEST_F(ParquetReaderDictTest, NullRowGroupDictTranscode)
+{
+  auto input_col = make_strings_with_null_row_group();
+
+  auto const input_tbl = cudf::table_view{{input_col}};
+  auto const filepath  = temp_env->get_temp_filepath("NullRowGroupDictTranscode.parquet");
+  write_parquet(input_tbl, filepath);  // row_group_size rows/group -> one group is fully null
+
+  auto const read_table = read_parquet_as_dict(filepath).tbl;
+  ASSERT_EQ(read_table->num_rows(), num_rows);
+  ASSERT_EQ(read_table->num_columns(), 1);
+
+  auto const read_col = read_table->view().column(0);
+  ASSERT_EQ(read_col.type().id(), cudf::type_id::DICTIONARY32);
+
+  cudf::dictionary_column_view const dict_view(read_col);
+  auto const keys = dict_view.keys();
+
+  // The all-null row group adds no keys; keys stay deduplicated across the surviving row groups.
+  auto const num_distinct =
+    cudf::distinct_count(keys, cudf::null_policy::INCLUDE, cudf::nan_policy::NAN_IS_VALID);
+  EXPECT_EQ(num_distinct, keys.size());
+  EXPECT_LE(keys.size(), cardinality);
+
+  auto const decoded = cudf::dictionary::decode(dict_view);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
 }

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -526,7 +526,7 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 TEST_F(ParquetReaderDictTest, MultiStringColumnsDictTranscode)
 {
   auto col_a = make_low_cardinality_strings();                  // default seed
-  auto col_b = make_low_cardinality_strings(seed ^ 0xBEEF01u);  // distinct data
+  auto col_b = make_low_cardinality_strings(seed ^ 0xBE'EF01u);  // distinct data
 
   auto const input_tbl = cudf::table_view{{col_a, col_b}};
   auto const filepath  = temp_env->get_temp_filepath("MultiStringColumnsDictTranscode.parquet");

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -17,6 +17,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/reduction/distinct_count.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table_view.hpp>
@@ -484,4 +485,35 @@ TEST_F(ParquetReaderDictTest, MultiColumnMixedEligibility)
   auto const read_key = read_table->view().column(2);
   ASSERT_EQ(read_key.type().id(), cudf::type_id::INT32);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(key_col, read_key);
+}
+
+// A low-cardinality flat string column spanning multiple row groups must transcode to a
+// DICTIONARY32 whose keys are unique: the per-row-group dictionaries are deduplicated during
+// assembly, not merely stacked. Without dedup the keys would carry up to one copy per row group.
+TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
+{
+  auto input_col = make_low_cardinality_strings();
+
+  auto const input_tbl = cudf::table_view{{input_col}};
+  auto const filepath  = temp_env->get_temp_filepath("MultiRowGroupKeysAreUnique.parquet");
+  write_parquet(input_tbl, filepath);  // row_group_size rows/group -> multiple row groups
+
+  auto const read_table = read_parquet_as_dict(filepath).tbl;
+  ASSERT_EQ(read_table->num_columns(), 1);
+  auto const read_col = read_table->view().column(0);
+  ASSERT_EQ(read_col.type().id(), cudf::type_id::DICTIONARY32);
+
+  cudf::dictionary_column_view const dict_view(read_col);
+  auto const keys = dict_view.keys();
+
+  // Keys must be unique and no larger than the source cardinality; a stacked-but-not-deduplicated
+  // dictionary would carry up to (number of row groups) times more keys.
+  auto const num_distinct =
+    cudf::distinct_count(keys, cudf::null_policy::INCLUDE, cudf::nan_policy::NAN_IS_VALID);
+  EXPECT_EQ(num_distinct, keys.size());
+  EXPECT_LE(keys.size(), cardinality);
+
+  // And it still decodes to the original input.
+  auto const decoded = cudf::dictionary::decode(dict_view);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
 }

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -488,15 +488,15 @@ TEST_F(ParquetReaderDictTest, MultiColumnMixedEligibility)
 }
 
 // A low-cardinality flat string column spanning multiple row groups must transcode to a
-// DICTIONARY32 whose keys are unique: the per-row-group dictionaries are deduplicated during
-// assembly, not merely stacked. Without dedup the keys would carry up to one copy per row group.
+// DICTIONARY32 with unique keys. Check if deduplication works correctly by checking for unique
+// keys.
 TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
 {
   auto input_col = make_low_cardinality_strings();
 
   auto const input_tbl = cudf::table_view{{input_col}};
   auto const filepath  = temp_env->get_temp_filepath("MultiRowGroupKeysAreUnique.parquet");
-  write_parquet(input_tbl, filepath);  // row_group_size rows/group -> multiple row groups
+  write_parquet(input_tbl, filepath);
 
   auto const read_table = read_parquet_as_dict(filepath).tbl;
   ASSERT_EQ(read_table->num_columns(), 1);
@@ -513,7 +513,7 @@ TEST_F(ParquetReaderDictTest, MultiRowGroupKeysAreUnique)
   EXPECT_EQ(num_distinct, keys.size());
   EXPECT_LE(keys.size(), cardinality);
 
-  // And it still decodes to the original input.
+  // Check if the decoded column is equal to the original input.
   auto const decoded = cudf::dictionary::decode(dict_view);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
 }


### PR DESCRIPTION
## Description
Follow-up to [#22532](https://github.com/rapidsai/cudf/pull/22532) (direct Parquet-dict → DICTIONARY32 transcode). That PR's fast transcode path built the output dictionary with cudf::dictionary::detail::concatenate, which was the bottleneck for columns spanning many row groups, as it materialized the per-chunk keys one make_strings_column launch at a time, and its general-purpose implementation re-copied the already-contiguous decoded indices into a fresh buffer before remapping them.

This PR rewrites that path to do the same work with far less overhead, while producing the same compact, unique-keyed output. 

- All string's dictionary keys are now materialized with a single make_strings_column. 
- Instead of using concatenate, we now stack all the keys, deduplicate them, and remap the indices.
- When a column's per-chunk key ranges are already contiguous (e.g. a single string column), the stacked keys are a zero-copy slice of the batched column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
