### PR TITLE
[FEA] Make JIT Compilation Warnings Only Emit in Verbose Mode

### DIFF
--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -242,6 +242,9 @@ std::tuple<rtcx::library, rtcx::blob> compile_library(
 
   if (use_minimal) { options.emplace_back("--minimal"); }
 
+  // suppress warnings if not in verbose mode
+  if (!cfg.jit_verbose) { options.emplace_back("--disable-warnings"); }
+
   if (use_pch) {
     options.emplace_back("--pch");
 
@@ -252,9 +255,6 @@ std::tuple<rtcx::library, rtcx::blob> compile_library(
       options.emplace_back("--pch-verbose=false");
       options.emplace_back("--pch-messages=false");
     }
-  } else {
-    // suppress warning about nv_hdrstop directive on later CUDA versions
-    options.emplace_back("--diag-suppress=161");
   }
 
   if (cfg.disable_cuda_cache) { options.emplace_back("--no-cache"); }
@@ -328,6 +328,9 @@ rtcx::blob compile_fragment(char const* name,
 
   if (use_minimal) { options.emplace_back("--minimal"); }
 
+  // suppress warnings if not in verbose mode
+  if (!cfg.jit_verbose) { options.emplace_back("--disable-warnings"); }
+
   if (use_pch) {
     options.emplace_back("--pch");
     options.emplace_back(std::format("--pch-dir={}", pch_dir));
@@ -339,9 +342,6 @@ rtcx::blob compile_fragment(char const* name,
       options.emplace_back("--pch-verbose=false");
       options.emplace_back("--pch-messages=false");
     }
-  } else {
-    // suppress warning about nv_hdrstop directive on later CUDA versions
-    options.emplace_back("--diag-suppress=161");
   }
 
   if (cfg.disable_cuda_cache) { options.emplace_back("--no-cache"); }


### PR DESCRIPTION
## Description

Makes JIT compilation warnings to only be emitted in verbose mode.
Upstream Dependencies like CCCL and CUB may deprecate public and internal APIs and we don't have control over them. We don't want downstream libcudf users to have JIT compilation warnings in their logs.

Closes https://github.com/NVIDIA/cudf/issues/23707



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
