### PR TITLE
Add length check to cudf::strings::is_timestamp logic for literals

### DIFF
--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -515,7 +515,7 @@ struct check_datetime_format {
       // eliminate static character values first
       if (item.item_type == format_char_type::literal) {
         // check static character matches
-        if (*ptr != item.value) return cuda::std::nullopt;
+        if (length < item.length || *ptr != item.value) { return cuda::std::nullopt; }
         ptr += item.length;
         length -= item.length;
         continue;

--- a/cpp/tests/strings/datetime_tests.cpp
+++ b/cpp/tests/strings/datetime_tests.cpp
@@ -633,3 +633,14 @@ TEST_F(StringsDatetimeTest, Errors)
   EXPECT_THROW(cudf::strings::is_timestamp(view, "%p %"), std::invalid_argument);
   EXPECT_THROW(cudf::strings::from_timestamps(timestamps, "%Y:%H", view), std::invalid_argument);
 }
+
+TEST_F(StringsDatetimeTest, IsTimestampLiteralOverrun)
+{
+  auto input = cudf::test::strings_column_wrapper{"2021-01-01 02:00:00"};
+  cudf::strings_column_view sv(input);
+
+  auto format   = "%Y-%m-%d %H:%M:%S_";  // extra literal at the end
+  auto result   = cudf::strings::is_timestamp(sv, format);
+  auto expected = cudf::test::fixed_width_column_wrapper<bool>({0});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+}


### PR DESCRIPTION
## Description
Adds a length check before comparing a literal within the given format against a string row value in the `cudf::strings::is_timestamp()` API. This prevents reading past the end of the string. Also added a test for this case as well. The other format specifiers (non-literal) already check the length correctly.

Closes #23660 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
