### PR TITLE
Backport #23646, #23732, #23714: Fix cudf-java native load

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -509,8 +509,15 @@ jobs:
   java-gather:
     needs: [java-build]
     runs-on: linux-amd64-cpu4
+    # The container image is only used to make rapids-is-release-build
+    # available for the release-flag check below. The artifact assembly
+    # itself does not depend on any image-specific tooling.
+    container:
+      image: "rapidsai/ci-wheel:26.08-latest"
     permissions:
       contents: read
+    outputs:
+      is_release: ${{ steps.release-check.outputs.is_release }}
     steps:
       - name: Checkout code repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -534,3 +541,33 @@ jobs:
           name: cudf_java_maven_repo
           path: ${{ runner.temp }}/maven-repo
           if-no-files-found: error
+      - name: Determine release-build status
+        id: release-check
+        run: |
+          if rapids-is-release-build; then
+            echo "is_release=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "is_release=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  # Publish tagged release candidates to Maven Central via the Sonatype
+  # Central Publisher Portal. Release path only (vYY.MM.PP tags). Does not
+  # publish nightlies.
+  # TODO: add nightly Sonatype snapshot publishing.
+  java-publish:
+    needs: [java-gather]
+    if: ${{ needs.java-gather.outputs.is_release == 'true' && (inputs.build_type || 'branch') == 'branch' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/maven-publish.yaml@release/26.08
+    secrets:
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      MAVEN_DEPLOY_TOKEN: ${{ secrets.MAVEN_DEPLOY_TOKEN }}
+    with:
+      publication-type: 'rc'
+      artifact-name: cudf_java_maven_repo
+      source-git-sha: ${{ inputs.sha || github.sha }}
+      # false = validate + drop (safe). true = stage PENDING for manual publish.
+      stage-for-maven-central-publish: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -472,46 +472,39 @@ jobs:
       push: true
       cuda: '["12.9", "13.3"]'
   # Build the cuDF Java JAR for every Maven classifier.
-  java-build:
+  java-build-matrix:
     needs: [telemetry-setup]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { cuda: "12.9", cuda_major: "12", arch: "x86_64", runner: "linux-amd64-cpu16" }
-          - { cuda: "13.3", cuda_major: "13", arch: "x86_64", runner: "linux-amd64-cpu16" }
-          - { cuda: "12.9", cuda_major: "12", arch: "aarch64", runner: "linux-arm64-cpu16" }
-          - { cuda: "13.3", cuda_major: "13", arch: "aarch64", runner: "linux-arm64-cpu16" }
-    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-    steps:
-      - name: Checkout code repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ inputs.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Build static libcudf
-        run: |
-          ./java/ci/build_static_libcudf.sh \
-            --output-dir "${RUNNER_TEMP}/libcudf" \
-            --cuda-version "${{ matrix.cuda }}"
-      - name: Build cuDF Java JAR
-        run: |
-          ./java/ci/build_cudf_java_jar.sh \
-            --libcudf-dir "${RUNNER_TEMP}/libcudf" \
-            --output-dir "${RUNNER_TEMP}/jars" \
-            --cuda-version "${{ matrix.cuda }}"
-      - name: Upload per-entry JAR artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: cudf_java_cuda${{ matrix.cuda_major }}_${{ matrix.arch }}
-          # Ship only the JARs and POMs. Exclude the per-classifier Maven build scratch dir.
-          path: |
-            ${{ runner.temp }}/jars
-            !${{ runner.temp }}/jars/.mvn-temp-target
-          if-no-files-found: error
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.08
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      matrix_name: conda-cpp-build
+      matrix_filter: 'map(. + {CUDA_MAJOR: (.CUDA_VER | split(".") | .[0])})'
+  java-build:
+    needs: [telemetry-setup, java-build-matrix]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      arch: ${{ matrix.ARCH }}
+      node_type: cpu16
+      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      script: "ci/build_java.sh"
+      file_to_upload: output_jars
+      artifact-name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
   # Assemble the per-classifier JARs into one Maven-repository layout.
   java-gather:
     needs: [java-build]
@@ -527,7 +520,7 @@ jobs:
       - name: Download per-entry JAR artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: cudf_java_cuda*
+          pattern: cudf_java_*
           path: ${{ runner.temp }}/jars
           merge-multiple: true
       - name: Assemble Maven repository layout

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -533,36 +533,20 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
-    runs-on: linux-${{ matrix.ARCH }}-gpu-l4-latest-1
-    container:
-      image: rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }} # zizmor: ignore[unpinned-images]
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-      - name: Download java-build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
-          path: java_pkg
-      - name: Run Java tests
-        env:
-          LIBCUDF_LARGE_STRINGS_ENABLED: "0"
-        run: |
-          . java/ci/java_classifier.sh
-          JAVA_JAR="$(cudf_java_resolve_artifact_jar java_pkg)"
-          export JAVA_JAR
-          ci/test_packaged_java.sh
+    with:
+      build_type: pull-request
+      arch: ${{ matrix.ARCH }}
+      node_type: "gpu-l4-latest-1"
+      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      script: "ci/test_packaged_java.sh"
   conda-notebook-tests:
     needs: [conda-python-build, conda-python-build-noarch, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,9 @@ jobs:
       - conda-python-cudf-tests
       - conda-python-other-tests
       - conda-java-tests
+      - java-build-matrix
+      - java-build
+      - java-tests
       - conda-notebook-tests
       - docs-build
       - wheel-build-libcudf
@@ -492,6 +495,74 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.08-latest"
       script: "ci/test_java.sh"
+  # Build and test the cuDF Java JAR for every Maven classifier.
+  java-build-matrix:
+    needs: [checks]
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.08
+    with:
+      build_type: pull-request
+      matrix_name: conda-cpp-build
+      matrix_filter: 'map(. + {CUDA_MAJOR: (.CUDA_VER | split(".") | .[0])})'
+  java-build:
+    needs: [java-build-matrix, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+    with:
+      build_type: pull-request
+      arch: ${{ matrix.ARCH }}
+      node_type: cpu16
+      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      script: "ci/build_java.sh"
+      file_to_upload: output_jars
+      artifact-name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
+  java-tests:
+    needs: [java-build, java-build-matrix]
+    if: ${{ !cancelled() && needs.java-build.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+    runs-on: linux-${{ matrix.ARCH }}-gpu-l4-latest-1
+    container:
+      image: rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }} # zizmor: ignore[unpinned-images]
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Download java-build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
+          path: java_pkg
+      - name: Run Java tests
+        env:
+          LIBCUDF_LARGE_STRINGS_ENABLED: "0"
+        run: |
+          . java/ci/java_classifier.sh
+          JAVA_JAR="$(cudf_java_resolve_artifact_jar java_pkg)"
+          export JAVA_JAR
+          ci/test_packaged_java.sh
   conda-notebook-tests:
     needs: [conda-python-build, conda-python-build-noarch, changed-files]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -155,6 +155,37 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.08-latest"
       script: "ci/test_java.sh"
+  # Test the packaged cuDF Java JAR built by build.yaml java-build for every Maven classifier.
+  java-build-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.08
+    with:
+      build_type: ${{ inputs.build_type }}
+      matrix_name: conda-cpp-build
+      matrix_filter: 'map(. + {CUDA_MAJOR: (.CUDA_VER | split(".") | .[0])})'
+  java-tests:
+    needs: [java-build-matrix]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      arch: ${{ matrix.ARCH }}
+      node_type: "gpu-l4-latest-1"
+      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      script: "ci/test_packaged_java.sh"
   conda-notebook-tests:
     permissions:
       actions: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: cython-lint
+        additional_dependencies: ["Cython==3.2.9"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v2.1.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: cython-lint
-        additional_dependencies: ["Cython==3.2.9"]
+        additional_dependencies: ["cython>=3.2.2,<3.3.0a0"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v2.1.0'
     hooks:

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -28,6 +28,9 @@ if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
   exit 1
 fi
 
+export HOST_UID="${HOST_UID:-$(id -u)}"
+export HOST_GID="${HOST_GID:-$(id -g)}"
+
 RAPIDS_CUDA_VERSION="$(cudf_java_normalize_cuda_version "${RAPIDS_CUDA_VERSION}")"
 export RAPIDS_CUDA_VERSION
 CLASSIFIER="$(cudf_java_maven_classifier "${RAPIDS_CUDA_VERSION}")"

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CI entrypoint: static libcudf + classifier JAR for one matrix cell.
+#
+# Builds the static libcudf install tree and packages the matching classifier
+# JAR, writing ./output_jars/<classifier>/ for the custom-job upload step.
+#
+# Inputs (environment variables):
+#   RAPIDS_CUDA_VERSION        CUDA version, e.g. 12.9.2 (required).
+#   PARALLEL_LEVEL             Build parallelism (default: nproc).
+#   CMAKE_CUDA_ARCHITECTURES   Optional override for -DCMAKE_CUDA_ARCHITECTURES.
+#   JAVA_WORK_DIR              Optional scratch dir (default: <repo>/.java-work).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# shellcheck disable=SC1091
+. "${REPO_ROOT}/java/ci/ci_wheel_image.sh"
+# shellcheck disable=SC1091
+. "${REPO_ROOT}/java/ci/java_classifier.sh"
+
+if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
+  echo "Error: RAPIDS_CUDA_VERSION must be set" >&2
+  exit 1
+fi
+
+RAPIDS_CUDA_VERSION="$(cudf_java_normalize_cuda_version "${RAPIDS_CUDA_VERSION}")"
+export RAPIDS_CUDA_VERSION
+CLASSIFIER="$(cudf_java_maven_classifier "${RAPIDS_CUDA_VERSION}")"
+
+WORK_DIR="${JAVA_WORK_DIR:-${REPO_ROOT}/.java-work}"
+LIBCUDF_DIR="${WORK_DIR}/libcudf"
+CLASSIFIER_OUT="${REPO_ROOT}/output_jars/${CLASSIFIER}"
+
+cleanup_scratch() {
+  # Do not delete a caller-provided JAVA_WORK_DIR.
+  if [[ -z ${JAVA_WORK_DIR:-} ]]; then
+    rm -rf "${WORK_DIR}"
+  else
+    rm -rf "${LIBCUDF_DIR}" "${BUILD_DIR}"
+  fi
+}
+trap cleanup_scratch EXIT
+
+rm -rf "${LIBCUDF_DIR}" "${CLASSIFIER_OUT}"
+mkdir -p "${LIBCUDF_DIR}" "${CLASSIFIER_OUT}"
+
+export REPO_ROOT
+export INSTALL_PREFIX="${LIBCUDF_DIR}"
+export BUILD_DIR="${WORK_DIR}/libcudf-build"
+export CUDF_INSTALL_DIR="${LIBCUDF_DIR}"
+export OUTPUT_DIR="${CLASSIFIER_OUT}"
+
+rapids-logger "Building static libcudf (${CLASSIFIER})"
+bash "${REPO_ROOT}/java/ci/build_static_libcudf_in_container.sh"
+
+rapids-logger "Packaging cuDF Java JAR (${CLASSIFIER})"
+bash "${REPO_ROOT}/java/ci/build_cudf_java_jar_in_container.sh"
+
+cudf_java_assert_classifier_artifacts "${CLASSIFIER_OUT}" "${CLASSIFIER}"
+ls -la "${CLASSIFIER_OUT}"

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -31,7 +31,6 @@ fi
 export HOST_UID="${HOST_UID:-$(id -u)}"
 export HOST_GID="${HOST_GID:-$(id -g)}"
 
-RAPIDS_CUDA_VERSION="$(cudf_java_normalize_cuda_version "${RAPIDS_CUDA_VERSION}")"
 export RAPIDS_CUDA_VERSION
 CLASSIFIER="$(cudf_java_maven_classifier "${RAPIDS_CUDA_VERSION}")"
 

--- a/ci/test_packaged_java.sh
+++ b/ci/test_packaged_java.sh
@@ -5,11 +5,15 @@
 # Run the Java tests against an already-packaged classifier JAR.
 #
 # Activates -Ppackaged-jar-tests so the surefire classpath uses the JAR at
-# JAVA_JAR instead of a locally compiled target/classes tree. Caller places
-# the JAR (e.g. via actions/download-artifact) before invoking this script.
+# JAVA_JAR instead of a locally compiled target/classes tree.
+#
+# When JAVA_JAR is unset, download the java-build artifact via
+# rapids-download-from-github (pr.yaml for PRs, build.yaml otherwise).
 #
 # Inputs (environment variables):
-#   JAVA_JAR                       Absolute path to the classifier JAR (required).
+#   JAVA_JAR                       Optional. Absolute path to the classifier JAR.
+#                                  If unset, the JAR is downloaded from the
+#                                  matching java-build artifact.
 #   LIBCUDF_LARGE_STRINGS_ENABLED  Optional; defaults to 0 (same as ci/test_java.sh).
 
 set -euo pipefail
@@ -17,8 +21,34 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-if [[ -z ${JAVA_JAR:-} || ! -f ${JAVA_JAR} ]]; then
-  echo "Error: JAVA_JAR must point to an existing classifier JAR" >&2
+# shellcheck disable=SC1091
+. "${REPO_ROOT}/java/ci/java_classifier.sh"
+
+if [[ -z ${JAVA_JAR:-} ]]; then
+  if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
+    echo "Error: RAPIDS_CUDA_VERSION must be set when JAVA_JAR is unset" >&2
+    exit 1
+  fi
+  cuda_major="${RAPIDS_CUDA_VERSION%%.*}"
+
+  # matrix.ARCH values are amd64/arm64; $(arch) / uname -m return x86_64/aarch64.
+  case "$(uname -m)" in
+    x86_64)  java_arch=amd64 ;;
+    aarch64|arm64) java_arch=arm64 ;;
+    *)
+      echo "Error: unsupported host arch '$(uname -m)'" >&2
+      exit 1
+      ;;
+  esac
+
+  rapids-logger "Downloading cudf_java_${java_arch}_cu${cuda_major}"
+  JAVA_PKG="$(rapids-download-from-github "cudf_java_${java_arch}_cu${cuda_major}")"
+  JAVA_JAR="$(cudf_java_resolve_artifact_jar "${JAVA_PKG}")"
+  export JAVA_JAR
+fi
+
+if [[ ! -f ${JAVA_JAR} ]]; then
+  echo "Error: JAVA_JAR='${JAVA_JAR}' does not point to an existing file" >&2
   exit 1
 fi
 

--- a/ci/test_packaged_java.sh
+++ b/ci/test_packaged_java.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the Java tests against an already-packaged classifier JAR.
+#
+# Activates -Ppackaged-jar-tests so the surefire classpath uses the JAR at
+# JAVA_JAR instead of a locally compiled target/classes tree. Caller places
+# the JAR (e.g. via actions/download-artifact) before invoking this script.
+#
+# Inputs (environment variables):
+#   JAVA_JAR                       Absolute path to the classifier JAR (required).
+#   LIBCUDF_LARGE_STRINGS_ENABLED  Optional; defaults to 0 (same as ci/test_java.sh).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [[ -z ${JAVA_JAR:-} || ! -f ${JAVA_JAR} ]]; then
+  echo "Error: JAVA_JAR must point to an existing classifier JAR" >&2
+  exit 1
+fi
+
+if ! command -v mvn >/dev/null 2>&1 || ! command -v java >/dev/null 2>&1; then
+  # shellcheck disable=SC1091
+  . "${REPO_ROOT}/java/ci/setup_java_env.sh"
+fi
+
+# Match the existing conda Java test entrypoint in ci/test_java.sh.
+export LIBCUDF_LARGE_STRINGS_ENABLED="${LIBCUDF_LARGE_STRINGS_ENABLED:-0}"
+
+PRODUCT_JAR="$(cd "$(dirname "${JAVA_JAR}")" && pwd)/$(basename "${JAVA_JAR}")"
+rapids-logger "Product JAR: ${PRODUCT_JAR}"
+
+rapids-logger "Check GPU usage"
+nvidia-smi
+
+rm -rf "${REPO_ROOT}/java/target"
+
+pushd "${REPO_ROOT}/java" >/dev/null
+set +e
+timeout 30m mvn -B test -Ppackaged-jar-tests \
+  "-Dcudf.jar.path=${PRODUCT_JAR}" \
+  "-DCUDF_JNI_ENABLE_PROFILING=OFF"
+EXITCODE=$?
+set -e
+popd >/dev/null
+rapids-logger "Java tests exit=${EXITCODE}"
+exit "${EXITCODE}"

--- a/cpp/examples/versions.cmake
+++ b/cpp/examples/versions.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -4,14 +4,14 @@
 
 The scripts under `java/ci/` build the cuDF Java JAR for every Maven classifier the
 same way locally and in CI (GitHub Actions is only a thin wrapper that adds
-artifact upload/download). Each script pulls the RAPIDS `ci-conda` build image,
+artifact upload/download). Each script pulls the RAPIDS `ci-wheel` build image,
 runs the build in a throwaway container, and writes its output to a host
 directory. No local `docker build` is required, and no GPU is required to build.
 
 ### Prerequisites
 
 1. Docker is installed and the current user can run `docker`.
