### PR TITLE
[FEA] Update `ndsh` data generator to use partitions and stage in pinned memory

### DIFF
--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -396,41 +396,12 @@ std::unique_ptr<cudf::table> generate_lineitem_core(cudf::table_view const& orde
     return std::make_tuple(std::move(gathered_table->release()[1]), std::move(mask_index_type));
   }();
 
-  // Generate the `lineitem` core
-  std::vector<std::unique_ptr<cudf::column>> columns;
-  columns.push_back(std::move(l_linestatus_mask));
-  columns.push_back(std::move(l_orderkey));
-  columns.push_back(std::move(l_partkey));
-  columns.push_back(std::move(l_suppkey));
-  columns.push_back(std::move(l_linenumber));
-  columns.push_back(std::move(l_quantity));
-  columns.push_back(std::move(l_discount));
-  columns.push_back(std::move(l_tax));
-  columns.push_back(std::move(l_returnflag));
-  columns.push_back(std::move(l_linestatus));
-  columns.push_back(std::move(l_shipdate_ts));
-  columns.push_back(std::move(l_commitdate_ts));
-  columns.push_back(std::move(l_receiptdate_ts));
-  return std::make_unique<cudf::table>(std::move(columns));
-}
-
-std::unique_ptr<cudf::table> generate_lineitem_core_with_extended_price(
-  cudf::table_view const& orders_independent,
-  double scale_factor,
-  unsigned int seed,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
-{
-  auto lineitem_core = generate_lineitem_core(orders_independent, scale_factor, seed, stream, mr);
-
   // `p_retailprice` is a deterministic function of `p_partkey`, so a full `part` table is not
   // required to calculate `l_extendedprice`.
   auto l_extendedprice = [&]() {
-    auto const l_partkey     = lineitem_core->get_column(2).view();
-    auto const l_quantity    = lineitem_core->get_column(5).view();
-    auto const p_retailprice = calculate_p_retailprice(l_partkey, stream, mr);
+    auto const p_retailprice = calculate_p_retailprice(l_partkey->view(), stream, mr);
     auto const l_quantity_fp =
-      cudf::cast(l_quantity, cudf::data_type{cudf::type_id::FLOAT64}, stream, mr);
+      cudf::cast(l_quantity->view(), cudf::data_type{cudf::type_id::FLOAT64}, stream, mr);
     return cudf::binary_operation(l_quantity_fp->view(),
                                   p_retailprice->view(),
                                   cudf::binary_operator::MUL,
@@ -439,9 +410,23 @@ std::unique_ptr<cudf::table> generate_lineitem_core_with_extended_price(
                                   mr);
   }();
 
-  auto lineitem_core_columns = lineitem_core->release();
-  lineitem_core_columns.insert(lineitem_core_columns.begin() + 6, std::move(l_extendedprice));
-  return std::make_unique<cudf::table>(std::move(lineitem_core_columns));
+  // Generate the `lineitem` core
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(l_linestatus_mask));
+  columns.push_back(std::move(l_orderkey));
+  columns.push_back(std::move(l_partkey));
+  columns.push_back(std::move(l_suppkey));
+  columns.push_back(std::move(l_linenumber));
+  columns.push_back(std::move(l_quantity));
+  columns.push_back(std::move(l_extendedprice));
+  columns.push_back(std::move(l_discount));
+  columns.push_back(std::move(l_tax));
+  columns.push_back(std::move(l_returnflag));
+  columns.push_back(std::move(l_linestatus));
+  columns.push_back(std::move(l_shipdate_ts));
+  columns.push_back(std::move(l_commitdate_ts));
+  columns.push_back(std::move(l_receiptdate_ts));
+  return std::make_unique<cudf::table>(std::move(columns));
 }
 
 std::vector<cudf::table_view> partition_orders(cudf::table_view const& orders,
@@ -765,8 +750,7 @@ std::unique_ptr<cudf::table> generate_orders(double scale_factor,
   dependent_partitions.reserve(order_partitions.size());
   unsigned int seed = 0;
   for (auto const& order_partition : order_partitions) {
-    auto lineitem_core =
-      generate_lineitem_core_with_extended_price(order_partition, scale_factor, seed++, stream, mr);
+    auto lineitem_core = generate_lineitem_core(order_partition, scale_factor, seed++, stream, mr);
     dependent_partitions.push_back(generate_orders_dependent(lineitem_core->view(), stream, mr));
   }
 
@@ -799,8 +783,7 @@ void generate_lineitem_partitions(double scale_factor,
   unsigned int seed       = 0;
   for (auto const& order_partition :
        partition_orders(orders_independent->view(), orders_per_chunk, stream)) {
-    auto lineitem_core =
-      generate_lineitem_core_with_extended_price(order_partition, scale_factor, seed, stream, mr);
+    auto lineitem_core = generate_lineitem_core(order_partition, scale_factor, seed, stream, mr);
     consumer(
       finish_lineitem(std::move(lineitem_core), include_lineitem_comment, seed++, stream, mr));
   }

--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -14,6 +14,7 @@
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/sorting.hpp>
@@ -23,11 +24,14 @@
 #include <cudf/strings/padding.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <algorithm>
 #include <array>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -236,7 +240,7 @@ std::unique_ptr<cudf::table> generate_orders_independent(double scale_factor,
   // Generate the `o_shippriority` column
   auto o_shippriority = [&]() {
     auto const empty = cudf::make_numeric_column(
-      cudf::data_type{cudf::type_id::INT8}, o_num_rows, cudf::mask_state::UNALLOCATED, stream);
+      cudf::data_type{cudf::type_id::INT8}, o_num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
     return cudf::fill(empty->view(), 0, o_num_rows, cudf::numeric_scalar<int8_t>(0), stream, mr);
   }();
 
@@ -257,17 +261,18 @@ std::unique_ptr<cudf::table> generate_orders_independent(double scale_factor,
 }
 
 /**
- * @brief Generate the `lineitem` table partially
+ * @brief Generate the retained core columns of the `lineitem` table
  *
  * @param orders_independent Table with the independent columns of the `orders` table
  * @param scale_factor The scale factor to generate
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
-std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& orders_independent,
-                                                       double scale_factor,
-                                                       rmm::cuda_stream_view stream,
-                                                       rmm::device_async_resource_ref mr)
+std::unique_ptr<cudf::table> generate_lineitem_core(cudf::table_view const& orders_independent,
+                                                    double scale_factor,
+                                                    unsigned int seed,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
   auto const o_num_rows = orders_independent.num_rows();
@@ -277,7 +282,8 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   // For each `o_orderkey`, generate a random number (between 1 and 7),
   // which will be the number of rows in the `lineitem` table that will
   // have the same `l_orderkey`
-  auto const o_rep_freqs = generate_random_numeric_column<int8_t>(1, 7, o_num_rows, stream, mr);
+  auto const o_rep_freqs =
+    generate_random_numeric_column<int8_t>(1, 7, o_num_rows, seed, stream, mr);
 
   // Sum up the `o_rep_freqs` to get the number of rows in the
   // `lineitem` table. This is required to generate the independent columns
@@ -297,7 +303,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
 
   // Generate the `l_partkey` column
   auto l_partkey = generate_random_numeric_column<cudf::size_type>(
-    1, scale_factor * 200'000, l_num_rows, stream, mr);
+    1, scale_factor * 200'000, l_num_rows, seed, stream, mr);
 
   // Generate the `l_suppkey` column
   auto l_suppkey = calculate_l_suppkey(l_partkey->view(), scale_factor, l_num_rows, stream, mr);
@@ -306,13 +312,14 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   auto l_linenumber = generate_repeat_sequence_column<int8_t>(7, false, l_num_rows, stream, mr);
 
   // Generate the `l_quantity` column
-  auto l_quantity = generate_random_numeric_column<int8_t>(1, 50, l_num_rows, stream, mr);
+  auto l_quantity = generate_random_numeric_column<int8_t>(1, 50, l_num_rows, seed, stream, mr);
 
   // Generate the `l_discount` column
-  auto l_discount = generate_random_numeric_column<double>(0.00, 0.10, l_num_rows, stream, mr);
+  auto l_discount =
+    generate_random_numeric_column<double>(0.00, 0.10, l_num_rows, seed, stream, mr);
 
   // Generate the `l_tax` column
-  auto l_tax = generate_random_numeric_column<double>(0.00, 0.08, l_num_rows, stream, mr);
+  auto l_tax = generate_random_numeric_column<double>(0.00, 0.08, l_num_rows, seed, stream, mr);
 
   // Get the orderdate column from the `l_base` table
   auto const ol_orderdate_ts = std::move(l_base_columns[1]);
@@ -320,7 +327,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   // Generate the `l_shipdate` column
   auto l_shipdate_ts = [&]() {
     auto const l_shipdate_rand_add_days =
-      generate_random_numeric_column<int8_t>(1, 121, l_num_rows, stream, mr);
+      generate_random_numeric_column<int8_t>(1, 121, l_num_rows, seed, stream, mr);
     return add_calendrical_days(
       ol_orderdate_ts->view(), l_shipdate_rand_add_days->view(), stream, mr);
   }();
@@ -328,7 +335,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   // Generate the `l_commitdate` column
   auto l_commitdate_ts = [&]() {
     auto const l_commitdate_rand_add_days =
-      generate_random_numeric_column<int8_t>(30, 90, l_num_rows, stream, mr);
+      generate_random_numeric_column<int8_t>(30, 90, l_num_rows, seed, stream, mr);
     return add_calendrical_days(
       ol_orderdate_ts->view(), l_commitdate_rand_add_days->view(), stream, mr);
   }();
@@ -336,7 +343,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   // Generate the `l_receiptdate` column
   auto l_receiptdate_ts = [&]() {
     auto const l_receiptdate_rand_add_days =
-      generate_random_numeric_column<int8_t>(1, 30, l_num_rows, stream, mr);
+      generate_random_numeric_column<int8_t>(1, 30, l_num_rows, seed, stream, mr);
     return add_calendrical_days(
       l_shipdate_ts->view(), l_receiptdate_rand_add_days->view(), stream, mr);
   }();
@@ -389,26 +396,7 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
     return std::make_tuple(std::move(gathered_table->release()[1]), std::move(mask_index_type));
   }();
 
-  // Generate the `l_shipinstruct` column
-  auto l_shipinstruct = generate_random_string_column_from_set(
-    cudf::host_span<char const* const>(vocab_instructions.data(), vocab_instructions.size()),
-    l_num_rows,
-    stream,
-    mr);
-
-  // Generate the `l_shipmode` column
-  auto l_shipmode = generate_random_string_column_from_set(
-    cudf::host_span<char const* const>(vocab_modes.data(), vocab_modes.size()),
-    l_num_rows,
-    stream,
-    mr);
-
-  // Generate the `l_comment` column
-  // NOTE: This column is not compliant with
-  // clause 4.2.2.10 of the TPC-H specification
-  auto l_comment = generate_random_string_column(10, 43, l_num_rows, stream, mr);
-
-  // Generate the `lineitem_partial` table
+  // Generate the `lineitem` core
   std::vector<std::unique_ptr<cudf::column>> columns;
   columns.push_back(std::move(l_linestatus_mask));
   columns.push_back(std::move(l_orderkey));
@@ -423,10 +411,78 @@ std::unique_ptr<cudf::table> generate_lineitem_partial(cudf::table_view const& o
   columns.push_back(std::move(l_shipdate_ts));
   columns.push_back(std::move(l_commitdate_ts));
   columns.push_back(std::move(l_receiptdate_ts));
-  columns.push_back(std::move(l_shipinstruct));
-  columns.push_back(std::move(l_shipmode));
-  columns.push_back(std::move(l_comment));
   return std::make_unique<cudf::table>(std::move(columns));
+}
+
+std::unique_ptr<cudf::table> generate_lineitem_core_with_extended_price(
+  cudf::table_view const& orders_independent,
+  double scale_factor,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto lineitem_core = generate_lineitem_core(orders_independent, scale_factor, seed, stream, mr);
+
+  // `p_retailprice` is a deterministic function of `p_partkey`, so a full `part` table is not
+  // required to calculate `l_extendedprice`.
+  auto l_extendedprice = [&]() {
+    auto const l_partkey     = lineitem_core->get_column(2).view();
+    auto const l_quantity    = lineitem_core->get_column(5).view();
+    auto const p_retailprice = calculate_p_retailprice(l_partkey, stream, mr);
+    auto const l_quantity_fp =
+      cudf::cast(l_quantity, cudf::data_type{cudf::type_id::FLOAT64}, stream, mr);
+    return cudf::binary_operation(l_quantity_fp->view(),
+                                  p_retailprice->view(),
+                                  cudf::binary_operator::MUL,
+                                  cudf::data_type{cudf::type_id::FLOAT64},
+                                  stream,
+                                  mr);
+  }();
+
+  auto lineitem_core_columns = lineitem_core->release();
+  lineitem_core_columns.insert(lineitem_core_columns.begin() + 6, std::move(l_extendedprice));
+  return std::make_unique<cudf::table>(std::move(lineitem_core_columns));
+}
+
+std::vector<cudf::table_view> partition_orders(cudf::table_view const& orders,
+                                               cudf::size_type orders_per_chunk,
+                                               rmm::cuda_stream_view stream)
+{
+  CUDF_EXPECTS(orders_per_chunk > 0, "Orders per chunk must be positive");
+  std::vector<cudf::size_type> splits;
+  for (auto split = orders_per_chunk; split < orders.num_rows(); split += orders_per_chunk) {
+    splits.push_back(split);
+  }
+  return cudf::split(orders, splits, stream);
+}
+
+std::unique_ptr<cudf::table> finish_lineitem(std::unique_ptr<cudf::table> lineitem_core,
+                                             bool include_lineitem_comment,
+                                             unsigned int seed,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr)
+{
+  auto const l_num_rows = lineitem_core->num_rows();
+  auto lineitem_columns = lineitem_core->release();
+  lineitem_columns.erase(lineitem_columns.begin());  // Remove the private `l_linestatus_mask`
+
+  lineitem_columns.push_back(generate_random_string_column_from_set(
+    cudf::host_span<char const* const>(vocab_instructions.data(), vocab_instructions.size()),
+    l_num_rows,
+    seed,
+    stream,
+    mr));
+  lineitem_columns.push_back(generate_random_string_column_from_set(
+    cudf::host_span<char const* const>(vocab_modes.data(), vocab_modes.size()),
+    l_num_rows,
+    seed,
+    stream,
+    mr));
+  if (include_lineitem_comment) {
+    // NOTE: This column is not compliant with clause 4.2.2.10 of the TPC-H specification
+    lineitem_columns.push_back(generate_random_string_column(10, 43, l_num_rows, seed, stream, mr));
+  }
+  return std::make_unique<cudf::table>(std::move(lineitem_columns));
 }
 
 /**
@@ -695,72 +751,59 @@ std::unique_ptr<cudf::table> generate_part(double scale_factor,
   return std::make_unique<cudf::table>(std::move(columns));
 }
 
-/**
- * @brief Generate the `orders`, `lineitem`, and `part` tables
- *
- * @param scale_factor The scale factor to generate
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
- */
-std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>>
-generate_orders_lineitem_part(double scale_factor,
-                              rmm::cuda_stream_view stream,
-                              rmm::device_async_resource_ref mr)
+std::unique_ptr<cudf::table> generate_orders(double scale_factor,
+                                             cudf::size_type orders_per_chunk,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr)
 {
   CUDF_BENCHMARK_RANGE();
-  // Generate a table with the independent columns of the `orders` table
   auto orders_independent = generate_orders_independent(scale_factor, stream, mr);
+  auto const order_partitions =
+    partition_orders(orders_independent->view(), orders_per_chunk, stream);
 
-  // Generate the `lineitem` table partially
-  auto lineitem_partial =
-    generate_lineitem_partial(orders_independent->view(), scale_factor, stream, mr);
+  std::vector<std::unique_ptr<cudf::table>> dependent_partitions;
+  dependent_partitions.reserve(order_partitions.size());
+  unsigned int seed = 0;
+  for (auto const& order_partition : order_partitions) {
+    auto lineitem_core =
+      generate_lineitem_core_with_extended_price(order_partition, scale_factor, seed++, stream, mr);
+    dependent_partitions.push_back(generate_orders_dependent(lineitem_core->view(), stream, mr));
+  }
 
-  // Generate the `part` table
-  auto part = generate_part(scale_factor, stream, mr);
-
-  // Join the `part` and partial `lineitem` tables, then calculate the `l_extendedprice` column
-  auto l_extendedprice = [&]() {
-    auto const left = cudf::table_view(
-      {lineitem_partial->get_column(2).view(), lineitem_partial->get_column(5).view()});
-    auto const right = cudf::table_view({part->get_column(0).view(), part->get_column(7).view()});
-    auto const joined_table   = perform_left_join(left, right, {0}, {0}, stream, mr);
-    auto joined_table_columns = joined_table->release();
-    auto const l_quantity     = std::move(joined_table_columns[1]);
-    auto const l_quantity_fp =
-      cudf::cast(l_quantity->view(), cudf::data_type{cudf::type_id::FLOAT64}, stream, mr);
-    auto const p_retailprice = std::move(joined_table_columns[3]);
-    return cudf::binary_operation(l_quantity_fp->view(),
-                                  p_retailprice->view(),
-                                  cudf::binary_operator::MUL,
-                                  cudf::data_type{cudf::type_id::FLOAT64},
-                                  stream,
-                                  mr);
-  }();
-
-  // Insert the `l_extendedprice` column into the partial columns of the `lineitem` table
-  auto lineitem_partial_columns = lineitem_partial->release();
-  lineitem_partial_columns.insert(lineitem_partial_columns.begin() + 6, std::move(l_extendedprice));
-  auto lineitem_temp = std::make_unique<cudf::table>(std::move(lineitem_partial_columns));
-
-  // Generate the dependent columns of the `orders` table
-  // and merge them with the independent columns
-  auto orders_dependent = generate_orders_dependent(lineitem_temp->view(), stream, mr);
+  std::vector<cudf::table_view> dependent_views;
+  dependent_views.reserve(dependent_partitions.size());
+  std::transform(dependent_partitions.begin(),
+                 dependent_partitions.end(),
+                 std::back_inserter(dependent_views),
+                 [](auto const& table) { return table->view(); });
+  auto orders_dependent = cudf::concatenate(dependent_views, stream, mr);
+  dependent_partitions.clear();
 
   auto orders_independent_columns = orders_independent->release();
   auto orders_dependent_columns   = orders_dependent->release();
   orders_independent_columns.insert(orders_independent_columns.begin() + 2,
                                     std::make_move_iterator(orders_dependent_columns.begin()),
                                     std::make_move_iterator(orders_dependent_columns.end()));
+  return std::make_unique<cudf::table>(std::move(orders_independent_columns));
+}
 
-  // Create the `orders` table
-  auto orders = std::make_unique<cudf::table>(std::move(orders_independent_columns));
-
-  // Create the `lineitem` table
-  auto lineitem_temp_columns = lineitem_temp->release();
-  lineitem_temp_columns.erase(lineitem_temp_columns.begin());
-  auto lineitem = std::make_unique<cudf::table>(std::move(lineitem_temp_columns));
-
-  return std::make_tuple(std::move(orders), std::move(lineitem), std::move(part));
+void generate_lineitem_partitions(double scale_factor,
+                                  cudf::size_type orders_per_chunk,
+                                  std::function<void(std::unique_ptr<cudf::table>)> const& consumer,
+                                  bool include_lineitem_comment,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr)
+{
+  CUDF_BENCHMARK_RANGE();
+  auto orders_independent = generate_orders_independent(scale_factor, stream, mr);
+  unsigned int seed       = 0;
+  for (auto const& order_partition :
+       partition_orders(orders_independent->view(), orders_per_chunk, stream)) {
+    auto lineitem_core =
+      generate_lineitem_core_with_extended_price(order_partition, scale_factor, seed, stream, mr);
+    consumer(
+      finish_lineitem(std::move(lineitem_core), include_lineitem_comment, seed++, stream, mr));
+  }
 }
 
 /**

--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.hpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.hpp
@@ -9,18 +9,51 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <functional>
+
 namespace CUDF_EXPORT cudf {
 namespace datagen {
 
 /**
- * @brief Generate the `orders`, `lineitem`, and `part` tables
+ * @brief Generate `orders` without retaining generated `lineitem` columns
+ *
+ * @param scale_factor The scale factor to generate
+ * @param orders_per_chunk Maximum number of orders used to generate each lineitem chunk
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned table
+ */
+std::unique_ptr<cudf::table> generate_orders(
+  double scale_factor,
+  cudf::size_type orders_per_chunk,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Generate and consume bounded-size `lineitem` partitions
+ *
+ * @param scale_factor The scale factor to generate
+ * @param orders_per_chunk Maximum number of orders used to generate each lineitem chunk
+ * @param consumer Function invoked once for each generated partition
+ * @param include_lineitem_comment Whether to generate the `l_comment` column
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate generated tables
+ */
+void generate_lineitem_partitions(
+  double scale_factor,
+  cudf::size_type orders_per_chunk,
+  std::function<void(std::unique_ptr<cudf::table>)> const& consumer,
+  bool include_lineitem_comment     = false,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Generate the `part` table independently
  *
  * @param scale_factor The scale factor to generate
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
+ * @param mr Device memory resource used to allocate the returned table
  */
-std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>>
-generate_orders_lineitem_part(
+std::unique_ptr<cudf::table> generate_part(
   double scale_factor,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());

--- a/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.cu
+++ b/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.cu
@@ -33,7 +33,10 @@ struct random_string_generator {
   thrust::default_random_engine engine;
   thrust::uniform_int_distribution<unsigned char> char_dist;
 
-  CUDF_HOST_DEVICE random_string_generator(char* c) : chars(c), char_dist(44, 122) {}
+  CUDF_HOST_DEVICE random_string_generator(char* c, unsigned int seed)
+    : chars(c), engine(seed), char_dist(44, 122)
+  {
+  }
 
   __device__ void operator()(cuda::std::tuple<int64_t, int64_t> str_begin_end)
   {
@@ -55,18 +58,22 @@ template <typename T>
 struct random_number_generator {
   T lower;
   T upper;
+  unsigned int seed;
 
-  CUDF_HOST_DEVICE random_number_generator(T lower, T upper) : lower(lower), upper(upper) {}
+  CUDF_HOST_DEVICE random_number_generator(T lower, T upper, unsigned int seed = 0)
+    : lower(lower), upper(upper), seed(seed)
+  {
+  }
 
   __device__ T operator()(int64_t const idx) const
   {
     if constexpr (cudf::is_integral<T>()) {
-      thrust::default_random_engine engine;
+      thrust::default_random_engine engine(seed);
       thrust::uniform_int_distribution<T> dist(lower, upper);
       engine.discard(idx);
       return dist(engine);
     } else {
-      thrust::default_random_engine engine;
+      thrust::default_random_engine engine(seed);
       thrust::uniform_real_distribution<T> dist(lower, upper);
       engine.discard(idx);
       return dist(engine);
@@ -82,12 +89,22 @@ std::unique_ptr<cudf::column> generate_random_string_column(cudf::size_type lowe
                                                             rmm::cuda_stream_view stream,
                                                             rmm::device_async_resource_ref mr)
 {
+  return generate_random_string_column(lower, upper, num_rows, 0, stream, mr);
+}
+
+std::unique_ptr<cudf::column> generate_random_string_column(cudf::size_type lower,
+                                                            cudf::size_type upper,
+                                                            cudf::size_type num_rows,
+                                                            unsigned int seed,
+                                                            rmm::cuda_stream_view stream,
+                                                            rmm::device_async_resource_ref mr)
+{
   CUDF_BENCHMARK_RANGE();
   auto offsets_begin = cudf::detail::make_counting_transform_iterator(
-    0, random_number_generator<cudf::size_type>(lower, upper));
+    0, random_number_generator<cudf::size_type>(lower, upper, seed));
   auto [offsets_column, computed_bytes] = cudf::strings::detail::make_offsets_child_column(
     offsets_begin, offsets_begin + num_rows, stream, mr);
-  rmm::device_uvector<char> chars(computed_bytes, stream);
+  rmm::device_uvector<char> chars(computed_bytes, stream, mr);
 
   auto const offset_itr =
     cudf::detail::offsetalator_factory::make_input_iterator(offsets_column->view());
@@ -97,7 +114,7 @@ std::unique_ptr<cudf::column> generate_random_string_column(cudf::size_type lowe
   thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      cuda::make_zip_iterator(cuda::std::make_tuple(offset_itr, offset_itr + 1)),
                      num_rows,
-                     random_string_generator(chars.data()));
+                     random_string_generator(chars.data(), seed));
 
   return cudf::make_strings_column(
     num_rows, std::move(offsets_column), chars.release(), 0, rmm::device_buffer{});
@@ -110,6 +127,17 @@ std::unique_ptr<cudf::column> generate_random_numeric_column(T lower,
                                                              rmm::cuda_stream_view stream,
                                                              rmm::device_async_resource_ref mr)
 {
+  return generate_random_numeric_column(lower, upper, num_rows, 0, stream, mr);
+}
+
+template <typename T>
+std::unique_ptr<cudf::column> generate_random_numeric_column(T lower,
+                                                             T upper,
+                                                             cudf::size_type num_rows,
+                                                             unsigned int seed,
+                                                             rmm::cuda_stream_view stream,
+                                                             rmm::device_async_resource_ref mr)
+{
   CUDF_BENCHMARK_RANGE();
   auto col = cudf::make_numeric_column(
     cudf::data_type{cudf::type_to_id<T>()}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
@@ -119,7 +147,7 @@ std::unique_ptr<cudf::column> generate_random_numeric_column(T lower,
                     cuda::counting_iterator{begin},
                     cuda::counting_iterator{end},
                     col->mutable_view().begin<T>(),
-                    random_number_generator<T>(lower, upper));
+                    random_number_generator<T>(lower, upper, seed));
   return col;
 }
 
@@ -151,6 +179,38 @@ template std::unique_ptr<cudf::column> generate_random_numeric_column<double>(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
+template std::unique_ptr<cudf::column> generate_random_numeric_column<int8_t>(
+  int8_t lower,
+  int8_t upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+template std::unique_ptr<cudf::column> generate_random_numeric_column<int16_t>(
+  int16_t lower,
+  int16_t upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+template std::unique_ptr<cudf::column> generate_random_numeric_column<cudf::size_type>(
+  cudf::size_type lower,
+  cudf::size_type upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+template std::unique_ptr<cudf::column> generate_random_numeric_column<double>(
+  double lower,
+  double upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
 std::unique_ptr<cudf::column> generate_primary_key_column(cudf::scalar const& start,
                                                           cudf::size_type num_rows,
                                                           rmm::cuda_stream_view stream,
@@ -176,6 +236,16 @@ std::unique_ptr<cudf::column> generate_random_string_column_from_set(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  return generate_random_string_column_from_set(set, num_rows, 0, stream, mr);
+}
+
+std::unique_ptr<cudf::column> generate_random_string_column_from_set(
+  cudf::host_span<char const* const> set,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
   CUDF_BENCHMARK_RANGE();
   // Build a gather map of random strings to choose from
   // The size of the string sets always fits within 16-bit integers
@@ -186,7 +256,7 @@ std::unique_ptr<cudf::column> generate_random_string_column_from_set(
 
   // Build a column of random keys to gather from the set
   auto const gather_keys =
-    generate_random_numeric_column<int16_t>(0, set.size() - 1, num_rows, stream, mr);
+    generate_random_numeric_column<int16_t>(0, set.size() - 1, num_rows, seed, stream, mr);
 
   // Perform the gather operation
   auto const gathered_table = cudf::gather(

--- a/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.hpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/random_column_generator.hpp
@@ -30,6 +30,18 @@ std::unique_ptr<cudf::column> generate_random_string_column(
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
+ * @overload
+ * @param seed Seed used to initialize the random number generator
+ */
+std::unique_ptr<cudf::column> generate_random_string_column(
+  cudf::size_type lower,
+  cudf::size_type upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
  * @brief Generate a column of random numbers
  *
  * Example:
@@ -51,6 +63,19 @@ std::unique_ptr<cudf::column> generate_random_numeric_column(
   T lower,
   T upper,
   cudf::size_type num_rows,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @overload
+ * @param seed Seed used to initialize the random number generator
+ */
+template <typename T>
+std::unique_ptr<cudf::column> generate_random_numeric_column(
+  T lower,
+  T upper,
+  cudf::size_type num_rows,
+  unsigned int seed,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
@@ -111,6 +136,17 @@ std::unique_ptr<cudf::column> generate_repeat_string_column(
 std::unique_ptr<cudf::column> generate_random_string_column_from_set(
   cudf::host_span<char const* const> set,
   cudf::size_type num_rows,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @overload
+ * @param seed Seed used to initialize the random number generator
+ */
+std::unique_ptr<cudf::column> generate_random_string_column_from_set(
+  cudf::host_span<char const* const> set,
+  cudf::size_type num_rows,
+  unsigned int seed,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
 
   // Generate the `s` col
   auto s_empty = cudf::make_numeric_column(
-    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream);
+    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
 
   auto s = cudf::fill(s_empty->view(),
                       0,
@@ -227,7 +227,7 @@ std::unique_ptr<cudf::table> perform_left_join(cudf::table_view const& left_inpu
 
   // Generate the `s` col
   auto s_empty = cudf::make_numeric_column(
-    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream);
+    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
 
   auto s = cudf::fill(s_empty->view(),
                       0,

--- a/cpp/benchmarks/ndsh/q01.cpp
+++ b/cpp/benchmarks/ndsh/q01.cpp
@@ -165,7 +165,7 @@ void ndsh_q1(nvbench::state& state)
     state.skip("Only scale_factor=1 supported with filename input");
     return;
   }
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   auto source = [&] {
     if (filename.empty()) {
       generate_parquet_data_sources(scale_factor, {"lineitem"}, sources);

--- a/cpp/benchmarks/ndsh/q01.cpp
+++ b/cpp/benchmarks/ndsh/q01.cpp
@@ -6,6 +6,7 @@
 #include "utilities.hpp"
 
 #include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
@@ -95,8 +96,10 @@
     disc_price, one_plus_tax->view(), cudf::binary_operator::MUL, tax.type(), stream, mr);
 }
 
-void run_ndsh_q1(nvbench::state& state, cudf::io::source_info const& source)
+void run_ndsh_q1(cudf::io::source_info const& source)
 {
+  auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+
   // Define the column projections and filter predicate for `lineitem` table
   std::vector<std::string> const lineitem_cols = {"l_returnflag",
                                                   "l_linestatus",
@@ -177,7 +180,7 @@ void ndsh_q1(nvbench::state& state)
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q1(state, source); });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q1(source); });
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/ndsh/q05.cpp
+++ b/cpp/benchmarks/ndsh/q05.cpp
@@ -79,8 +79,7 @@
   return revenue;
 }
 
-void run_ndsh_q5(nvbench::state& state,
-                 std::unordered_map<std::string, cuio_source_sink_pair>& sources)
+void run_ndsh_q5(nvbench::state& state, ndsh_data_sources& sources)
 {
   // Define the column projection and filter predicate for the `orders` table
   std::vector<std::string> const orders_cols = {"o_custkey", "o_orderkey", "o_orderdate"};
@@ -156,15 +155,16 @@ void ndsh_q5(nvbench::state& state)
 {
   // Generate the required parquet files in device buffers
   double const scale_factor = state.get_float64("scale_factor");
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(
     scale_factor, {"customer", "orders", "lineitem", "supplier", "nation", "region"}, sources);
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.exec(nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) { run_ndsh_q5(state, sources); });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    run_ndsh_q5(state, sources);
+  });
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/ndsh/q05.cpp
+++ b/cpp/benchmarks/ndsh/q05.cpp
@@ -6,6 +6,7 @@
 #include "utilities.hpp"
 
 #include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
@@ -79,8 +80,10 @@
   return revenue;
 }
 
-void run_ndsh_q5(nvbench::state& state, ndsh_data_sources& sources)
+void run_ndsh_q5(ndsh_data_sources& sources)
 {
+  auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+
   // Define the column projection and filter predicate for the `orders` table
   std::vector<std::string> const orders_cols = {"o_custkey", "o_orderkey", "o_orderdate"};
   auto const o_orderdate_ref                 = cudf::ast::column_reference(std::distance(
@@ -162,9 +165,7 @@ void ndsh_q5(nvbench::state& state)
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    run_ndsh_q5(state, sources);
-  });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q5(sources); });
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/ndsh/q06.cpp
+++ b/cpp/benchmarks/ndsh/q06.cpp
@@ -6,6 +6,7 @@
 #include "utilities.hpp"
 
 #include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
@@ -54,8 +55,10 @@
   return revenue;
 }
 
-void run_ndsh_q6(nvbench::state& state, ndsh_data_sources& sources)
+void run_ndsh_q6(ndsh_data_sources& sources)
 {
+  auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+
   // Read out the `lineitem` table from parquet file
   std::vector<std::string> const lineitem_cols = {
     "l_extendedprice", "l_discount", "l_shipdate", "l_quantity"};
@@ -130,8 +133,7 @@ void ndsh_q6(nvbench::state& state)
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.exec(nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) { run_ndsh_q6(state, sources); });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q6(sources); });
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/ndsh/q06.cpp
+++ b/cpp/benchmarks/ndsh/q06.cpp
@@ -54,8 +54,7 @@
   return revenue;
 }
 
-void run_ndsh_q6(nvbench::state& state,
-                 std::unordered_map<std::string, cuio_source_sink_pair>& sources)
+void run_ndsh_q6(nvbench::state& state, ndsh_data_sources& sources)
 {
   // Read out the `lineitem` table from parquet file
   std::vector<std::string> const lineitem_cols = {
@@ -125,7 +124,7 @@ void ndsh_q6(nvbench::state& state)
 {
   // Generate the required parquet files in device buffers
   double const scale_factor = state.get_float64("scale_factor");
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(scale_factor, {"lineitem"}, sources);
 
   auto stream = cudf::get_default_stream();

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -318,8 +318,9 @@ void ndsh_q9(nvbench::state& state)
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    q9_data const data = load_data(sources);
-    auto const result  = compute_profit(state,
+    auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+    q9_data const data               = load_data(sources);
+    auto const result                = compute_profit(state,
                                        engine,
                                        data,
                                        launch.get_stream().get_stream(),
@@ -345,7 +346,8 @@ void ndsh_q9_noio(nvbench::state& state)
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    result = compute_profit(state,
+    auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+    result                           = compute_profit(state,
                             engine,
                             data,
                             launch.get_stream().get_stream(),
@@ -378,7 +380,8 @@ void ndsh_q9_amount(nvbench::state& state)
 
   auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto amount = compute_amount(joined_table->column("l_discount"),
+    auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+    auto amount                      = compute_amount(joined_table->column("l_discount"),
                                  joined_table->column("l_extendedprice"),
                                  joined_table->column("ps_supplycost"),
                                  joined_table->column("l_quantity"),

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -225,7 +225,7 @@ struct q9_data {
   }
 }
 
-q9_data load_data(std::unordered_map<std::string, cuio_source_sink_pair>& sources)
+q9_data load_data(ndsh_data_sources& sources)
 {
   auto lineitem = read_parquet(
     sources.at("lineitem").make_source_info(),
@@ -312,7 +312,7 @@ void ndsh_q9(nvbench::state& state)
   auto const scale_factor = state.get_float64("scale_factor");
   auto const engine       = engine_from_string(state.get_string("engine"));
 
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(
     scale_factor, {"part", "supplier", "lineitem", "partsupp", "orders", "nation"}, sources);
 
@@ -335,7 +335,7 @@ void ndsh_q9_noio(nvbench::state& state)
   auto const scale_factor = state.get_float64("scale_factor");
   auto const engine       = engine_from_string(state.get_string("engine"));
 
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(
     scale_factor, {"part", "supplier", "lineitem", "partsupp", "orders", "nation"}, sources);
 
@@ -363,7 +363,7 @@ void ndsh_q9_amount(nvbench::state& state)
   auto const scale_factor = state.get_float64("scale_factor");
   auto const engine       = engine_from_string(state.get_string("engine"));
 
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(
     scale_factor, {"part", "supplier", "lineitem", "partsupp", "orders", "nation"}, sources);
 

--- a/cpp/benchmarks/ndsh/q10.cpp
+++ b/cpp/benchmarks/ndsh/q10.cpp
@@ -6,6 +6,7 @@
 #include "utilities.hpp"
 
 #include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
@@ -84,8 +85,10 @@
   return revenue;
 }
 
-void run_ndsh_q10(nvbench::state& state, ndsh_data_sources& sources)
+void run_ndsh_q10(ndsh_data_sources& sources)
 {
+  auto const query_execution_range = cudf::benchmark::scoped_range{"query_execution"};
+
   // Define the column projection and filter predicate for the `orders` table
   std::vector<std::string> const orders_cols = {"o_custkey", "o_orderkey", "o_orderdate"};
   auto const o_orderdate_ref                 = cudf::ast::column_reference(std::distance(
@@ -161,8 +164,7 @@ void ndsh_q10(nvbench::state& state)
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const mem_stats_logger = cudf::memory_stats_logger();
-  state.exec(nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) { run_ndsh_q10(state, sources); });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) { run_ndsh_q10(sources); });
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/ndsh/q10.cpp
+++ b/cpp/benchmarks/ndsh/q10.cpp
@@ -84,8 +84,7 @@
   return revenue;
 }
 
-void run_ndsh_q10(nvbench::state& state,
-                  std::unordered_map<std::string, cuio_source_sink_pair>& sources)
+void run_ndsh_q10(nvbench::state& state, ndsh_data_sources& sources)
 {
   // Define the column projection and filter predicate for the `orders` table
   std::vector<std::string> const orders_cols = {"o_custkey", "o_orderkey", "o_orderdate"};
@@ -155,7 +154,7 @@ void ndsh_q10(nvbench::state& state)
 {
   // Generate the required parquet files in device buffers
   double const scale_factor = state.get_float64("scale_factor");
-  std::unordered_map<std::string, cuio_source_sink_pair> sources;
+  ndsh_data_sources sources;
   generate_parquet_data_sources(
     scale_factor, {"customer", "orders", "lineitem", "nation"}, sources);
 

--- a/cpp/benchmarks/ndsh/utilities.cpp
+++ b/cpp/benchmarks/ndsh/utilities.cpp
@@ -99,7 +99,7 @@ std::unordered_map<std::string, std::vector<std::string> const> const SCHEMAS = 
 
 class device_buffer_sink final : public cudf::io::data_sink {
  public:
-  device_buffer_sink(std::size_t capacity, rmm::cuda_stream_view stream)
+  device_buffer_sink(std::size_t capacity, cuda::stream_ref stream)
     : buffer_{capacity, stream}, stream_{stream}
   {
   }
@@ -107,9 +107,8 @@ class device_buffer_sink final : public cudf::io::data_sink {
   void host_write(void const* data, std::size_t size) override
   {
     auto* destination = reserve(size);
-    CUDF_CUDA_TRY(
-      cudaMemcpyAsync(destination, data, size, cudaMemcpyHostToDevice, stream_.value()));
-    stream_.synchronize();
+    CUDF_CUDA_TRY(cudaMemcpyAsync(destination, data, size, cudaMemcpyDefault, stream_.get()));
+    stream_.sync();
   }
 
   [[nodiscard]] bool supports_device_write() const override { return true; }
@@ -126,8 +125,7 @@ class device_buffer_sink final : public cudf::io::data_sink {
                                        cuda::stream_ref stream) override
   {
     auto* destination = reserve(size);
-    CUDF_CUDA_TRY(
-      cudaMemcpyAsync(destination, gpu_data, size, cudaMemcpyDeviceToDevice, stream.get()));
+    CUDF_CUDA_TRY(cudaMemcpyAsync(destination, gpu_data, size, cudaMemcpyDefault, stream.get()));
     return std::async(std::launch::deferred, [stream] { stream.sync(); });
   }
 
@@ -147,32 +145,29 @@ class device_buffer_sink final : public cudf::io::data_sink {
   }
 
   rmm::device_buffer buffer_;
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
   std::size_t size_{};
 };
 }  // namespace
 
-ndsh_parquet_source::~ndsh_parquet_source()
+ndsh_parquet_source::ndsh_parquet_source()
+  : pinned_mr_{std::make_unique<rmm::mr::pinned_host_memory_resource>()}
 {
-  for (auto const& buffer : buffers_) {
-    (void)cudaFreeHost(buffer.data);
-  }
 }
 
+ndsh_parquet_source::~ndsh_parquet_source() = default;
+
 ndsh_parquet_source::ndsh_parquet_source(ndsh_parquet_source&& other) noexcept
-  : buffers_{std::move(other.buffers_)}
+  : pinned_mr_{std::move(other.pinned_mr_)}, buffers_{std::move(other.buffers_)}
 {
-  other.buffers_.clear();
 }
 
 ndsh_parquet_source& ndsh_parquet_source::operator=(ndsh_parquet_source&& other) noexcept
 {
   if (this != &other) {
-    for (auto const& buffer : buffers_) {
-      (void)cudaFreeHost(buffer.data);
-    }
-    buffers_ = std::move(other.buffers_);
-    other.buffers_.clear();
+    buffers_.clear();
+    pinned_mr_ = std::move(other.pinned_mr_);
+    buffers_   = std::move(other.buffers_);
   }
   return *this;
 }
@@ -183,8 +178,8 @@ ndsh_parquet_source& ndsh_parquet_source::operator=(ndsh_parquet_source&& other)
   spans.reserve(buffers_.size());
   std::transform(
     buffers_.begin(), buffers_.end(), std::back_inserter(spans), [](auto const& buffer) {
-      return cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(buffer.data),
-                                              buffer.size);
+      return cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(buffer.data()),
+                                              buffer.size());
     });
   return cudf::io::source_info(
     cudf::host_span<cudf::host_span<std::byte const>>(spans.data(), spans.size()));
@@ -192,14 +187,12 @@ ndsh_parquet_source& ndsh_parquet_source::operator=(ndsh_parquet_source&& other)
 
 void ndsh_parquet_source::append_from_device(void const* device_data,
                                              std::size_t size,
-                                             rmm::cuda_stream_view stream)
+                                             cuda::stream_ref stream)
 {
-  void* host_buffer{};
-  CUDF_CUDA_TRY(cudaMallocHost(&host_buffer, size));
-  buffers_.push_back({host_buffer, size});
+  buffers_.emplace_back(size, stream, *pinned_mr_);
   CUDF_CUDA_TRY(
-    cudaMemcpyAsync(host_buffer, device_data, size, cudaMemcpyDeviceToHost, stream.value()));
-  stream.synchronize();
+    cudaMemcpyAsync(buffers_.back().data(), device_data, size, cudaMemcpyDefault, stream.get()));
+  stream.sync();
 }
 
 cudf::table_view table_with_names::table() const { return tbl->view(); }

--- a/cpp/benchmarks/ndsh/utilities.cpp
+++ b/cpp/benchmarks/ndsh/utilities.cpp
@@ -13,22 +13,27 @@
 #include <cudf/copying.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/io/data_sink.hpp>
 #include <cudf/join/join.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
 
 #include <algorithm>
 #include <cstdlib>
 #include <ctime>
+#include <future>
 #include <iterator>
 #include <unordered_set>
+#include <utility>
 
 namespace {
 
@@ -91,7 +96,111 @@ std::unordered_map<std::string, std::vector<std::string> const> const SCHEMAS = 
   {"customer", CUSTOMER_SCHEMA},
   {"nation", NATION_SCHEMA},
   {"region", REGION_SCHEMA}};
+
+class device_buffer_sink final : public cudf::io::data_sink {
+ public:
+  device_buffer_sink(std::size_t capacity, rmm::cuda_stream_view stream)
+    : buffer_{capacity, stream}, stream_{stream}
+  {
+  }
+
+  void host_write(void const* data, std::size_t size) override
+  {
+    auto* destination = reserve(size);
+    CUDF_CUDA_TRY(
+      cudaMemcpyAsync(destination, data, size, cudaMemcpyHostToDevice, stream_.value()));
+    stream_.synchronize();
+  }
+
+  [[nodiscard]] bool supports_device_write() const override { return true; }
+
+  [[nodiscard]] bool is_device_write_preferred(std::size_t) const override { return true; }
+
+  void device_write(void const* gpu_data, std::size_t size, cuda::stream_ref stream) override
+  {
+    device_write_async(gpu_data, size, stream).get();
+  }
+
+  std::future<void> device_write_async(void const* gpu_data,
+                                       std::size_t size,
+                                       cuda::stream_ref stream) override
+  {
+    auto* destination = reserve(size);
+    CUDF_CUDA_TRY(
+      cudaMemcpyAsync(destination, gpu_data, size, cudaMemcpyDeviceToDevice, stream.get()));
+    return std::async(std::launch::deferred, [stream] { stream.sync(); });
+  }
+
+  void flush() override {}
+
+  [[nodiscard]] std::size_t bytes_written() override { return size_; }
+
+  [[nodiscard]] void const* data() const { return buffer_.data(); }
+
+ private:
+  void* reserve(std::size_t size)
+  {
+    CUDF_EXPECTS(size <= buffer_.size() - size_, "Parquet device sink capacity exceeded");
+    auto* destination = static_cast<std::byte*>(buffer_.data()) + size_;
+    size_ += size;
+    return destination;
+  }
+
+  rmm::device_buffer buffer_;
+  rmm::cuda_stream_view stream_;
+  std::size_t size_{};
+};
 }  // namespace
+
+ndsh_parquet_source::~ndsh_parquet_source()
+{
+  for (auto const& buffer : buffers_) {
+    (void)cudaFreeHost(buffer.data);
+  }
+}
+
+ndsh_parquet_source::ndsh_parquet_source(ndsh_parquet_source&& other) noexcept
+  : buffers_{std::move(other.buffers_)}
+{
+  other.buffers_.clear();
+}
+
+ndsh_parquet_source& ndsh_parquet_source::operator=(ndsh_parquet_source&& other) noexcept
+{
+  if (this != &other) {
+    for (auto const& buffer : buffers_) {
+      (void)cudaFreeHost(buffer.data);
+    }
+    buffers_ = std::move(other.buffers_);
+    other.buffers_.clear();
+  }
+  return *this;
+}
+
+[[nodiscard]] cudf::io::source_info ndsh_parquet_source::make_source_info() const
+{
+  std::vector<cudf::host_span<std::byte const>> spans;
+  spans.reserve(buffers_.size());
+  std::transform(
+    buffers_.begin(), buffers_.end(), std::back_inserter(spans), [](auto const& buffer) {
+      return cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(buffer.data),
+                                              buffer.size);
+    });
+  return cudf::io::source_info(
+    cudf::host_span<cudf::host_span<std::byte const>>(spans.data(), spans.size()));
+}
+
+void ndsh_parquet_source::append_from_device(void const* device_data,
+                                             std::size_t size,
+                                             rmm::cuda_stream_view stream)
+{
+  void* host_buffer{};
+  CUDF_CUDA_TRY(cudaMallocHost(&host_buffer, size));
+  buffers_.push_back({host_buffer, size});
+  CUDF_CUDA_TRY(
+    cudaMemcpyAsync(host_buffer, device_data, size, cudaMemcpyDeviceToHost, stream.value()));
+  stream.synchronize();
+}
 
 cudf::table_view table_with_names::table() const { return tbl->view(); }
 
@@ -154,11 +263,9 @@ std::unique_ptr<cudf::table> join_and_gather(cudf::table_view const& left_input,
 {
   CUDF_BENCHMARK_RANGE();
   constexpr auto oob_policy = cudf::out_of_bounds_policy::DONT_CHECK;
-  auto const left_selected  = left_input.select(left_on);
-  auto const right_selected = right_input.select(right_on);
-  auto const [left_join_indices, right_join_indices] =
-    cudf::inner_join(left_selected,
-                     right_selected,
+  auto [left_join_indices, right_join_indices] =
+    cudf::inner_join(left_input.select(left_on),
+                     right_input.select(right_on),
                      compare_nulls,
                      cudf::get_default_stream(),
                      cudf::get_current_device_resource_ref());
@@ -200,7 +307,6 @@ std::unique_ptr<table_with_names> apply_inner_join(
                  [&](auto const& col_name) { return right_input->column_id(col_name); });
   auto table = join_and_gather(
     left_input->table(), right_input->table(), left_on_indices, right_on_indices, compare_nulls);
-  ;
   std::vector<std::string> merged_column_names;
   merged_column_names.reserve(left_input->column_names().size() +
                               right_input->column_names().size());
@@ -342,9 +448,11 @@ int32_t days_since_epoch(int year, int month, int day)
 
 void write_to_parquet_device_buffer(std::unique_ptr<cudf::table> const& table,
                                     std::vector<std::string> const& col_names,
-                                    cuio_source_sink_pair& source)
+                                    ndsh_parquet_source& source,
+                                    std::size_t max_parquet_file_bytes)
 {
   CUDF_BENCHMARK_RANGE();
+  CUDF_EXPECTS(max_parquet_file_bytes > 0, "Maximum Parquet file size must be positive");
   auto const stream = cudf::get_default_stream();
 
   // Prepare the table metadata
@@ -356,45 +464,44 @@ void write_to_parquet_device_buffer(std::unique_ptr<cudf::table> const& table,
   metadata.schema_info            = col_name_infos;
   auto const table_input_metadata = cudf::io::table_input_metadata{metadata};
 
-  auto est_size                     = static_cast<std::size_t>(estimate_size(table->view()));
-  constexpr auto PQ_MAX_TABLE_BYTES = 8ul << 30;  // 8GB
-  // TODO: best to get this limit from percent_of_free_device_memory(50) of device memory resource.
-  if (est_size > PQ_MAX_TABLE_BYTES) {
-    auto builder = cudf::io::chunked_parquet_writer_options::builder(source.make_sink_info());
-    builder.metadata(table_input_metadata);
-    auto const options = builder.build();
-    auto num_splits    = static_cast<cudf::size_type>(
-      std::ceil(static_cast<long double>(est_size) / (PQ_MAX_TABLE_BYTES)));
-    std::vector<cudf::size_type> splits(num_splits - 1);
-    auto num_rows          = table->num_rows();
-    auto num_row_per_chunk = cudf::util::div_rounding_up_safe(num_rows, num_splits);
-    std::generate_n(splits.begin(), splits.size(), [num_row_per_chunk, i = 0]() mutable {
-      return (i += num_row_per_chunk);
-    });
-    std::vector<cudf::table_view> split_tables = cudf::split(table->view(), splits, stream);
-    auto writer                                = cudf::io::chunked_parquet_writer(options, stream);
-    for (auto const& chunk_table : split_tables) {
-      writer.write(chunk_table);
+  auto const est_size             = static_cast<std::size_t>(estimate_size(table->view()));
+  constexpr auto SINK_SLACK_BYTES = 64ul << 20;  // Parquet metadata and compression overhead
+  auto const num_partitions =
+    std::max<std::size_t>(1, cudf::util::div_rounding_up_safe(est_size, max_parquet_file_bytes));
+  auto const rows_per_partition = cudf::util::div_rounding_up_safe(
+    table->num_rows(), static_cast<cudf::size_type>(num_partitions));
+  std::vector<cudf::size_type> splits(num_partitions - 1);
+  std::generate_n(splits.begin(), splits.size(), [rows_per_partition, i = 0]() mutable {
+    return (i += rows_per_partition);
+  });
+  auto const partitions = cudf::split(table->view(), splits, stream);
+
+  for (auto const& partition : partitions) {
+    auto const partition_size = static_cast<std::size_t>(estimate_size(partition));
+    auto const sink_capacity  = partition_size + (partition_size / 20) + SINK_SLACK_BYTES;
+    device_buffer_sink sink{sink_capacity, stream};
+    auto const sink_info = cudf::io::sink_info(&sink);
+
+    auto const write_range = cudf::benchmark::scoped_range{"write_parquet_to_device_buffer"};
+    {
+      auto builder = cudf::io::parquet_writer_options::builder(sink_info, partition);
+      builder.metadata(table_input_metadata);
+      auto const options = builder.build();
+      cudf::io::write_parquet(options, stream);
     }
-    writer.close();
-    return;
+
+    auto const copy_range = cudf::benchmark::scoped_range{"copy_parquet_device_buffer_to_host"};
+    source.append_from_device(sink.data(), sink.bytes_written(), stream);
   }
-  // Write parquet data to host buffer
-  auto builder = cudf::io::parquet_writer_options::builder(source.make_sink_info(), table->view());
-  builder.metadata(table_input_metadata);
-  auto const options = builder.build();
-  cudf::io::write_parquet(options, stream);
 }
 
 void generate_parquet_data_sources(double scale_factor,
                                    std::vector<std::string> const& table_names,
-                                   std::unordered_map<std::string, cuio_source_sink_pair>& sources)
+                                   ndsh_data_sources& sources,
+                                   ndsh_data_generation_options const& options)
 {
   CUDF_BENCHMARK_RANGE();
-
-  // Use a managed pool for parquet generation.
-  rmm::mr::pool_memory_resource managed_pool_mr{rmm::mr::managed_memory_resource{},
-                                                rmm::percent_of_free_device_memory(50)};
+  auto const mr = cudf::get_current_device_resource_ref();
 
   std::unordered_set<std::string> const requested_table_names = [&table_names]() {
     if (table_names.empty()) {
@@ -403,53 +510,68 @@ void generate_parquet_data_sources(double scale_factor,
     }
     return std::unordered_set(table_names.begin(), table_names.end());
   }();
-  std::for_each(
-    requested_table_names.begin(), requested_table_names.end(), [&](auto const& table_name) {
-      sources.emplace(table_name, cuio_source_sink_pair(io_type::HOST_BUFFER));
-    });
-  std::unordered_map<std::string, std::unique_ptr<cudf::table>> tables;
+  std::for_each(requested_table_names.begin(),
+                requested_table_names.end(),
+                [&](auto const& table_name) { sources.try_emplace(table_name); });
 
   auto const stream = cudf::get_default_stream();
 
-  if (sources.count("orders") or sources.count("lineitem") or sources.count("part")) {
-    auto [orders, lineitem, part] =
-      cudf::datagen::generate_orders_lineitem_part(scale_factor, stream, managed_pool_mr);
+  if (sources.count("orders") or sources.count("lineitem")) {
     if (sources.count("orders")) {
-      write_to_parquet_device_buffer(orders, SCHEMAS.at("orders"), sources.at("orders"));
-      orders = {};
-    }
-    if (sources.count("part")) {
-      write_to_parquet_device_buffer(part, SCHEMAS.at("part"), sources.at("part"));
-      part = {};
+      auto orders =
+        cudf::datagen::generate_orders(scale_factor, options.orders_per_chunk, stream, mr);
+      write_to_parquet_device_buffer(
+        orders, SCHEMAS.at("orders"), sources.at("orders"), options.max_parquet_file_bytes);
     }
     if (sources.count("lineitem")) {
-      write_to_parquet_device_buffer(lineitem, SCHEMAS.at("lineitem"), sources.at("lineitem"));
-      lineitem = {};
+      auto lineitem_schema = LINEITEM_SCHEMA;
+      if (!options.include_lineitem_comment) { lineitem_schema.pop_back(); }
+      cudf::datagen::generate_lineitem_partitions(
+        scale_factor,
+        options.orders_per_chunk,
+        [&](auto lineitem) {
+          write_to_parquet_device_buffer(
+            lineitem, lineitem_schema, sources.at("lineitem"), options.max_parquet_file_bytes);
+        },
+        options.include_lineitem_comment,
+        stream,
+        mr);
     }
+  }
+
+  if (sources.count("part")) {
+    auto part = cudf::datagen::generate_part(scale_factor, stream, mr);
+    write_to_parquet_device_buffer(
+      part, SCHEMAS.at("part"), sources.at("part"), options.max_parquet_file_bytes);
   }
 
   if (sources.count("partsupp")) {
-    auto partsupp = cudf::datagen::generate_partsupp(scale_factor, stream, managed_pool_mr);
-    write_to_parquet_device_buffer(partsupp, SCHEMAS.at("partsupp"), sources.at("partsupp"));
+    auto partsupp = cudf::datagen::generate_partsupp(scale_factor, stream, mr);
+    write_to_parquet_device_buffer(
+      partsupp, SCHEMAS.at("partsupp"), sources.at("partsupp"), options.max_parquet_file_bytes);
   }
 
   if (sources.count("supplier")) {
-    auto supplier = cudf::datagen::generate_supplier(scale_factor, stream, managed_pool_mr);
-    write_to_parquet_device_buffer(supplier, SCHEMAS.at("supplier"), sources.at("supplier"));
+    auto supplier = cudf::datagen::generate_supplier(scale_factor, stream, mr);
+    write_to_parquet_device_buffer(
+      supplier, SCHEMAS.at("supplier"), sources.at("supplier"), options.max_parquet_file_bytes);
   }
 
   if (sources.count("customer")) {
-    auto customer = cudf::datagen::generate_customer(scale_factor, stream, managed_pool_mr);
-    write_to_parquet_device_buffer(customer, SCHEMAS.at("customer"), sources.at("customer"));
+    auto customer = cudf::datagen::generate_customer(scale_factor, stream, mr);
+    write_to_parquet_device_buffer(
+      customer, SCHEMAS.at("customer"), sources.at("customer"), options.max_parquet_file_bytes);
   }
 
   if (sources.count("nation")) {
-    auto nation = cudf::datagen::generate_nation(stream, managed_pool_mr);
-    write_to_parquet_device_buffer(nation, SCHEMAS.at("nation"), sources.at("nation"));
+    auto nation = cudf::datagen::generate_nation(stream, mr);
+    write_to_parquet_device_buffer(
+      nation, SCHEMAS.at("nation"), sources.at("nation"), options.max_parquet_file_bytes);
   }
 
   if (sources.count("region")) {
-    auto region = cudf::datagen::generate_region(stream, managed_pool_mr);
-    write_to_parquet_device_buffer(region, SCHEMAS.at("region"), sources.at("region"));
+    auto region = cudf::datagen::generate_region(stream, mr);
+    write_to_parquet_device_buffer(
+      region, SCHEMAS.at("region"), sources.at("region"), options.max_parquet_file_bytes);
   }
 }

--- a/cpp/benchmarks/ndsh/utilities.hpp
+++ b/cpp/benchmarks/ndsh/utilities.hpp
@@ -5,12 +5,50 @@
 
 #pragma once
 
-#include "io/cuio_common.hpp"
-
 #include <cudf/groupby.hpp>
 #include <cudf/io/parquet.hpp>
 
 #include <rmm/device_uvector.hpp>
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @brief Host-backed Parquet source populated from an NDS-H device sink
+ */
+class ndsh_parquet_source {
+ public:
+  ndsh_parquet_source() = default;
+  ~ndsh_parquet_source();
+
+  ndsh_parquet_source(ndsh_parquet_source&& other) noexcept;
+  ndsh_parquet_source& operator=(ndsh_parquet_source&& other) noexcept;
+
+  ndsh_parquet_source(ndsh_parquet_source const&)            = delete;
+  ndsh_parquet_source& operator=(ndsh_parquet_source const&) = delete;
+
+  [[nodiscard]] cudf::io::source_info make_source_info() const;
+
+  void append_from_device(void const* device_data, std::size_t size, rmm::cuda_stream_view stream);
+
+ private:
+  struct pinned_buffer {
+    void* data;
+    std::size_t size;
+  };
+
+  std::vector<pinned_buffer> buffers_;
+};
+
+using ndsh_data_sources = std::unordered_map<std::string, ndsh_parquet_source>;
+
+struct ndsh_data_generation_options {
+  cudf::size_type orders_per_chunk{16'000'000};
+  std::size_t max_parquet_file_bytes{8ul << 30};
+  bool include_lineitem_comment{false};
+};
 
 /**
  * @brief A class to represent a table with column names attached
@@ -193,10 +231,12 @@ int32_t days_since_epoch(int year, int month, int day);
  * @param table The `cudf::table` to write
  * @param col_names The column names of the table
  * @param source The source sink pair to write the table to
+ * @param max_parquet_file_bytes Maximum estimated uncompressed bytes per Parquet file
  */
 void write_to_parquet_device_buffer(std::unique_ptr<cudf::table> const& table,
                                     std::vector<std::string> const& col_names,
-                                    cuio_source_sink_pair& source);
+                                    ndsh_parquet_source& source,
+                                    std::size_t max_parquet_file_bytes);
 
 /**
  * @brief Generate NDS-H tables and write to parquet device buffers
@@ -204,7 +244,9 @@ void write_to_parquet_device_buffer(std::unique_ptr<cudf::table> const& table,
  * @param scale_factor The scale factor of NDS-H tables to generate
  * @param table_names The names of the tables to generate
  * @param sources The parquet data sources to populate
+ * @param options Chunking and schema options for generated data
  */
 void generate_parquet_data_sources(double scale_factor,
                                    std::vector<std::string> const& table_names,
-                                   std::unordered_map<std::string, cuio_source_sink_pair>& sources);
+                                   ndsh_data_sources& sources,
+                                   ndsh_data_generation_options const& options = {});

--- a/cpp/benchmarks/ndsh/utilities.hpp
+++ b/cpp/benchmarks/ndsh/utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,9 +8,13 @@
 #include <cudf/groupby.hpp>
 #include <cudf/io/parquet.hpp>
 
-#include <rmm/device_uvector.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/pinned_host_memory_resource.hpp>
+
+#include <cuda/stream>
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -20,7 +24,7 @@
  */
 class ndsh_parquet_source {
  public:
-  ndsh_parquet_source() = default;
+  ndsh_parquet_source();
   ~ndsh_parquet_source();
 
   ndsh_parquet_source(ndsh_parquet_source&& other) noexcept;
@@ -31,15 +35,11 @@ class ndsh_parquet_source {
 
   [[nodiscard]] cudf::io::source_info make_source_info() const;
 
-  void append_from_device(void const* device_data, std::size_t size, rmm::cuda_stream_view stream);
+  void append_from_device(void const* device_data, std::size_t size, cuda::stream_ref stream);
 
  private:
-  struct pinned_buffer {
-    void* data;
-    std::size_t size;
-  };
-
-  std::vector<pinned_buffer> buffers_;
+  std::unique_ptr<rmm::mr::pinned_host_memory_resource> pinned_mr_;
+  std::vector<rmm::device_buffer> buffers_;
 };
 
 using ndsh_data_sources = std::unordered_map<std::string, ndsh_parquet_source>;


### PR DESCRIPTION
## Description
libcudf's ndsh benchmarks give a useful demonstration of single-batch query execution with the libcudf C++ public API. The benchmarks also provide regression testing via the nvbench harness. "ndsh" includes a data generator to enable portability. 

As of 26.08, the data generator used an awkward pattern to inject a managed MR instead of using the current MR set in the nvbench fixture. Also the data generated `lineitem` in a single partition, creating a peak memory peak way above what the queries need.

This PR:
* removes the managed MR hack
* introduce partitioned generation for `lineitem` and `order`
* stage in pinned host memory instead of pageable, for faster and more predictable transfer timing.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
