### PR TITLE
Pin Cython version for cython-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: v0.21.0
     hooks:
       - id: cython-lint
+        additional_dependencies: ["cython>=3.2.2,<3.3.0a0"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v2.3.0'
     hooks:

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - ${{ stdlib("c") }}
   host:
-    - cython >=3.2.2
+    - cython >=3.2.2,<3.3.0a0
     - pip
     - python =${{ py_abi_min }}
     - python-abi3 ${{ py_abi_min }}.*

--- a/conda/recipes/cudf_kafka/recipe.yaml
+++ b/conda/recipes/cudf_kafka/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - ${{ stdlib("c") }}
   host:
-    - cython >=3.2.2
+    - cython >=3.2.2,<3.3.0a0
     - pip
     - python =${{ py_abi_min }}
     - python-abi3 ${{ py_abi_min }}.*

--- a/conda/recipes/cudf_streaming/recipe.yaml
+++ b/conda/recipes/cudf_streaming/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - ${{ stdlib("c") }}
   host:
-    - cython >=3.2.2
+    - cython >=3.2.2,<3.3.0a0
     - pip
     - python =${{ py_abi_min }}
     - python-abi3 ${{ py_abi_min }}.*

--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - ${{ stdlib("c") }}
   host:
-    - cython >=3.2.2
+    - cython >=3.2.2,<3.3.0a0
     - pip
     - python =${{ py_abi_min }}
     - python-abi3 ${{ py_abi_min }}.*


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
cython-lint job is currently failing CI. Two things going on:

1. cython-lint is not compatible with the newest cython release. There's an issue: https://github.com/MarcoGorelli/cython-lint/issues/201
2. Pinning cython in cudf was not applied everywhere. Everywhere else cython is pinned to >=3.2.2,<3.3.0a0, but the cython-lint doesn't have it. Not sure if that was intentional or an oversight.

If the lack of pinning was an oversight, we can merge this PR regardless of when the cython-lint issue gets fixed and a new release is cut. If not, this should be treated as a temporary workaround. And may not be nescessary at all depending on when the issue is fixed upstream.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