-2. Network access to pull `rapidsai/ci-conda:<rapids_version>-latest`.
+2. Network access to pull `rapidsai/ci-wheel:<rapids>-cuda<ver>-rockylinux8-py3.11`.
 
 ### Local one-command shortcut
 
@@ -95,6 +95,17 @@ runs Steps 1-2 per (CUDA x arch) entry and uploads each classifier subdir as a
 per-entry artifact. The separate `java-gather` job downloads them (with
 `merge-multiple: true`, so all subdirs land in a single parent dir), runs
 Step 3, and uploads the combined `cudf_java_maven_repo` artifact.
+
+### Packaging-aware tests (local)
+
+Plain `cd java && mvn test` does not exercise the classifier JAR. Use
+`java/ci/test_packaged_java_local.sh` (or CI entrypoint
+`ci/test_packaged_java.sh`) to run the existing Java tests against a packaged
+JAR. Needs Docker + GPU.
+
+```bash
+./java/ci/test_packaged_java_local.sh --work-dir /tmp/java-build-test
+```
 
 ## Legacy: manual Dockerfile.rocky build (obsolete)
 

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -24,7 +24,7 @@ For local testing only, `java/ci/test_java_build_local.sh` runs Steps 1-3 end-to
 ### Step 1 - Build the static libcudf install tree
 
 ```bash
-./java/ci/build_static_libcudf.sh --output-dir /tmp/libcudf-cuda12 --cuda-version 12.9
+./java/ci/build_static_libcudf.sh --output-dir /tmp/libcudf-cuda12 --cuda-version 12.9.2
 ```
 
 This produces a static libcudf install tree (`lib/libcudf.a` plus its static
@@ -37,7 +37,7 @@ so plain `rm -rf` works.
 ./java/ci/build_cudf_java_jar.sh \
   --libcudf-dir /tmp/libcudf-cuda12 \
   --output-dir /tmp/jars \
-  --cuda-version 12.9
+  --cuda-version 12.9.2
 ```
 
 Optional `GITHUB_REF` selects release tag vs SNAPSHOT versioning. Unset means

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -40,12 +40,15 @@ so plain `rm -rf` works.
   --cuda-version 12.9
 ```
 
+Optional `GITHUB_REF` selects release tag vs SNAPSHOT versioning. Unset means
+SNAPSHOT. See the versioning section below.
+
 This compiles the JNI layer against the static libcudf from Step 1 and emits
 the classifier JAR (e.g. `cudf-26.08.0-SNAPSHOT-cuda12.jar`), a
 classifier-independent sources jar and javadoc jar, and the POM into a
 classifier-named subdirectory under `--output-dir`:
 
-```
+```text
 /tmp/jars/cuda12/
     cudf-26.08.0-SNAPSHOT-cuda12.jar
     cudf-26.08.0-SNAPSHOT-sources.jar
@@ -58,9 +61,10 @@ The classifier is derived from `--cuda-version` (major) + host arch (`uname
 `aarch64`. Producing the ARM classifiers requires a real `aarch64` host.
 Repeat Step 2 for each classifier, pointing `--libcudf-dir` at the matching
 static libcudf tree and using the same `--output-dir` (each classifier lands
-in its own subdirectory). Concurrent invocations for different classifiers
-are safe because each nests its own bind-mount over `/repo/java/target`
-inside the container.
+in its own subdirectory). Concurrent SNAPSHOT invocations for different
+classifiers are safe because each nests its own bind-mount over
+`/repo/java/target` inside the container. Release builds rewrite the shared
+`java/pom.xml` and must not overlap.
 
 ### Step 3 - Assemble the Maven repository layout
 
@@ -72,23 +76,44 @@ inside the container.
 
 This walks every subdirectory of `--jars-dir` (each subdir name IS the
 classifier), gathers the per-classifier JAR, one shared sources jar, one
-shared javadoc jar, and the shared POM, derives the artifact version from
-the JAR filenames (requiring a single unique version across subdirs), and
+shared javadoc jar, the shared POM, and seeds an unclassified primary JAR
+as a copy of the `cuda12` classifier. Derives the artifact version from
+the JAR filenames (requiring a single unique version across subdirs) and
 lays them out as:
 
-```
-/tmp/maven-repo/ai/rapids/cudf/26.08.0-SNAPSHOT/
-    cudf-26.08.0-SNAPSHOT-cuda12.jar
-    cudf-26.08.0-SNAPSHOT-cuda13.jar
-    cudf-26.08.0-SNAPSHOT-sources.jar
-    cudf-26.08.0-SNAPSHOT-javadoc.jar
-    cudf-26.08.0-SNAPSHOT.pom
+```text
+/tmp/maven-repo/ai/rapids/cudf/<CUDF_VERSION>-SNAPSHOT/
+    cudf-<CUDF_VERSION>-SNAPSHOT.jar
+    cudf-<CUDF_VERSION>-SNAPSHOT-cuda12.jar
+    cudf-<CUDF_VERSION>-SNAPSHOT-cuda13.jar
+    cudf-<CUDF_VERSION>-SNAPSHOT-sources.jar
+    cudf-<CUDF_VERSION>-SNAPSHOT-javadoc.jar
+    cudf-<CUDF_VERSION>-SNAPSHOT.pom
 ```
 
 The set of classifiers is whatever subdirectories are present under
 `--jars-dir`. For a local `x86_64`-only run, populate `/tmp/jars/cuda12/`
 and `/tmp/jars/cuda13/`. For the full four-way release build, add
-`/tmp/jars/cuda12-arm64/` and `/tmp/jars/cuda13-arm64/`.
+`/tmp/jars/cuda12-arm64/` and `/tmp/jars/cuda13-arm64/`. The `cuda12`
+subdirectory is required because the unclassified primary JAR is copied from
+it, so an `aarch64`-only set of subdirectories is not a valid gather input.
+
+### Release Tag vs SNAPSHOT Versioning
+
+Release tag CI runs (`GITHUB_REF=refs/tags/vYY.MM.PP`) produce release-versioned
+JARs (`cudf-<CUDF_VERSION>-*.jar`). All other runs produce `-SNAPSHOT`. Gated by
+[`rapids-is-release-build`](https://github.com/rapidsai/gha-tools/blob/main/tools/rapids-is-release-build).
+`GITHUB_REF` is optional. Unset or non-tag values stay SNAPSHOT.
+
+To rehearse the release path locally:
+
+```bash
+GITHUB_REF=refs/tags/vYY.MM.PP ./java/ci/test_java_build_local.sh
+```
+
+Rewrites `java/pom.xml` in place for packaging, then restores it on exit.
+
+### GitHub Actions
 
 In GitHub Actions (`.github/workflows/build.yaml`), the `java-build` matrix job
 runs Steps 1-2 per (CUDA x arch) entry and uploads each classifier subdir as a

--- a/java/ci/assemble_maven_repo.sh
+++ b/java/ci/assemble_maven_repo.sh
@@ -166,12 +166,24 @@ if [[ -z "${FIRST_VERSION}" ]]; then
   exit 1
 fi
 
+DEST_DIR="${OUTPUT_DIR}/${GROUP_PATH}/${ARTIFACT_ID}/${FIRST_VERSION}"
+
+# Seed the unclassified primary from cuda12. Maven Central serves this to
+# consumers depending on ai.rapids:cudf without a <classifier>.
+PRIMARY_SOURCE="${DEST_DIR}/cudf-${FIRST_VERSION}-cuda12.jar"
+if [[ ! -f "${PRIMARY_SOURCE}" ]]; then
+  echo "Error: ${PRIMARY_SOURCE} missing." >&2
+  exit 1
+fi
+UNCLASSIFIED="${DEST_DIR}/cudf-${FIRST_VERSION}.jar"
+cp -f "${PRIMARY_SOURCE}" "${UNCLASSIFIED}"
+echo "  + cudf-${FIRST_VERSION}.jar (unclassified primary, copy of cuda12)"
+
 # Sources and javadoc jars are classifier-independent (pure Java, no arch or
 # cuda variation). Every classifier subdir produces byte-equivalent copies;
 # pick the lexicographically first subdir's copy as canonical. Fail fast if
 # any subdir is missing either file - that indicates -Prelease or
 # -Pjavadoc-jdk17 did not activate for that classifier's build.
-DEST_DIR="${OUTPUT_DIR}/${GROUP_PATH}/${ARTIFACT_ID}/${FIRST_VERSION}"
 FIRST_CLASSIFIER_SUBDIR=""
 for subdir in "${JARS_DIR}"/*/; do
   if [[ -z ${FIRST_CLASSIFIER_SUBDIR} ]]; then

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -69,7 +69,7 @@ BUILD_ARG=(
   "-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS"
   "-DCUDF_JNI_LIBCUDF_STATIC=ON"
   "-DUSE_GDS=$ENABLE_GDS"
-  "-Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest"
+  "-Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest,!PackagedJarOriginCheck"
 )
 
 if [ "$SIGN_FILE" == true ]; then

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/java/ci/build_cudf_java_jar.sh
+++ b/java/ci/build_cudf_java_jar.sh
@@ -5,7 +5,7 @@
 # Self-contained packaging of the cuDF Java JAR for a single classifier.
 #
 # Consumes a prebuilt static libcudf install tree (from build_static_libcudf.sh),
-# compiles the JNI layer against it inside a throwaway RAPIDS ci-conda container,
+# compiles the JNI layer against it inside a throwaway RAPIDS ci-wheel container,
 # and emits the single classifier JAR (plus its POM) to a per-classifier
 # subdirectory under --output-dir. This script is layout-agnostic: it produces
 # one classifier's artifacts and knows nothing about the combined
@@ -18,6 +18,10 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/argparse.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/ci_wheel_image.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/java_classifier.sh"
 
 LIBCUDF_DIR=""
 OUTPUT_DIR=""
@@ -31,11 +35,10 @@ print_help() {
 Usage: build_cudf_java_jar.sh --libcudf-dir <path> --output-dir <path> \\
                               --cuda-version <ver> [OPTIONS]
 
-Packages the cuDF Java JAR for a single classifier inside a RAPIDS ci-conda
+Packages the cuDF Java JAR for a single classifier inside a RAPIDS ci-wheel
 container, linking against a prebuilt static libcudf. Always builds for the
-host architecture (uname -m). The build image is fixed to
-rapidsai/ci-conda:<rapids_version>-latest (version derived from the VERSION
-file).
+host architecture (uname -m). The build image is derived from --cuda-version
+and the VERSION file (see java/ci/ci_wheel_image.sh).
 
 The classifier is derived from --cuda-version (major) + host arch (uname -m),
 mirroring the pom.xml Groovy logic: "cuda<major>" for x86_64,
@@ -49,7 +52,7 @@ REQUIRED:
     -o, --output-dir     Host parent directory. The script creates and writes
                          to <output-dir>/<classifier>/, which must not already
                          exist.
-    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.1").
+    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.2").
                          Must match --cuda-version of the static libcudf tree;
                          determines the cuda12/cuda13 classifier.
 
@@ -126,26 +129,9 @@ if [[ ! -d ${LIBCUDF_DIR} ]]; then
   exit 1
 fi
 
-# Derive the Maven classifier from --cuda-version major + host arch, mirroring
-# the pom.xml Groovy logic: "cuda<major>" for x86_64, "cuda<major>-arm64" for
-# aarch64.
-CUDA_MAJOR="$(echo "${CUDA_VERSION}" | cut -d. -f1)"
-HOST_ARCH="$(uname -m)"
-case "${HOST_ARCH}" in
-  x86_64)
-    CLASSIFIER="cuda${CUDA_MAJOR}"
-    ;;
-  aarch64|arm64)
-    CLASSIFIER="cuda${CUDA_MAJOR}-arm64"
-    ;;
-  *)
-    echo "Error: Unsupported host arch '${HOST_ARCH}' (expected x86_64 or aarch64)" >&2
-    exit 1
-    ;;
-esac
-
-RAPIDS_VERSION="$(head -1 "${REPO_ROOT}/VERSION" | cut -d. -f1,2)"
-IMAGE="rapidsai/ci-conda:${RAPIDS_VERSION}-latest"
+CLASSIFIER="$(cudf_java_maven_classifier "${CUDA_VERSION}")"
+IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
+CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
 
 mkdir -p "${OUTPUT_DIR}"
 OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd)"
@@ -173,7 +159,7 @@ mkdir -p "${TARGET_SCRATCH}"
 
 echo "Packaging cuDF Java JAR"
 echo "  image:        ${IMAGE}"
-echo "  cuda version: ${CUDA_VERSION}"
+echo "  cuda version: ${CUDA_VERSION_FULL}"
 echo "  classifier:   ${CLASSIFIER}"
 echo "  parallel:     ${PARALLEL_LEVEL}"
 echo "  libcudf dir:  ${LIBCUDF_DIR}"
@@ -190,10 +176,13 @@ DOCKER_ARGS=(
   --volume "${CLASSIFIER_OUT}:/output"
   --volume "${TARGET_SCRATCH}:/repo/java/target"
   --workdir /repo
-  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION}"
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}"
   --env PARALLEL_LEVEL="${PARALLEL_LEVEL}"
   --env HOST_UID="$(id -u)"
   --env HOST_GID="$(id -g)"
+  --env CUDF_INSTALL_DIR=/libcudf
+  --env OUTPUT_DIR=/output
+  --env REPO_ROOT=/repo
 )
 
 if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
@@ -205,42 +194,4 @@ docker run "${DOCKER_ARGS[@]}" "${IMAGE}" \
 
 # Post-run: assert exactly one main classifier JAR + one POM, and that the
 # JAR's classifier suffix matches the subdir name we chose (catches pom drift).
-PRODUCED_JAR=""
-for candidate in "${CLASSIFIER_OUT}"/cudf-*-"${CLASSIFIER}".jar; do
-  if [[ -f "${candidate}" ]]; then
-    if [[ -n "${PRODUCED_JAR}" ]]; then
-      echo "Error: multiple JARs matching cudf-*-${CLASSIFIER}.jar found in ${CLASSIFIER_OUT}"
-      ls -1 "${CLASSIFIER_OUT}"
-      exit 1
-    fi
-    PRODUCED_JAR=${candidate}
-  fi
-done
-
-if [[ -z "${PRODUCED_JAR}" ]]; then
-  echo "Error: no cudf-*-${CLASSIFIER}.jar found in ${CLASSIFIER_OUT}"
-  ls -1 "${CLASSIFIER_OUT}" || true
-  exit 1
-fi
-
-PRODUCED_POM=""
-for candidate in "${CLASSIFIER_OUT}"/cudf-*.pom; do
-  if [[ -f "${candidate}" ]]; then
-    if [[ -n "${PRODUCED_POM}" ]]; then
-      echo "Error: multiple POMs found in ${CLASSIFIER_OUT}"
-      ls -1 "${CLASSIFIER_OUT}"
-      exit 1
-    fi
-    PRODUCED_POM=${candidate}
-  fi
-done
-
-if [[ -z "${PRODUCED_POM}" ]]; then
-  echo "Error: no cudf-*.pom found in ${CLASSIFIER_OUT}"
-  ls -1 "${CLASSIFIER_OUT}" || true
-  exit 1
-fi
-
-echo "cuDF Java JAR build succeeded:"
-echo "  $(basename "${PRODUCED_JAR}")"
-echo "  $(basename "${PRODUCED_POM}")"
+cudf_java_assert_classifier_artifacts "${CLASSIFIER_OUT}" "${CLASSIFIER}"

--- a/java/ci/build_cudf_java_jar.sh
+++ b/java/ci/build_cudf_java_jar.sh
@@ -185,6 +185,10 @@ DOCKER_ARGS=(
   --env REPO_ROOT=/repo
 )
 
+if [[ -n ${GITHUB_REF:-} ]]; then
+  DOCKER_ARGS+=(--env GITHUB_REF="${GITHUB_REF}")
+fi
+
 if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
   DOCKER_ARGS+=(--env CMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}")
 fi

--- a/java/ci/build_cudf_java_jar.sh
+++ b/java/ci/build_cudf_java_jar.sh
@@ -52,9 +52,10 @@ REQUIRED:
     -o, --output-dir     Host parent directory. The script creates and writes
                          to <output-dir>/<classifier>/, which must not already
                          exist.
-    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.2").
-                         Must match --cuda-version of the static libcudf tree;
-                         determines the cuda12/cuda13 classifier.
+    -c, --cuda-version   CUDA toolkit version to build for (e.g. "12.9.2").
+                         Must match a rapidsai/ci-wheel image tag and the
+                         --cuda-version of the static libcudf tree. The major
+                         version determines the cuda12/cuda13 classifier.
 
 OPTIONS:
     -A, --cmake-cuda-architectures
@@ -68,8 +69,8 @@ OPTIONS:
     -h, --help           Show this help message.
 
 EXAMPLES:
-    build_cudf_java_jar.sh -l /tmp/libcudf-cuda12 -o /tmp/jars -c 12.9
-    build_cudf_java_jar.sh -l /tmp/libcudf-cuda13 -o /tmp/jars -c 13.3 -A 80
+    build_cudf_java_jar.sh -l /tmp/libcudf-cuda12 -o /tmp/jars -c 12.9.2
+    build_cudf_java_jar.sh -l /tmp/libcudf-cuda13 -o /tmp/jars -c 13.3.0 -A 80
     # writes:
     #   /tmp/jars/cuda12/cudf-<version>-cuda12.jar
     #   /tmp/jars/cuda12/cudf-<version>.pom
@@ -131,7 +132,6 @@ fi
 
 CLASSIFIER="$(cudf_java_maven_classifier "${CUDA_VERSION}")"
 IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
-CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
 
 mkdir -p "${OUTPUT_DIR}"
 OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd)"
@@ -159,7 +159,7 @@ mkdir -p "${TARGET_SCRATCH}"
 
 echo "Packaging cuDF Java JAR"
 echo "  image:        ${IMAGE}"
-echo "  cuda version: ${CUDA_VERSION_FULL}"
+echo "  cuda version: ${CUDA_VERSION}"
 echo "  classifier:   ${CLASSIFIER}"
 echo "  parallel:     ${PARALLEL_LEVEL}"
 echo "  libcudf dir:  ${LIBCUDF_DIR}"
@@ -176,7 +176,7 @@ DOCKER_ARGS=(
   --volume "${CLASSIFIER_OUT}:/output"
   --volume "${TARGET_SCRATCH}:/repo/java/target"
   --workdir /repo
-  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}"
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION}"
   --env PARALLEL_LEVEL="${PARALLEL_LEVEL}"
   --env HOST_UID="$(id -u)"
   --env HOST_GID="$(id -g)"

--- a/java/ci/build_cudf_java_jar_in_container.sh
+++ b/java/ci/build_cudf_java_jar_in_container.sh
@@ -4,116 +4,92 @@
 
 # In-container packaging of the cuDF Java JAR for a single classifier.
 #
-# This script runs inside the rapidsai/ci-conda container launched by
-# java/ci/build_cudf_java_jar.sh. It generates the build_java conda toolchain
-# environment, installs a JDK 17 side-prefix for the javadoc-jdk17 profile,
-# compiles the JNI layer against a prebuilt static libcudf (mounted at
-# /libcudf), and packages the cuDF Java JAR. The resulting classifier JAR,
-# sources JAR, javadoc JAR, and POM are copied to /output. /output and
-# /repo/java/target are chowned to HOST_UID:HOST_GID on exit so the host user
-# owns the outputs.
+# Expects a RAPIDS ci-wheel environment. Sources the toolchain from
+# setup_java_env.sh, compiles the JNI layer against the prebuilt static
+# libcudf at CUDF_INSTALL_DIR, and packages the cuDF Java JAR. The classifier
+# JAR, sources JAR, javadoc JAR, and POM are copied to OUTPUT_DIR. When
+# HOST_UID / HOST_GID are set, OUTPUT_DIR and java/target are chowned on exit
+# so the host user owns the outputs.
 #
 # Inputs (environment variables):
-#   RAPIDS_CUDA_VERSION        CUDA version, e.g. 12.9 or 12.9.1 (required).
+#   RAPIDS_CUDA_VERSION        CUDA version, e.g. 12.9.2 (required).
 #   PARALLEL_LEVEL             Build parallelism (default: nproc).
 #   CMAKE_CUDA_ARCHITECTURES   Optional override for -DCMAKE_CUDA_ARCHITECTURES.
-#   HOST_UID / HOST_GID        Chown target for /output and /repo/java/target
-#                              (both required).
+#   CUDF_INSTALL_DIR           Static libcudf install tree (default: /libcudf).
+#   OUTPUT_DIR                 Artifact output dir (default: /output).
+#   REPO_ROOT                  cuDF checkout (default: /repo).
+#   HOST_UID / HOST_GID        Optional chown target for OUTPUT_DIR + java/target.
 
 set -e
 
-OUTPUT_DIR=/output
-REPO_ROOT=/repo
-CUDF_INSTALL_DIR=/libcudf
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-/output}"
+REPO_ROOT="${REPO_ROOT:-/repo}"
+CUDF_INSTALL_DIR="${CUDF_INSTALL_DIR:-/libcudf}"
 
-. /opt/conda/etc/profile.d/conda.sh
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/setup_java_env.sh"
 
-if [[ -z ${RAPIDS_CUDA_VERSION} ]]; then
+if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
   echo "Error: RAPIDS_CUDA_VERSION must be set" >&2
   exit 1
 fi
 
-if [[ -z ${HOST_UID} || -z ${HOST_GID} ]]; then
-  echo "Error: HOST_UID and HOST_GID must both be set" >&2
-  exit 1
-fi
-
 _chown_outputs_on_exit() {
-  chown -R "${HOST_UID}:${HOST_GID}" "${OUTPUT_DIR}" "${REPO_ROOT}/java/target" 2>/dev/null || true
+  if [[ -n ${HOST_UID:-} && -n ${HOST_GID:-} ]]; then
+    chown -R "${HOST_UID}:${HOST_GID}" "${OUTPUT_DIR}" "${REPO_ROOT}/java/target" 2>/dev/null || true
+  fi
 }
 trap _chown_outputs_on_exit EXIT
 
-if [[ -z ${PARALLEL_LEVEL} ]]; then
-  PARALLEL_LEVEL=$(nproc)
-fi
-
-CUDA_MAJOR_MINOR=$(echo "${RAPIDS_CUDA_VERSION}" | cut -d. -f1,2)
-
-rapids-logger "Configuring conda strict channel priority"
-conda config --set channel_priority strict
-
-rapids-logger "Generating build_java conda environment (cuda=${CUDA_MAJOR_MINOR}, arch=$(arch))"
-ENV_YAML_DIR="$(mktemp -d)"
-rapids-dependency-file-generator \
-  --output conda \
-  --file-key build_java \
-  --matrix "cuda=${CUDA_MAJOR_MINOR};arch=$(arch)" | tee "${ENV_YAML_DIR}/env.yaml"
-
-rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n build_java
-conda activate build_java
-
-rapids-print-env
-
-# The `javadoc-jdk17` profile in java/pom.xml points
-# <javadocExecutable> at ${env.JDK17_HOME}/bin/javadoc. The build_java env
-# above provides only JDK 8 (mvn's own JVM), so install JDK 17 into a
-# dedicated prefix that JDK17_HOME can point to. The primary mvn JVM stays
-# on JDK 8; only the javadoc binary is invoked from this prefix.
-rapids-logger "Installing JDK 17 into /opt/jdk17 for javadoc-jdk17 profile"
-rapids-mamba-retry create --yes --prefix /opt/jdk17 openjdk=17.*
-export JDK17_HOME=/opt/jdk17
-
-if [[ -z ${CUDACXX} ]]; then
-  export CUDACXX="${CONDA_PREFIX}/bin/nvcc"
-fi
-if [[ -z ${LIBCUDF_KERNEL_CACHE_PATH} ]]; then
-  export LIBCUDF_KERNEL_CACHE_PATH=/tmp/rapids-kernel-cache
-fi
-
 BUILD_ARG=(
   -B
-  # Prefix every log line with HH:mm:ss.SSS so the elapsed time of individual
-  # plugin executions is recorded.
+  # Prefix every log line with HH:mm:ss.SSS to record per-plugin elapsed time.
   "-Dorg.slf4j.simpleLogger.showDateTime=true"
   "-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
-  "-Dmaven.repo.local=/tmp/.m2"
+  "-Dmaven.repo.local=${MAVEN_REPO_LOCAL:-/tmp/.m2}"
   "-Dparallel.level=${PARALLEL_LEVEL}"
   "-DskipTests=true"
   "-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=ON"
   "-DCUDF_JNI_LIBCUDF_STATIC=ON"
   "-DUSE_GDS=OFF"
-  # -Prelease produces the sources.jar file via maven-source-plugin;
-  # -Pjavadoc-jdk17 produces the javadoc.jar file via maven-javadoc-plugin
-  # running against ${env.JDK17_HOME}/bin/javadoc. Both are required by
-  # Maven Central for every published release.
+  # -Prelease adds the sources.jar; -Pjavadoc-jdk17 adds the javadoc.jar (built
+  # against ${JDK17_HOME}/bin/javadoc). Both are required by Maven Central.
   "-Prelease"
   "-Pjavadoc-jdk17"
 )
-
-if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
+if [[ -n ${CMAKE_CUDA_ARCHITECTURES:-} ]]; then
   BUILD_ARG+=("-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
 fi
 
+# Pass the toolchain + sccache launchers from setup_java_env.sh to the JNI cmake
+# invocation via the pom's cmake.ccache.opts property.
+CMAKE_CCACHE_OPTS=()
+if [[ -n ${CMAKE_C_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_CCACHE_OPTS+=("-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}")
+fi
+if [[ -n ${CMAKE_CXX_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_CCACHE_OPTS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
+fi
+if [[ -n ${CMAKE_CUDA_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_CCACHE_OPTS+=("-DCMAKE_CUDA_COMPILER_LAUNCHER=${CMAKE_CUDA_COMPILER_LAUNCHER}")
+fi
+CMAKE_CCACHE_OPTS+=("-DCMAKE_C_COMPILER=${CC}" "-DCMAKE_CXX_COMPILER=${CXX}")
+CMAKE_CCACHE_OPTS+=("-DCMAKE_CUDA_HOST_COMPILER=${CMAKE_CUDA_HOST_COMPILER}")
+if [[ -d ${BOOST_PREFIX} ]]; then
+  CMAKE_CCACHE_OPTS+=("-DCMAKE_PREFIX_PATH=${BOOST_PREFIX}")
+fi
+BUILD_ARG+=("-Dcmake.ccache.opts=${CMAKE_CCACHE_OPTS[*]}")
+
 cd "${REPO_ROOT}/java"
 
-CUDF_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout "${BUILD_ARG[@]}")"
-rapids-logger "Packaging cuDF Java JAR version ${CUDF_VERSION} (libcudf: ${CUDF_INSTALL_DIR})"
+CUDF_VERSION="$(cudf_java_scl mvn help:evaluate -Dexpression=project.version -q -DforceStdout "${BUILD_ARG[@]}")"
+rapids-logger "Packaging cuDF Java JAR ${CUDF_VERSION}"
 
-# The `clean` goal is intentionally omitted: /repo/java/target is a
-# bind-mount point, so when `mvn clean` attempts to remove the directory,
-# it fails with EBUSY. The host wrapper (build_cudf_java_jar.sh) recreates
-# the scratch dir before each container launch to guarantee target/ starts empty.
-CUDF_INSTALL_DIR="${CUDF_INSTALL_DIR}" mvn package "${BUILD_ARG[@]}"
+# Omit the `clean` goal: java/target may be a bind-mount point, so `mvn clean`
+# fails with EBUSY. The host wrapper recreates the scratch dir before each
+# launch to guarantee target/ starts empty.
+CUDF_INSTALL_DIR="${CUDF_INSTALL_DIR}" cudf_java_scl mvn package "${BUILD_ARG[@]}"
 
 mkdir -p "${OUTPUT_DIR}"
 
@@ -132,8 +108,7 @@ for candidate in target/cudf-"${CUDF_VERSION}"-*.jar; do
     *)
       if [[ -f ${candidate} ]]; then
         if [[ -n ${MAIN_JAR} ]]; then
-          echo "Error: multiple main classifier JARs matched under target/" >&2
-          ls -l target/ >&2 || true
+          echo "Error: multiple main classifier JARs under target/" >&2
           exit 1
         fi
         MAIN_JAR=${candidate}
@@ -143,23 +118,25 @@ for candidate in target/cudf-"${CUDF_VERSION}"-*.jar; do
 done
 
 if [[ -z ${MAIN_JAR} ]]; then
-  echo "Error: no cuDF classifier JAR produced under target/" >&2
-  ls -l target/ >&2 || true
+  echo "Error: no classifier JAR under target/" >&2
+  ls -l target/ >&2
   exit 1
 fi
 
 # Assert the release-profile artifacts landed. A missing file here means
-# -Prelease or -Pjavadoc-jdk17 did not activate, or JDK17_HOME did not
-# resolve to a usable javadoc binary.
+# -Prelease or -Pjavadoc-jdk17 did not activate, or JDK17_HOME did not resolve
+# to a usable javadoc binary.
 for required in "${OUTPUT_DIR}/cudf-${CUDF_VERSION}-sources.jar" \
                 "${OUTPUT_DIR}/cudf-${CUDF_VERSION}-javadoc.jar"; do
   if [[ ! -f ${required} ]]; then
-    echo "Error: expected ${required} not found (mvn -Prelease -Pjavadoc-jdk17 did not produce it)" >&2
+    echo "Error: missing ${required}" >&2
     exit 1
   fi
 done
 
 cp -f "${MAIN_JAR}" "${OUTPUT_DIR}/"
 cp -f pom.xml "${OUTPUT_DIR}/cudf-${CUDF_VERSION}.pom"
-
-rapids-logger "Emitted $(basename "${MAIN_JAR}"), cudf-${CUDF_VERSION}-sources.jar, cudf-${CUDF_VERSION}-javadoc.jar, and cudf-${CUDF_VERSION}.pom to ${OUTPUT_DIR}"
+rapids-logger "Emitted artifacts to ${OUTPUT_DIR}"
+if command -v sccache >/dev/null 2>&1; then
+  sccache --show-adv-stats || true
+fi

--- a/java/ci/build_cudf_java_jar_in_container.sh
+++ b/java/ci/build_cudf_java_jar_in_container.sh
@@ -35,12 +35,25 @@ if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
   exit 1
 fi
 
-_chown_outputs_on_exit() {
-  if [[ -n ${HOST_UID:-} && -n ${HOST_GID:-} ]]; then
-    chown -R "${HOST_UID}:${HOST_GID}" "${OUTPUT_DIR}" "${REPO_ROOT}/java/target" 2>/dev/null || true
+if [[ -z ${HOST_UID} || -z ${HOST_GID} ]]; then
+  echo "Error: HOST_UID and HOST_GID must both be set" >&2
+  exit 1
+fi
+
+POM_WAS_REWRITTEN=0
+_cleanup_on_exit() {
+  local prior_status=$?
+  if [[ ${POM_WAS_REWRITTEN} -eq 1 ]]; then
+    if ! mv -f "${REPO_ROOT}/java/pom.xml.backup" "${REPO_ROOT}/java/pom.xml"; then
+      echo "Warning: failed to restore ${REPO_ROOT}/java/pom.xml from pom.xml.backup" >&2
+    fi
   fi
+  if ! chown -R "${HOST_UID}:${HOST_GID}" "${OUTPUT_DIR}" "${REPO_ROOT}/java/target"; then
+    echo "Warning: chown -R ${HOST_UID}:${HOST_GID} on ${OUTPUT_DIR} + ${REPO_ROOT}/java/target failed. Outputs may remain owned by root." >&2
+  fi
+  return "${prior_status}"
 }
-trap _chown_outputs_on_exit EXIT
+trap _cleanup_on_exit EXIT
 
 BUILD_ARG=(
   -B
@@ -83,7 +96,18 @@ BUILD_ARG+=("-Dcmake.ccache.opts=${CMAKE_CCACHE_OPTS[*]}")
 
 cd "${REPO_ROOT}/java"
 
-CUDF_VERSION="$(cudf_java_scl mvn help:evaluate -Dexpression=project.version -q -DforceStdout "${BUILD_ARG[@]}")"
+CUDF_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout "${BUILD_ARG[@]}")"
+
+# Release tag builds strip -SNAPSHOT and rewrite the POM so packaged artifacts
+# carry the release version. Non-release builds keep -SNAPSHOT. The EXIT trap
+# restores java/pom.xml after packaging (the rewritten POM is copied to OUTPUT_DIR).
+if rapids-is-release-build; then
+  CUDF_VERSION="${CUDF_VERSION%-SNAPSHOT}"
+  cp -p "${REPO_ROOT}/java/pom.xml" "${REPO_ROOT}/java/pom.xml.backup"
+  POM_WAS_REWRITTEN=1
+  mvn versions:set -DnewVersion="${CUDF_VERSION}" -DgenerateBackupPoms=false "${BUILD_ARG[@]}"
+fi
+
 rapids-logger "Packaging cuDF Java JAR ${CUDF_VERSION}"
 
 # Omit the `clean` goal: java/target may be a bind-mount point, so `mvn clean`
@@ -136,6 +160,7 @@ done
 
 cp -f "${MAIN_JAR}" "${OUTPUT_DIR}/"
 cp -f pom.xml "${OUTPUT_DIR}/cudf-${CUDF_VERSION}.pom"
+
 rapids-logger "Emitted artifacts to ${OUTPUT_DIR}"
 if command -v sccache >/dev/null 2>&1; then
   sccache --show-adv-stats || true

--- a/java/ci/build_static_libcudf.sh
+++ b/java/ci/build_static_libcudf.sh
@@ -4,7 +4,7 @@
 
 # Self-contained build of a static libcudf install tree.
 #
-# Pulls the RAPIDS ci-conda image, builds libcudf with BUILD_SHARED_LIBS=OFF
+# Pulls the RAPIDS ci-wheel image, builds libcudf with BUILD_SHARED_LIBS=OFF
 # inside a throwaway container, and installs the static libcudf tree (libcudf.a
 # plus its static dependencies) into a directory on the host. No GPU is required
 # to build.
@@ -16,6 +16,8 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/argparse.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/ci_wheel_image.sh"
 
 OUTPUT_DIR=""
 CUDA_VERSION=""
@@ -27,15 +29,15 @@ print_help() {
 
 Usage: build_static_libcudf.sh --output-dir <path> --cuda-version <ver> [OPTIONS]
 
-Builds a static libcudf install tree inside a RAPIDS ci-conda container and
+Builds a static libcudf install tree inside a RAPIDS ci-wheel container and
 writes it to a directory on the host. Always builds for the host architecture
-(uname -m). The build image is fixed to rapidsai/ci-conda:<rapids_version>-latest
-(version derived from the VERSION file).
+(uname -m). The build image is derived from --cuda-version and the VERSION file
+(see java/ci/ci_wheel_image.sh).
 
 REQUIRED:
     -o, --output-dir     Host directory to receive the static install tree
                          (libcudf.a and its static dependencies).
-    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.1").
+    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.2").
 
 OPTIONS:
     -A, --cmake-cuda-architectures
@@ -97,15 +99,15 @@ parse_args "$@"
 require_arg --output-dir   "${OUTPUT_DIR}"
 require_arg --cuda-version "${CUDA_VERSION}"
 
-RAPIDS_VERSION="$(head -1 "${REPO_ROOT}/VERSION" | cut -d. -f1,2)"
-IMAGE="rapidsai/ci-conda:${RAPIDS_VERSION}-latest"
+IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
+CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
 
 mkdir -p "${OUTPUT_DIR}"
 OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd)"
 
 echo "Building static libcudf"
 echo "  image:        ${IMAGE}"
-echo "  cuda version: ${CUDA_VERSION}"
+echo "  cuda version: ${CUDA_VERSION_FULL}"
 echo "  parallel:     ${PARALLEL_LEVEL}"
 echo "  output dir:   ${OUTPUT_DIR}"
 if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
@@ -117,10 +119,12 @@ DOCKER_ARGS=(
   --volume "${REPO_ROOT}:/repo"
   --volume "${OUTPUT_DIR}:/output"
   --workdir /repo
-  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION}"
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}"
   --env PARALLEL_LEVEL="${PARALLEL_LEVEL}"
   --env HOST_UID="$(id -u)"
   --env HOST_GID="$(id -g)"
+  --env INSTALL_PREFIX=/output
+  --env REPO_ROOT=/repo
 )
 
 if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then

--- a/java/ci/build_static_libcudf.sh
+++ b/java/ci/build_static_libcudf.sh
@@ -37,7 +37,8 @@ writes it to a directory on the host. Always builds for the host architecture
 REQUIRED:
     -o, --output-dir     Host directory to receive the static install tree
                          (libcudf.a and its static dependencies).
-    -c, --cuda-version   CUDA version to build for (e.g. "12.9" or "12.9.2").
+    -c, --cuda-version   CUDA toolkit version to build for (e.g. "12.9.2").
+                         Must match a rapidsai/ci-wheel image tag.
 
 OPTIONS:
     -A, --cmake-cuda-architectures
@@ -52,8 +53,8 @@ OPTIONS:
     -h, --help           Show this help message.
 
 EXAMPLES:
-    build_static_libcudf.sh --output-dir /tmp/libcudf-cuda12 --cuda-version "12.9"
-    build_static_libcudf.sh -o /tmp/libcudf-cuda13 -c 13.3 -A "80"
+    build_static_libcudf.sh --output-dir /tmp/libcudf-cuda12 --cuda-version "12.9.2"
+    build_static_libcudf.sh -o /tmp/libcudf-cuda13 -c 13.3.0 -A "80"
 
 EOF
 }
@@ -100,14 +101,13 @@ require_arg --output-dir   "${OUTPUT_DIR}"
 require_arg --cuda-version "${CUDA_VERSION}"
 
 IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
-CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
 
 mkdir -p "${OUTPUT_DIR}"
 OUTPUT_DIR="$(cd "${OUTPUT_DIR}" && pwd)"
 
 echo "Building static libcudf"
 echo "  image:        ${IMAGE}"
-echo "  cuda version: ${CUDA_VERSION_FULL}"
+echo "  cuda version: ${CUDA_VERSION}"
 echo "  parallel:     ${PARALLEL_LEVEL}"
 echo "  output dir:   ${OUTPUT_DIR}"
 if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
@@ -119,7 +119,7 @@ DOCKER_ARGS=(
   --volume "${REPO_ROOT}:/repo"
   --volume "${OUTPUT_DIR}:/output"
   --workdir /repo
-  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}"
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION}"
   --env PARALLEL_LEVEL="${PARALLEL_LEVEL}"
   --env HOST_UID="$(id -u)"
   --env HOST_GID="$(id -g)"

--- a/java/ci/build_static_libcudf_in_container.sh
+++ b/java/ci/build_static_libcudf_in_container.sh
@@ -34,6 +34,20 @@ if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
   exit 1
 fi
 
+if [[ -z ${HOST_UID} || -z ${HOST_GID} ]]; then
+  echo "Error: HOST_UID and HOST_GID must both be set" >&2
+  exit 1
+fi
+
+_cleanup_on_exit() {
+  local prior_status=$?
+  if ! chown -R "${HOST_UID}:${HOST_GID}" "${INSTALL_PREFIX}"; then
+    echo "Warning: chown -R ${HOST_UID}:${HOST_GID} on ${INSTALL_PREFIX} failed. Outputs may remain owned by root." >&2
+  fi
+  return "${prior_status}"
+}
+trap _cleanup_on_exit EXIT
+
 CMAKE_ARGS=(
   -S "${REPO_ROOT}/cpp"
   -B "${BUILD_DIR}"
@@ -75,10 +89,7 @@ cudf_java_scl cmake "${CMAKE_ARGS[@]}"
 cmake --build "${BUILD_DIR}" --parallel "${PARALLEL_LEVEL}"
 cmake --install "${BUILD_DIR}"
 
-# Hand the install tree back to the host user (host wrapper passes HOST_UID/GID).
-if [[ -n ${HOST_UID:-} && -n ${HOST_GID:-} ]]; then
-  chown -R "${HOST_UID}:${HOST_GID}" "${INSTALL_PREFIX}"
-fi
+rapids-logger "Emitted static libcudf install tree to ${INSTALL_PREFIX}"
 if command -v sccache >/dev/null 2>&1; then
   sccache --show-adv-stats || true
 fi

--- a/java/ci/build_static_libcudf_in_container.sh
+++ b/java/ci/build_static_libcudf_in_container.sh
@@ -4,62 +4,34 @@
 
 # In-container build of a static libcudf install tree.
 #
-# This script runs inside the rapidsai/ci-conda container launched by
-# java/ci/build_static_libcudf.sh. It generates the build_java conda toolchain
-# environment, builds libcudf with BUILD_SHARED_LIBS=OFF, and installs the
-# resulting static libcudf (plus its static dependencies) into /output. Then
-# chowns /output to HOST_UID:HOST_GID so the host user owns the outputs.
+# Expects a RAPIDS ci-wheel environment. Sources the toolchain from
+# setup_java_env.sh, builds libcudf with BUILD_SHARED_LIBS=OFF, and installs
+# the resulting static libcudf (plus its static dependencies) into
+# INSTALL_PREFIX. When HOST_UID / HOST_GID are set, chowns the install tree so
+# the host user owns the outputs.
 #
 # Inputs (environment variables):
-#   RAPIDS_CUDA_VERSION        CUDA version, e.g. 12.9 or 12.9.1 (required).
+#   RAPIDS_CUDA_VERSION        CUDA version, e.g. 12.9.2 (required).
 #   PARALLEL_LEVEL             Build parallelism (default: nproc).
 #   CMAKE_CUDA_ARCHITECTURES   Optional override for -DCMAKE_CUDA_ARCHITECTURES.
-#   HOST_UID / HOST_GID        Chown target for /output (both required).
+#   INSTALL_PREFIX             Static libcudf install dir (default: /output).
+#   REPO_ROOT                  cuDF checkout (default: /repo).
+#   BUILD_DIR                  CMake build dir (default: /tmp/libcudf-build).
+#   HOST_UID / HOST_GID        Optional chown target for INSTALL_PREFIX.
 
 set -e
 
-INSTALL_PREFIX=/output
-REPO_ROOT=/repo
-BUILD_DIR=/tmp/libcudf-build
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/output}"
+REPO_ROOT="${REPO_ROOT:-/repo}"
+BUILD_DIR="${BUILD_DIR:-/tmp/libcudf-build}"
 
-. /opt/conda/etc/profile.d/conda.sh
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/setup_java_env.sh"
 
-if [[ -z ${RAPIDS_CUDA_VERSION} ]]; then
+if [[ -z ${RAPIDS_CUDA_VERSION:-} ]]; then
   echo "Error: RAPIDS_CUDA_VERSION must be set" >&2
   exit 1
-fi
-
-if [[ -z ${HOST_UID} || -z ${HOST_GID} ]]; then
-  echo "Error: HOST_UID and HOST_GID must both be set" >&2
-  exit 1
-fi
-
-if [[ -z ${PARALLEL_LEVEL} ]]; then
-  PARALLEL_LEVEL=$(nproc)
-fi
-
-CUDA_MAJOR_MINOR=$(echo "${RAPIDS_CUDA_VERSION}" | cut -d. -f1,2)
-
-rapids-logger "Configuring conda strict channel priority"
-conda config --set channel_priority strict
-
-rapids-logger "Generating build_java conda environment (cuda=${CUDA_MAJOR_MINOR}, arch=$(arch))"
-ENV_YAML_DIR="$(mktemp -d)"
-rapids-dependency-file-generator \
-  --output conda \
-  --file-key build_java \
-  --matrix "cuda=${CUDA_MAJOR_MINOR};arch=$(arch)" | tee "${ENV_YAML_DIR}/env.yaml"
-
-rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n build_java
-conda activate build_java
-
-rapids-print-env
-
-if [[ -z ${CUDACXX} ]]; then
-  export CUDACXX="${CONDA_PREFIX}/bin/nvcc"
-fi
-if [[ -z ${LIBCUDF_KERNEL_CACHE_PATH} ]]; then
-  export LIBCUDF_KERNEL_CACHE_PATH=/tmp/rapids-kernel-cache
 fi
 
 CMAKE_ARGS=(
@@ -67,6 +39,9 @@ CMAKE_ARGS=(
   -B "${BUILD_DIR}"
   -GNinja
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
+  -DCMAKE_C_COMPILER="${CC}"
+  -DCMAKE_CXX_COMPILER="${CXX}"
+  -DCMAKE_CUDA_HOST_COMPILER="${CMAKE_CUDA_HOST_COMPILER}"
   -DBUILD_SHARED_LIBS=OFF
   -DBUILD_TESTS=OFF
   -DUSE_NVTX=ON
@@ -77,19 +52,33 @@ CMAKE_ARGS=(
   -DRMM_LOGGING_LEVEL=OFF
   -DCUDF_KVIKIO_REMOTE_IO=OFF
 )
-
-if [[ -n ${CMAKE_CUDA_ARCHITECTURES} ]]; then
+if [[ -n ${CMAKE_CUDA_ARCHITECTURES:-} ]]; then
   CMAKE_ARGS+=("-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
 fi
+# Forward the sccache launchers exported by setup_java_env.sh when present.
+if [[ -n ${CMAKE_C_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}")
+fi
+if [[ -n ${CMAKE_CXX_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
+fi
+if [[ -n ${CMAKE_CUDA_COMPILER_LAUNCHER:-} ]]; then
+  CMAKE_ARGS+=("-DCMAKE_CUDA_COMPILER_LAUNCHER=${CMAKE_CUDA_COMPILER_LAUNCHER}")
+fi
+# setup_java_env.sh builds the static Boost archives into BOOST_PREFIX.
+if [[ -d ${BOOST_PREFIX} ]]; then
+  CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=${BOOST_PREFIX}")
+fi
 
-rapids-logger "Configuring static libcudf"
-cmake "${CMAKE_ARGS[@]}"
-
-rapids-logger "Building static libcudf with ${PARALLEL_LEVEL} jobs"
+rapids-logger "Configuring/building static libcudf (cuda=${RAPIDS_CUDA_VERSION})"
+cudf_java_scl cmake "${CMAKE_ARGS[@]}"
 cmake --build "${BUILD_DIR}" --parallel "${PARALLEL_LEVEL}"
-
-rapids-logger "Installing static libcudf to ${INSTALL_PREFIX}"
 cmake --install "${BUILD_DIR}"
 
-rapids-logger "Chowning ${INSTALL_PREFIX} to ${HOST_UID}:${HOST_GID}"
-chown -R "${HOST_UID}:${HOST_GID}" "${INSTALL_PREFIX}"
+# Hand the install tree back to the host user (host wrapper passes HOST_UID/GID).
+if [[ -n ${HOST_UID:-} && -n ${HOST_GID:-} ]]; then
+  chown -R "${HOST_UID}:${HOST_GID}" "${INSTALL_PREFIX}"
+fi
+if command -v sccache >/dev/null 2>&1; then
+  sccache --show-adv-stats || true
+fi

--- a/java/ci/ci_wheel_image.sh
+++ b/java/ci/ci_wheel_image.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Image-tag helpers for Java packaging containers. Source, do not execute.
+#
+# cudf_java_normalize_cuda_version maps short forms (12.9, 13.3) to the full
+# tags used by rapidsai/ci-wheel; cudf_java_ci_wheel_image builds the image
+# name from VERSION + CUDA + RAPIDS_PY_VERSION.
+
+_java_ci_image_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_java_ci_image_repo_root="${REPO_ROOT:-$(git -C "${_java_ci_image_script_dir}" rev-parse --show-toplevel)}"
+
+cudf_java_normalize_cuda_version() {
+  local ver=$1
+  case "${ver}" in
+    12.9)
+      echo "12.9.2"
+      ;;
+    13.3)
+      echo "13.3.0"
+      ;;
+    *)
+      echo "${ver}"
+      ;;
+  esac
+}
+
+cudf_java_ci_wheel_image() {
+  local cuda_ver=${1:?cuda version required}
+  local rapids_ver cuda_full py_ver
+  rapids_ver="$(head -1 "${_java_ci_image_repo_root}/VERSION" | cut -d. -f1,2)"
+  cuda_full="$(cudf_java_normalize_cuda_version "${cuda_ver}")"
+  py_ver="${RAPIDS_PY_VERSION:-3.11}"
+  echo "rapidsai/ci-wheel:${rapids_ver}-cuda${cuda_full}-rockylinux8-py${py_ver}"
+}

--- a/java/ci/ci_wheel_image.sh
+++ b/java/ci/ci_wheel_image.sh
@@ -2,35 +2,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Image-tag helpers for Java packaging containers. Source, do not execute.
+# Image-tag helper for Java packaging containers. Source, do not execute.
 #
-# cudf_java_normalize_cuda_version maps short forms (12.9, 13.3) to the full
-# tags used by rapidsai/ci-wheel; cudf_java_ci_wheel_image builds the image
-# name from VERSION + CUDA + RAPIDS_PY_VERSION.
+# cudf_java_ci_wheel_image builds the rapidsai/ci-wheel tag from VERSION +
+# CUDA_VERSION + RAPIDS_PY_VERSION. CUDA_VERSION must be the full toolkit
+# version used in the image tag (e.g. 12.9.2), matching RAPIDS_CUDA_VERSION
+# in CI.
 
 _java_ci_image_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _java_ci_image_repo_root="${REPO_ROOT:-$(git -C "${_java_ci_image_script_dir}" rev-parse --show-toplevel)}"
 
-cudf_java_normalize_cuda_version() {
-  local ver=$1
-  case "${ver}" in
-    12.9)
-      echo "12.9.2"
-      ;;
-    13.3)
-      echo "13.3.0"
-      ;;
-    *)
-      echo "${ver}"
-      ;;
-  esac
-}
-
 cudf_java_ci_wheel_image() {
-  local cuda_ver=${1:?cuda version required}
-  local rapids_ver cuda_full py_ver
+  local cuda_version=${1:?CUDA version required}
+  local rapids_ver py_ver
   rapids_ver="$(head -1 "${_java_ci_image_repo_root}/VERSION" | cut -d. -f1,2)"
-  cuda_full="$(cudf_java_normalize_cuda_version "${cuda_ver}")"
   py_ver="${RAPIDS_PY_VERSION:-3.11}"
-  echo "rapidsai/ci-wheel:${rapids_ver}-cuda${cuda_full}-rockylinux8-py${py_ver}"
+  echo "rapidsai/ci-wheel:${rapids_ver}-cuda${cuda_version}-rockylinux8-py${py_ver}"
 }

--- a/java/ci/java_classifier.sh
+++ b/java/ci/java_classifier.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Maven classifier helpers for cuDF Java JARs. Source, do not execute.
+#
+# Derives the cuda<major>[-arm64] classifier, locates the unique classifier JAR
+# under a build output dir, and asserts the expected JAR + POM pair.
+
+# Print Maven classifier for a CUDA version + host arch (e.g. cuda12, cuda12-arm64).
+cudf_java_maven_classifier() {
+  local cuda_ver=${1:?cuda version required}
+  local major host_arch
+  major="$(echo "${cuda_ver}" | cut -d. -f1)"
+  host_arch="$(uname -m)"
+  case "${host_arch}" in
+    x86_64)
+      echo "cuda${major}"
+      ;;
+    aarch64|arm64)
+      echo "cuda${major}-arm64"
+      ;;
+    *)
+      echo "Error: unsupported host arch '${host_arch}'" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Echo the unique cudf-*-${classifier}.jar under dir; error if 0 or >1.
+cudf_java_find_classifier_jar() {
+  local dir=${1:?classifier out dir required}
+  local classifier=${2:?classifier required}
+  local jar="" candidate
+  for candidate in "${dir}"/cudf-*-"${classifier}".jar; do
+    if [[ ! -f ${candidate} ]]; then
+      continue
+    fi
+    if [[ -n ${jar} ]]; then
+      echo "Error: multiple JARs matching cudf-*-${classifier}.jar in ${dir}" >&2
+      ls -1 "${dir}" >&2
+      return 1
+    fi
+    jar=${candidate}
+  done
+  if [[ -z ${jar} ]]; then
+    echo "Error: no cudf-*-${classifier}.jar in ${dir}" >&2
+    ls -1 "${dir}" >&2
+    return 1
+  fi
+  echo "${jar}"
+}
+
+# Assert unique classifier JAR + unique cudf-*.pom; print basenames.
+cudf_java_assert_classifier_artifacts() {
+  local dir=${1:?classifier out dir required}
+  local classifier=${2:?classifier required}
+  local jar pom="" candidate
+  if ! jar="$(cudf_java_find_classifier_jar "${dir}" "${classifier}")"; then
+    return 1
+  fi
+  for candidate in "${dir}"/cudf-*.pom; do
+    if [[ ! -f ${candidate} ]]; then
+      continue
+    fi
+    if [[ -n ${pom} ]]; then
+      echo "Error: multiple POMs in ${dir}" >&2
+      ls -1 "${dir}" >&2
+      return 1
+    fi
+    pom=${candidate}
+  done
+  if [[ -z ${pom} ]]; then
+    echo "Error: no cudf-*.pom in ${dir}" >&2
+    ls -1 "${dir}" >&2
+    return 1
+  fi
+  echo "cuDF Java JAR build succeeded:"
+  echo "  $(basename "${jar}")"
+  echo "  $(basename "${pom}")"
+}
+
+# Echo the absolute path of the unique classifier JAR under a java-build
+# artifact tree. Classifier from $2 or RAPIDS_CUDA_VERSION; errors if 0 or >1.
+cudf_java_resolve_artifact_jar() {
+  local root=${1:?artifact root required}
+  local cuda_ver=${2:-${RAPIDS_CUDA_VERSION:-}}
+  local classifier
+  local -a matches
+
+  if [[ -z ${cuda_ver} ]]; then
+    echo "Error: set RAPIDS_CUDA_VERSION or pass a cuda version" >&2
+    return 1
+  fi
+  if [[ ! -d ${root} ]]; then
+    echo "Error: artifact root '${root}' is not a directory" >&2
+    return 1
+  fi
+  if ! classifier="$(cudf_java_maven_classifier "${cuda_ver}")"; then
+    return 1
+  fi
+
+  # -${classifier}.jar excludes the sources/javadoc/tests JARs.
+  mapfile -t matches < <(find "${root}" -type f -name "cudf-*-${classifier}.jar" | sort)
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    echo "Error: no cudf-*-${classifier}.jar under ${root}" >&2
+    find "${root}" -type f >&2
+    return 1
+  fi
+  if [[ ${#matches[@]} -gt 1 ]]; then
+    echo "Error: multiple cudf-*-${classifier}.jar under ${root}" >&2
+    printf '%s\n' "${matches[@]}" >&2
+    return 1
+  fi
+  realpath "${matches[0]}"
+}

--- a/java/ci/setup_java_env.sh
+++ b/java/ci/setup_java_env.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Toolchain for Java builds inside a RAPIDS ci-wheel container.
+#
+# Installs/configures JDK 8 + 17, ninja, cmake, Boost.Filesystem/System static
+# archives, the RAPIDS GCC toolset, and sccache. Safe to source repeatedly
+# (JAVA_ENV_READY short-circuits after the first load).
+
+TOOLSET_VERSION="${TOOLSET_VERSION:-14}"
+NINJA_VERSION="${NINJA_VERSION:-v1.13.1}"
+BOOST_VERSION="${BOOST_VERSION:-1.79.0}"
+BOOST_PREFIX="${BOOST_PREFIX:-/usr/local}"
+
+if [[ -n "${JAVA_ENV_READY:-}" ]]; then
+  return 0
+fi
+
+if ! type rapids-logger >/dev/null 2>&1; then
+  rapids-logger() {
+    echo ">>>> $*" >&2
+  }
+fi
+
+# JDK 8 for javac; JDK 17 for the -Pjavadoc-jdk17 Maven profile.
+dnf install -y maven java-1.8.0-openjdk-devel java-17-openjdk-devel
+
+# ci-wheel images do not ship ninja; CMake uses it as the preferred generator.
+if ! command -V ninja >/dev/null 2>&1; then
+  case "$(uname -m)" in
+    x86_64)
+      wget --no-hsts -q -O /tmp/ninja-linux.zip \
+        "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux.zip"
+      ;;
+    aarch64)
+      wget --no-hsts -q -O /tmp/ninja-linux.zip \
+        "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux-aarch64.zip"
+      ;;
+    *)
+      echo "Unrecognized platform '$(uname -m)'" >&2
+      exit 1
+      ;;
+  esac
+  unzip -d /usr/bin /tmp/ninja-linux.zip
+  chmod +x /usr/bin/ninja
+  rm -f /tmp/ninja-linux.zip
+fi
+
+if command -v rapids-pip-retry >/dev/null 2>&1; then
+  rapids-pip-retry install cmake
+else
+  pip install cmake
+fi
+
+# Refresh pyenv shims so the cmake we just installed is on PATH.
+if command -v pyenv >/dev/null 2>&1; then
+  pyenv rehash || true
+fi
+
+# Static libcudf needs Boost.Filesystem / Boost.System. ci-wheel does not ship
+# those static archives, so build them from source into BOOST_PREFIX when missing.
+has_boost_static_lib() {
+  local name=$1
+  [[ -f "${BOOST_PREFIX}/lib/${name}" || -f "${BOOST_PREFIX}/lib64/${name}" ]]
+}
+
+if ! has_boost_static_lib libboost_filesystem.a || ! has_boost_static_lib libboost_system.a; then
+  BOOST_DIR="boost_${BOOST_VERSION//./_}"
+  wget -q -O /tmp/boost.tgz \
+    "https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_DIR}.tar.gz"
+  tar -xzf /tmp/boost.tgz -C /tmp
+  (
+    if ! cd "/tmp/${BOOST_DIR}"; then
+      exit 1
+    fi
+    ./bootstrap.sh --prefix="${BOOST_PREFIX}"
+    ./b2 install --prefix="${BOOST_PREFIX}" --with-filesystem --with-system -j"$(nproc)"
+  )
+  rm -rf "/tmp/${BOOST_DIR}" /tmp/boost.tgz
+fi
+
+if [[ -z "${CUDACXX:-}" ]]; then
+  if [[ -x /usr/local/cuda/bin/nvcc ]]; then
+    export CUDACXX=/usr/local/cuda/bin/nvcc
+  elif command -v nvcc >/dev/null 2>&1; then
+    CUDACXX="$(command -v nvcc)"
+    export CUDACXX
+  fi
+fi
+
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-1.8.0-openjdk}"
+if [[ -z "${JDK17_HOME:-}" ]]; then
+  if [[ -d /usr/lib/jvm/java-17-openjdk ]]; then
+    export JDK17_HOME=/usr/lib/jvm/java-17-openjdk
+  else
+    JDK17_HOME="$(ls -d /usr/lib/jvm/java-17-openjdk* 2>/dev/null | head -1)"
+    export JDK17_HOME
+  fi
+fi
+
+export LIBCUDF_KERNEL_CACHE_PATH="${LIBCUDF_KERNEL_CACHE_PATH:-/tmp/rapids-kernel-cache}"
+mkdir -p "${LIBCUDF_KERNEL_CACHE_PATH}"
+export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
+export PARALLEL_LEVEL="${PARALLEL_LEVEL:-$(nproc)}"
+
+# Prefer gcc-toolset over Rocky's default system compiler.
+GCC_TOOLSET_ROOT="/opt/rh/gcc-toolset-${TOOLSET_VERSION}/root"
+export CC="${CC:-${GCC_TOOLSET_ROOT}/usr/bin/gcc}"
+export CXX="${CXX:-${GCC_TOOLSET_ROOT}/usr/bin/g++}"
+export CMAKE_CUDA_HOST_COMPILER="${CMAKE_CUDA_HOST_COMPILER:-${CC}}"
+
+if command -v rapids-configure-sccache >/dev/null 2>&1; then
+  # shellcheck disable=SC1091
+  source rapids-configure-sccache || true
+fi
+
+if command -v sccache >/dev/null 2>&1; then
+  export CMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER:-sccache}"
+  export CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER:-sccache}"
+  export CMAKE_CUDA_COMPILER_LAUNCHER="${CMAKE_CUDA_COMPILER_LAUNCHER:-sccache}"
+  # Restart so the next compile picks up the launcher env we just set.
+  sccache --stop-server 2>/dev/null || true
+fi
+
+# Rocky SCL wrapper: child build steps run under gcc-toolset-${TOOLSET_VERSION}.
+cudf_java_scl() {
+  scl enable "gcc-toolset-${TOOLSET_VERSION}" -- "$@"
+}
+export -f cudf_java_scl
+export TOOLSET_VERSION BOOST_PREFIX
+export JAVA_ENV_READY=1

--- a/java/ci/setup_java_env.sh
+++ b/java/ci/setup_java_env.sh
@@ -9,7 +9,6 @@
 # (JAVA_ENV_READY short-circuits after the first load).
 
 TOOLSET_VERSION="${TOOLSET_VERSION:-14}"
-NINJA_VERSION="${NINJA_VERSION:-v1.13.1}"
 BOOST_VERSION="${BOOST_VERSION:-1.79.0}"
 BOOST_PREFIX="${BOOST_PREFIX:-/usr/local}"
 
@@ -26,34 +25,14 @@ fi
 # JDK 8 for javac; JDK 17 for the -Pjavadoc-jdk17 Maven profile.
 dnf install -y maven java-1.8.0-openjdk-devel java-17-openjdk-devel
 
-# ci-wheel images do not ship ninja; CMake uses it as the preferred generator.
-if ! command -V ninja >/dev/null 2>&1; then
-  case "$(uname -m)" in
-    x86_64)
-      wget --no-hsts -q -O /tmp/ninja-linux.zip \
-        "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux.zip"
-      ;;
-    aarch64)
-      wget --no-hsts -q -O /tmp/ninja-linux.zip \
-        "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux-aarch64.zip"
-      ;;
-    *)
-      echo "Unrecognized platform '$(uname -m)'" >&2
-      exit 1
-      ;;
-  esac
-  unzip -d /usr/bin /tmp/ninja-linux.zip
-  chmod +x /usr/bin/ninja
-  rm -f /tmp/ninja-linux.zip
-fi
-
+# ci-wheel images do not ship ninja or a modern cmake. Install both from PyPI.
 if command -v rapids-pip-retry >/dev/null 2>&1; then
-  rapids-pip-retry install cmake
+  rapids-pip-retry install cmake ninja
 else
-  pip install cmake
+  pip install cmake ninja
 fi
 
-# Refresh pyenv shims so the cmake we just installed is on PATH.
+# Refresh pyenv shims so the cmake/ninja we just installed are on PATH.
 if command -v pyenv >/dev/null 2>&1; then
   pyenv rehash || true
 fi

--- a/java/ci/test_java_build_local.sh
+++ b/java/ci/test_java_build_local.sh
@@ -32,8 +32,8 @@ CMAKE_CUDA_ARCHITECTURES=""
 
 # CUDA versions built for both classifiers. Keep in sync with the java-build
 # matrix in .github/workflows/build.yaml.
-CUDA12_VERSION="12.9"
-CUDA13_VERSION="13.3"
+CUDA12_VERSION="12.9.2"
+CUDA13_VERSION="13.3.0"
 
 # Wall-clock timing variables.
 STEP_NAMES=()

--- a/java/ci/test_packaged_java_local.sh
+++ b/java/ci/test_packaged_java_local.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Local GPU wrapper around ci/test_packaged_java.sh.
+#
+# Resolves the classifier JAR from a test_java_build_local.sh --work-dir and
+# runs the packaged-JAR tests in a GPU-enabled ci-wheel container. Set
+# RAPIDS_CUDA_VERSION to select which classifier to test (default: 12.9).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/ci_wheel_image.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/java_classifier.sh"
+
+print_help() {
+  cat << EOF
+Usage: test_packaged_java_local.sh --work-dir <path>
+
+Uses the output from test_java_build_local.sh. Set RAPIDS_CUDA_VERSION to
+select the classifier to test (default: 12.9).
+EOF
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  print_help
+  exit 0
+fi
+if [[ $# -ne 2 ]]; then
+  print_help
+  exit 1
+fi
+if [[ $1 != "-w" && $1 != "--work-dir" ]]; then
+  print_help
+  exit 1
+fi
+
+WORK_DIR="$(cd "$2" && pwd)"
+CUDA_VERSION="${RAPIDS_CUDA_VERSION:-12.9}"
+CLASSIFIER="$(cudf_java_maven_classifier "${CUDA_VERSION}")"
+JAR_PATH="$(realpath "$(cudf_java_find_classifier_jar "${WORK_DIR}/jars/${CLASSIFIER}" "${CLASSIFIER}")")"
+IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
+CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
+
+echo "Running cuDF Java tests"
+echo "  image:        ${IMAGE}"
+echo "  cuda version: ${CUDA_VERSION_FULL}"
+echo "  classifier:   ${CLASSIFIER}"
+echo "  jar:          ${JAR_PATH}"
+
+docker run --rm --gpus all \
+  --volume "${REPO_ROOT}:/repo" \
+  --volume "${JAR_PATH}:/product/cudf.jar:ro" \
+  --workdir /repo \
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}" \
+  --env JAVA_JAR=/product/cudf.jar \
+  --env LIBCUDF_LARGE_STRINGS_ENABLED=0 \
+  "${IMAGE}" bash /repo/ci/test_packaged_java.sh

--- a/java/ci/test_packaged_java_local.sh
+++ b/java/ci/test_packaged_java_local.sh
@@ -6,7 +6,7 @@
 #
 # Resolves the classifier JAR from a test_java_build_local.sh --work-dir and
 # runs the packaged-JAR tests in a GPU-enabled ci-wheel container. Set
-# RAPIDS_CUDA_VERSION to select which classifier to test (default: 12.9).
+# RAPIDS_CUDA_VERSION to select which classifier to test (default: 12.9.2).
 
 set -euo pipefail
 
@@ -23,7 +23,7 @@ print_help() {
 Usage: test_packaged_java_local.sh --work-dir <path>
 
 Uses the output from test_java_build_local.sh. Set RAPIDS_CUDA_VERSION to
-select the classifier to test (default: 12.9).
+select the classifier to test (default: 12.9.2).
 EOF
 }
 
@@ -41,15 +41,14 @@ if [[ $1 != "-w" && $1 != "--work-dir" ]]; then
 fi
 
 WORK_DIR="$(cd "$2" && pwd)"
-CUDA_VERSION="${RAPIDS_CUDA_VERSION:-12.9}"
+CUDA_VERSION="${RAPIDS_CUDA_VERSION:-12.9.2}"
 CLASSIFIER="$(cudf_java_maven_classifier "${CUDA_VERSION}")"
 JAR_PATH="$(realpath "$(cudf_java_find_classifier_jar "${WORK_DIR}/jars/${CLASSIFIER}" "${CLASSIFIER}")")"
 IMAGE="$(cudf_java_ci_wheel_image "${CUDA_VERSION}")"
-CUDA_VERSION_FULL="$(cudf_java_normalize_cuda_version "${CUDA_VERSION}")"
 
 echo "Running cuDF Java tests"
 echo "  image:        ${IMAGE}"
-echo "  cuda version: ${CUDA_VERSION_FULL}"
+echo "  cuda version: ${CUDA_VERSION}"
 echo "  classifier:   ${CLASSIFIER}"
 echo "  jar:          ${JAR_PATH}"
 
@@ -57,7 +56,7 @@ docker run --rm --gpus all \
   --volume "${REPO_ROOT}:/repo" \
   --volume "${JAR_PATH}:/product/cudf.jar:ro" \
   --workdir /repo \
-  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION_FULL}" \
+  --env RAPIDS_CUDA_VERSION="${CUDA_VERSION}" \
   --env JAVA_JAR=/product/cudf.jar \
   --env LIBCUDF_LARGE_STRINGS_ENABLED=0 \
   "${IMAGE}" bash /repo/ci/test_packaged_java.sh

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -225,6 +225,92 @@
                 <cxx.flags>-Wno-deprecated-declarations</cxx.flags>
             </properties>
         </profile>
+        <!--
+            Default `mvn test` compiles java/src/main, builds natives via cmake,
+            puts classes on the surefire classpath ahead of any JAR, and runs
+            java/src/test. That exercises the local tree, not a published
+            classifier JAR. Activate -Ppackaged-jar-tests with
+            -Dcudf.jar.path=<classifier.jar> to skip cmake/main compile, put the
+            packaged JAR on the classpath instead, and run the same tests
+            (plus PackagedJarOriginCheck) against it.
+        -->
+        <profile>
+            <id>packaged-jar-tests</id>
+            <properties>
+                <skipNativeCopy>true</skipNativeCopy>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>ai.rapids</groupId>
+                    <artifactId>cudf-packaged</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${cudf.jar.path}</systemPath>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cmake</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>setproperty</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <skipMain>true</skipMain>
+                        </configuration>
+                    </plugin>
+                    <!-- copy-native-libs resolves ${native.cudf.path}, which is
+                         only defined by the disabled setproperty step above; skip
+                         it entirely since the packaged JAR already bundles natives. -->
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-native-libs</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>packaged-jar-origin-check</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override"/>
+                                    <includes>
+                                        <include>**/PackagedJarOriginCheck.java</include>
+                                    </includes>
+                                    <failIfNoTests>true</failIfNoTests>
+                                    <systemPropertyVariables>
+                                        <cudf.packaged.jar>${cudf.jar.path}</cudf.packaged.jar>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>default-tests</id>
             <build>
@@ -236,6 +322,7 @@
                                 <exclude>**/CudaFatalTest.java</exclude>
                                 <exclude>**/ColumnViewNonEmptyNullsTest.java</exclude>
                                 <exclude>**/NativeDepsLoaderTest.java</exclude>
+                                <exclude>**/PackagedJarOriginCheck.java</exclude>
                             </excludes>
                         </configuration>
                         <executions>
@@ -298,6 +385,7 @@
                                 <exclude>**/CuFileTest.java</exclude>
                                 <exclude>**/CudaFatalTest.java</exclude>
                                 <exclude>**/NativeDepsLoaderTest.java</exclude>
+                                <exclude>**/PackagedJarOriginCheck.java</exclude>
                             </excludes>
                         </configuration>
                         <executions>
@@ -697,9 +785,12 @@
                     </systemPropertyVariables>
                     <!-- NativeDepsLoaderTest mutates the lib-native-dir system property
                          and asserts the JVM is pristine; it must run in its own forked
-                         JVM via the dedicated execution defined in the test profiles. -->
+                         JVM via the dedicated execution defined in the test profiles.
+                         PackagedJarOriginCheck needs a packaged classifier JAR and is
+                         only run by the packaged-jar-tests profile. -->
                     <excludes>
                         <exclude>**/NativeDepsLoaderTest.java</exclude>
+                        <exclude>**/PackagedJarOriginCheck.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -66,7 +66,8 @@ public class NativeDepsLoader {
    * stages where all the dependencies in a stage are not interdependent and
    * therefore can be loaded in parallel. All dependencies within an earlier
    * stage are guaranteed to have finished loading before any dependencies in
-   * subsequent stages are loaded.
+   * subsequent stages are loaded. nvcomp is skipped if its resource is absent
+   * because static libcudf builds include it.
    */
   private static final String[][] loadOrder = new String[][]{
       new String[]{
@@ -89,12 +90,33 @@ public class NativeDepsLoader {
   public static synchronized void loadNativeDeps() {
     if (!loaded) {
       try {
-        loadNativeDeps(loadOrder, preserveDepsAfterLoad);
+        String[][] deps = loadOrder;
+        if (!hasNativeResource("nvcomp")) {
+          log.info("Skipping optional native dependency {}", System.mapLibraryName("nvcomp"));
+          deps = Arrays.stream(loadOrder)
+              .filter(stage -> Arrays.stream(stage).noneMatch("nvcomp"::equals))
+              .toArray(String[][]::new);
+        }
+        loadNativeDeps(deps, preserveDepsAfterLoad);
         loaded = true;
       } catch (Throwable t) {
         log.error("Could not load cudf jni library...", t);
       }
     }
+  }
+
+  private static boolean hasNativeResource(String baseName) {
+    String mapped = System.mapLibraryName(baseName);
+    if (libNativeDir != null) {
+      return new File(libNativeDir, mapped).isFile();
+    }
+    String os = System.getProperty("os.name");
+    String arch = System.getProperty("os.arch");
+    String path = arch + "/" + os + "/" + mapped;
+    if (loader.getResource(path + CHUNK_MANIFEST_SUFFIX) != null) {
+      return true;
+    }
+    return loader.getResource(path) != null;
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -113,9 +113,6 @@ public class NativeDepsLoader {
     String os = System.getProperty("os.name");
     String arch = System.getProperty("os.arch");
     String path = arch + "/" + os + "/" + mapped;
-    if (loader.getResource(path + CHUNK_MANIFEST_SUFFIX) != null) {
-      return true;
-    }
     return loader.getResource(path) != null;
   }
 

--- a/java/src/test/java/ai/rapids/cudf/PackagedJarOriginCheck.java
+++ b/java/src/test/java/ai/rapids/cudf/PackagedJarOriginCheck.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guard for {@code -Ppackaged-jar-tests}: fail fast if cuDF classes were loaded
+ * from {@code target/classes} (or any other path) instead of the packaged
+ * classifier JAR supplied via {@code -Dcudf.jar.path} / the
+ * {@code cudf.packaged.jar} system property.
+ */
+class PackagedJarOriginCheck {
+  @Test
+  void cudfClassesAreLoadedFromPackagedJar() throws Exception {
+    Path expected = Paths.get(System.getProperty("cudf.packaged.jar")).toRealPath();
+    Path actual = Paths.get(
+        Cuda.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+        .toRealPath();
+    assertEquals(expected, actual);
+  }
+}

--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]

--- a/python/libcudf_streaming/pyproject.toml
+++ b/python/libcudf_streaming/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]


### PR DESCRIPTION
## Description
* Rebuild classifier JARs on RAPIDS `ci-wheel` (Rocky 8) so the bundled
  JNI library links against a libstdc++ ABI that Ubuntu 22.04 and Rocky
  Linux 8 can satisfy.

* Skip optional `nvcomp` in `NativeDepsLoader` when its native resource
  is absent.

* Run the existing Java suite against the packaged classifier JAR in PR
  and nightly CI so tests cover the published artifact.

* Add a tag-gated `java-publish` job that uploads the gathered Maven
  repo to Maven Central.

Closes https://github.com/NVIDIA/cudf/issues/23753

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
