### PR TITLE
Use cuda::stream_ref in libcudf tests

### DIFF
--- a/cpp/include/cudf/detail/utilities/cuda.hpp
+++ b/cpp/include/cudf/detail/utilities/cuda.hpp
@@ -9,7 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 

--- a/cpp/include/cudf/detail/utilities/stream_pool.hpp
+++ b/cpp/include/cudf/detail/utilities/stream_pool.hpp
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <span>

--- a/cpp/include/cudf_test/debug_utilities.hpp
+++ b/cpp/include/cudf_test/debug_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace CUDF_EXPORT cudf {
 namespace test {

--- a/cpp/include/cudf_test/debug_utilities.hpp
+++ b/cpp/include/cudf_test/debug_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test {
@@ -27,8 +27,8 @@ namespace test {
  */
 std::string to_string(cudf::column_view const& col,
                       std::string const& delimiter,
-                      rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-                      cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+                      cuda::stream_ref stream   = cudf::test::get_default_stream(),
+                      cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert column values to a host vector of strings
@@ -39,8 +39,8 @@ std::string to_string(cudf::column_view const& col,
  */
 std::vector<std::string> to_strings(
   cudf::column_view const& col,
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+  cuda::stream_ref stream   = cudf::test::get_default_stream(),
+  cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Print a column view to an ostream
@@ -51,9 +51,9 @@ std::vector<std::string> to_strings(
  * @param mr Memory resources used for temporary device allocations
  */
 void print(cudf::column_view const& col,
-           std::ostream& os             = std::cout,
-           rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-           cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+           std::ostream& os          = std::cout,
+           cuda::stream_ref stream   = cudf::test::get_default_stream(),
+           cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 }  // namespace test
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf_test/debug_utilities.hpp
+++ b/cpp/include/cudf_test/debug_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test {

--- a/cpp/include/cudf_test/default_stream.hpp
+++ b/cpp/include/cudf_test/default_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test {
@@ -26,7 +26,7 @@ namespace test {
  *
  * @return The default stream to use for tests.
  */
-rmm::cuda_stream_view const get_default_stream();
+cuda::stream_ref const get_default_stream();
 
 }  // namespace test
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf_test/default_stream.hpp
+++ b/cpp/include/cudf_test/default_stream.hpp
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test {

--- a/cpp/include/cudf_test/default_stream.hpp
+++ b/cpp/include/cudf_test/default_stream.hpp
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace CUDF_EXPORT cudf {
 namespace test {

--- a/cpp/include/cudf_test/print_utilities.cuh
+++ b/cpp/include/cudf_test/print_utilities.cuh
@@ -9,8 +9,8 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream_ref>
-#include <thrust/iterator/transform_iterator.h>
+#include <cuda/iterator>
+#include <cuda/stream>
 
 #include <iterator>
 #include <type_traits>

--- a/cpp/include/cudf_test/print_utilities.cuh
+++ b/cpp/include/cudf_test/print_utilities.cuh
@@ -9,7 +9,6 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/iterator>
 #include <cuda/stream>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/cpp/include/cudf_test/print_utilities.cuh
+++ b/cpp/include/cudf_test/print_utilities.cuh
@@ -9,7 +9,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <iterator>

--- a/cpp/include/cudf_test/print_utilities.cuh
+++ b/cpp/include/cudf_test/print_utilities.cuh
@@ -9,9 +9,9 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/iterator>
+#include <cuda/stream>
+#include <thrust/iterator/transform_iterator.h>
 
 #include <iterator>
 #include <type_traits>
@@ -115,7 +115,7 @@ CUDF_KERNEL void print_array_kernel(std::size_t count, int32_t width, char delim
  * @param args List of iterators to be printed
  */
 template <typename... Ts>
-void print_array(std::size_t count, rmm::cuda_stream_view stream, Ts... args)
+void print_array(std::size_t count, cuda::stream_ref stream, Ts... args)
 {
   // The width to pad printed numbers to
   constexpr int32_t width = 6;
@@ -125,7 +125,7 @@ void print_array(std::size_t count, rmm::cuda_stream_view stream, Ts... args)
 
   // TODO we want this to compile to nothing dependnig on compiler flag, rather than runtime
   if (std::getenv("CUDA_DBG_DUMP") != nullptr) {
-    detail::print_array_kernel<<<1, 1, 0, stream.value()>>>(count, width, delimiter, args...);
+    detail::print_array_kernel<<<1, 1, 0, stream.get()>>>(count, width, delimiter, args...);
   }
 }
 

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -9,11 +9,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <iostream>
@@ -76,7 +76,7 @@ class stream_checking_resource_adaptor final {
                  std::size_t bytes,
                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    verify_stream(rmm::cuda_stream_view{stream.get()});
+    verify_stream(cuda::stream_ref{stream.get()});
     return upstream_.allocate(stream, bytes, alignment);
   }
 
@@ -85,7 +85,7 @@ class stream_checking_resource_adaptor final {
                   std::size_t bytes,
                   std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    verify_stream(rmm::cuda_stream_view{stream.get()});
+    verify_stream(cuda::stream_ref{stream.get()});
     upstream_.deallocate(stream, ptr, bytes, alignment);
   }
 
@@ -116,13 +116,13 @@ class stream_checking_resource_adaptor final {
    *
    * @throws `std::runtime_error` if provided an invalid stream
    */
-  void verify_stream(rmm::cuda_stream_view const stream) const
+  void verify_stream(cuda::stream_ref const stream) const
   {
-    auto cstream{stream.value()};
+    auto cstream{stream.get()};
     auto const invalid_stream =
       check_default_stream_ ? ((cstream == cudaStreamDefault) || (cstream == cudaStreamLegacy) ||
                                (cstream == cudaStreamPerThread))
-                            : (cstream != cudf::test::get_default_stream().value());
+                            : (cstream != cudf::test::get_default_stream().get());
 
     if (invalid_stream) {
       if (error_on_invalid_stream_) {

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -12,7 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <iostream>

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -13,7 +13,6 @@
 
 #include <cuda/memory_resource>
 #include <cuda/stream>
-#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <iostream>

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -12,7 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <iostream>

--- a/cpp/include/cudf_test/table_utilities.hpp
+++ b/cpp/include/cudf_test/table_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace CUDF_EXPORT cudf {
 namespace test::detail {

--- a/cpp/include/cudf_test/table_utilities.hpp
+++ b/cpp/include/cudf_test/table_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test::detail {
@@ -41,8 +41,8 @@ void expect_table_properties_equal(cudf::table_view lhs, cudf::table_view rhs);
  */
 void expect_tables_equal(cudf::table_view lhs,
                          cudf::table_view rhs,
-                         rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-                         cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+                         cuda::stream_ref stream   = cudf::test::get_default_stream(),
+                         cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Verifies the equivalency of two tables.
@@ -60,7 +60,7 @@ void expect_tables_equal(cudf::table_view lhs,
  */
 void expect_tables_equivalent(cudf::table_view lhs,
                               cudf::table_view rhs,
-                              rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
+                              cuda::stream_ref stream   = cudf::test::get_default_stream(),
                               cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 }  // namespace test::detail

--- a/cpp/include/cudf_test/table_utilities.hpp
+++ b/cpp/include/cudf_test/table_utilities.hpp
@@ -12,7 +12,7 @@
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 namespace CUDF_EXPORT cudf {
 namespace test::detail {

--- a/cpp/include/cudf_test/testing_main.hpp
+++ b/cpp/include/cudf_test/testing_main.hpp
@@ -27,7 +27,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <iostream>
 

--- a/cpp/include/cudf_test/testing_main.hpp
+++ b/cpp/include/cudf_test/testing_main.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -28,6 +27,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <iostream>
 

--- a/cpp/include/cudf_test/testing_main.hpp
+++ b/cpp/include/cudf_test/testing_main.hpp
@@ -27,7 +27,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 #include <iostream>
 

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -49,7 +49,7 @@ struct executor_ast {
   static std::unique_ptr<cudf::column> compute_column(
     cudf::table_view const& table,
     cudf::ast::expression const& expr,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
   {
     return cudf::compute_column(table, expr, stream, mr);
@@ -60,7 +60,7 @@ struct executor_jit {
   static std::unique_ptr<cudf::column> compute_column(
     cudf::table_view const& table,
     cudf::ast::expression const& expr,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    cuda::stream_ref stream           = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
   {
     return cudf::compute_column_jit(table, expr, stream, mr);

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -22,7 +22,6 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream>
 
 #include <stdexcept>
 

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -84,7 +84,7 @@ rmm::device_uvector<cudf::bitmask_type> make_mask(cudf::size_type size, bool fil
     CUDF_CUDA_TRY(cudaMemsetAsync(ret.data(),
                                   ~cudf::bitmask_type{0},
                                   size * sizeof(cudf::bitmask_type),
-                                  cudf::get_default_stream().get()));
+                                  cudf::get_default_stream().value()));
     return ret;
   }
 }

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -85,7 +85,7 @@ rmm::device_uvector<cudf::bitmask_type> make_mask(cudf::size_type size, bool fil
     CUDF_CUDA_TRY(cudaMemsetAsync(ret.data(),
                                   ~cudf::bitmask_type{0},
                                   size * sizeof(cudf::bitmask_type),
-                                  cudf::get_default_stream().value()));
+                                  cudf::get_default_stream().get()));
     return ret;
   }
 }

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -360,7 +360,7 @@ TEST_F(OverflowTest, OverflowTest)
     cudf::table_view tbl_last({*many_chars_last});
     std::vector<cudf::table_view> table_views_to_concat({tbl, tbl, tbl, tbl, tbl, tbl_last});
     std::unique_ptr<cudf::table> concatenated_tables = cudf::concatenate(table_views_to_concat);
-    EXPECT_NO_THROW(cudf::get_default_stream().synchronize());
+    EXPECT_NO_THROW(cudf::get_default_stream().sync());
     ASSERT_EQ(concatenated_tables->num_rows(), std::numeric_limits<cudf::size_type>::max());
   }
 

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -360,7 +360,7 @@ TEST_F(OverflowTest, OverflowTest)
     cudf::table_view tbl_last({*many_chars_last});
     std::vector<cudf::table_view> table_views_to_concat({tbl, tbl, tbl, tbl, tbl, tbl_last});
     std::unique_ptr<cudf::table> concatenated_tables = cudf::concatenate(table_views_to_concat);
-    EXPECT_NO_THROW(cudf::get_default_stream().sync());
+    EXPECT_NO_THROW(cudf::get_default_stream().synchronize());
     ASSERT_EQ(concatenated_tables->num_rows(), std::numeric_limits<cudf::size_type>::max());
   }
 

--- a/cpp/tests/device_atomics/device_atomics_test.cu
+++ b/cpp/tests/device_atomics/device_atomics_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -146,16 +146,16 @@ struct AtomicsTest : public cudf::test::BaseFixture {
     if (block_size == 0) { block_size = vec_size; }
 
     if (is_cas_test) {
-      gpu_atomicCAS_test<<<grid_size, block_size, 0, cudf::get_default_stream().value()>>>(
+      gpu_atomicCAS_test<<<grid_size, block_size, 0, cudf::get_default_stream().get()>>>(
         dev_result.data(), dev_data.data(), vec_size);
     } else {
-      gpu_atomic_test<<<grid_size, block_size, 0, cudf::get_default_stream().value()>>>(
+      gpu_atomic_test<<<grid_size, block_size, 0, cudf::get_default_stream().get()>>>(
         dev_result.data(), dev_data.data(), vec_size);
     }
 
     auto host_result = cudf::detail::make_host_vector(dev_result, cudf::get_default_stream());
 
-    CUDF_CHECK_CUDA(cudf::get_default_stream().value());
+    CUDF_CHECK_CUDA(cudf::get_default_stream().get());
 
     if (!is_timestamp_sum<T, cudf::DeviceSum>()) {
       EXPECT_EQ(host_result[0], exact[0]) << "atomicAdd test failed";
@@ -265,9 +265,9 @@ class Atomic128Test : public cudf::test::BaseFixture {
                            __int128_t expected_result)
   {
     rmm::device_scalar<__int128_t> d_target(initial_value, cudf::get_default_stream());
-    test_single_atomic_add_kernel<<<32, 256, 0, cudf::get_default_stream().value()>>>(
-      d_target.data(), add_value);
-    CUDF_CHECK_CUDA(cudf::get_default_stream().value());
+    test_single_atomic_add_kernel<<<32, 256, 0, cudf::get_default_stream().get()>>>(d_target.data(),
+                                                                                    add_value);
+    CUDF_CHECK_CUDA(cudf::get_default_stream().get());
     __int128_t result = d_target.value(cudf::get_default_stream());
     EXPECT_EQ(result, expected_result);
   }

--- a/cpp/tests/device_atomics/device_atomics_test.cu
+++ b/cpp/tests/device_atomics/device_atomics_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -146,16 +146,16 @@ struct AtomicsTest : public cudf::test::BaseFixture {
     if (block_size == 0) { block_size = vec_size; }
 
     if (is_cas_test) {
-      gpu_atomicCAS_test<<<grid_size, block_size, 0, cudf::get_default_stream().get()>>>(
+      gpu_atomicCAS_test<<<grid_size, block_size, 0, cudf::get_default_stream().value()>>>(
         dev_result.data(), dev_data.data(), vec_size);
     } else {
-      gpu_atomic_test<<<grid_size, block_size, 0, cudf::get_default_stream().get()>>>(
+      gpu_atomic_test<<<grid_size, block_size, 0, cudf::get_default_stream().value()>>>(
         dev_result.data(), dev_data.data(), vec_size);
     }
 
     auto host_result = cudf::detail::make_host_vector(dev_result, cudf::get_default_stream());
 
-    CUDF_CHECK_CUDA(cudf::get_default_stream().get());
+    CUDF_CHECK_CUDA(cudf::get_default_stream().value());
 
     if (!is_timestamp_sum<T, cudf::DeviceSum>()) {
       EXPECT_EQ(host_result[0], exact[0]) << "atomicAdd test failed";
@@ -265,9 +265,9 @@ class Atomic128Test : public cudf::test::BaseFixture {
                            __int128_t expected_result)
   {
     rmm::device_scalar<__int128_t> d_target(initial_value, cudf::get_default_stream());
-    test_single_atomic_add_kernel<<<32, 256, 0, cudf::get_default_stream().get()>>>(d_target.data(),
-                                                                                    add_value);
-    CUDF_CHECK_CUDA(cudf::get_default_stream().get());
+    test_single_atomic_add_kernel<<<32, 256, 0, cudf::get_default_stream().value()>>>(
+      d_target.data(), add_value);
+    CUDF_CHECK_CUDA(cudf::get_default_stream().value());
     __int128_t result = d_target.value(cudf::get_default_stream());
     EXPECT_EQ(result, expected_result);
   }

--- a/cpp/tests/interop/from_arrow_device_test.cpp
+++ b/cpp/tests/interop/from_arrow_device_test.cpp
@@ -25,6 +25,7 @@
 #include <cudf/types.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <limits>
 #include <numeric>
@@ -791,9 +792,9 @@ TEST_F(FromArrowDeviceTest, StringViewType)
   NANOARROW_THROW_NOT_OK(ArrowArrayViewInitFromSchema(&view, &schema, nullptr));
   NANOARROW_THROW_NOT_OK(ArrowArrayViewSetArray(&view, &input, nullptr));
 
-  auto stream  = cudf::get_default_stream();
-  auto items   = view.buffer_views[1].data.as_binary_view;
-  auto d_items = rmm::device_uvector<ArrowBinaryView>(input.length, stream);
+  cuda::stream_ref stream = cudf::get_default_stream();
+  auto items              = view.buffer_views[1].data.as_binary_view;
+  auto d_items            = rmm::device_uvector<ArrowBinaryView>(input.length, stream);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_items.data(),
                                 items,
                                 input.length * sizeof(ArrowBinaryView),
@@ -893,9 +894,9 @@ TEST_F(FromArrowDeviceTest, StringViewTypeWithProducerOwnedPrivateData)
   NANOARROW_THROW_NOT_OK(ArrowArrayViewSetArray(&view, input.get(), nullptr));
   ASSERT_GT(view.n_variadic_buffers, 0);
 
-  auto stream  = cudf::get_default_stream();
-  auto items   = view.buffer_views[1].data.as_binary_view;
-  auto d_items = rmm::device_uvector<ArrowBinaryView>(input->length, stream);
+  cuda::stream_ref stream = cudf::get_default_stream();
+  auto items              = view.buffer_views[1].data.as_binary_view;
+  auto d_items            = rmm::device_uvector<ArrowBinaryView>(input->length, stream);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_items.data(),
                                 items,
                                 input->length * sizeof(ArrowBinaryView),

--- a/cpp/tests/interop/from_arrow_device_test.cpp
+++ b/cpp/tests/interop/from_arrow_device_test.cpp
@@ -25,7 +25,7 @@
 #include <cudf/types.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <limits>
 #include <numeric>

--- a/cpp/tests/interop/from_arrow_device_test.cpp
+++ b/cpp/tests/interop/from_arrow_device_test.cpp
@@ -798,7 +798,7 @@ TEST_F(FromArrowDeviceTest, StringViewType)
                                 items,
                                 input.length * sizeof(ArrowBinaryView),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
   auto variadics     = std::vector<rmm::device_buffer>();
   auto variadic_ptrs = std::vector<char*>();
   for (auto i = 0L; i < view.n_variadic_buffers; ++i) {
@@ -806,7 +806,7 @@ TEST_F(FromArrowDeviceTest, StringViewType)
     variadic_ptrs.push_back(static_cast<char*>(variadics.back().data()));
   }
 
-  stream.synchronize();
+  stream.sync();
 
   NANOARROW_THROW_NOT_OK(ArrowSchemaSetTypeStruct(&schema, 1));
   NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(schema.children[0], NANOARROW_TYPE_STRING_VIEW));
@@ -900,14 +900,14 @@ TEST_F(FromArrowDeviceTest, StringViewTypeWithProducerOwnedPrivateData)
                                 items,
                                 input->length * sizeof(ArrowBinaryView),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
   auto variadics     = std::vector<rmm::device_buffer>();
   auto variadic_ptrs = std::vector<char*>();
   for (auto i = 0L; i < view.n_variadic_buffers; ++i) {
     variadics.emplace_back(view.variadic_buffers[i], view.variadic_buffer_sizes[i], stream);
     variadic_ptrs.push_back(static_cast<char*>(variadics.back().data()));
   }
-  stream.synchronize();
+  stream.sync();
 
   auto variadic_sizes = std::vector<int64_t>();
   for (auto i = 0L; i < view.n_variadic_buffers; ++i) {

--- a/cpp/tests/io/experimental/variant_extract_test.cpp
+++ b/cpp/tests/io/experimental/variant_extract_test.cpp
@@ -2340,7 +2340,7 @@ TEST_F(CastVariantStatusTest, SqlNullInputProducesRowNullStatus)
   // Mask row 1 SQL null
   auto null_mask = cudf::create_null_mask(2, cudf::mask_state::ALL_VALID, stream, cmr());
   cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 1, 2, false);
-  stream.synchronize();
+  stream.sync();
   values_col->set_null_mask(std::move(null_mask), 1);
 
   auto status = make_status_buffer(values_col->size());

--- a/cpp/tests/io/json/json_quote_normalization_test.cpp
+++ b/cpp/tests/io/json/json_quote_normalization_test.cpp
@@ -27,7 +27,7 @@ void run_test(std::string const& host_input,
 {
   auto stream_view  = cudf::test::get_default_stream();
   auto device_input = rmm::device_buffer(host_input.c_str(), host_input.size(), stream_view);
-  stream_view.synchronize();
+  stream_view.sync();
 
   // Preprocessing FST
   cudf::io::datasource::owning_buffer<rmm::device_buffer> device_data(std::move(device_input));
@@ -39,8 +39,8 @@ void run_test(std::string const& host_input,
                                 device_data.data(),
                                 preprocessed_host_output.size(),
                                 cudaMemcpyDefault,
-                                stream_view.value()))
-  stream_view.synchronize();
+                                stream_view.get()))
+  stream_view.sync();
   CUDF_TEST_EXPECT_VECTOR_EQUAL(
     preprocessed_host_output, expected_host_output, preprocessed_host_output.size());
 }

--- a/cpp/tests/iterator/iterator_tests.cuh
+++ b/cpp/tests/iterator/iterator_tests.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -51,7 +51,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
                               num_items,
                               cuda::minimum{},
                               init,
-                              cudf::get_default_stream().value());
+                              cudf::get_default_stream().get());
 
     // Allocate temporary storage
     rmm::device_buffer d_temp_storage(temp_storage_bytes, cudf::get_default_stream());
@@ -64,7 +64,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
                               num_items,
                               cuda::minimum{},
                               init,
-                              cudf::get_default_stream().value());
+                              cudf::get_default_stream().get());
 
     evaluate(expected, dev_result, "cub test");
   }

--- a/cpp/tests/iterator/iterator_tests.cuh
+++ b/cpp/tests/iterator/iterator_tests.cuh
@@ -51,7 +51,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
                               num_items,
                               cuda::minimum{},
                               init,
-                              cudf::get_default_stream().get());
+                              cudf::get_default_stream().value());
 
     // Allocate temporary storage
     rmm::device_buffer d_temp_storage(temp_storage_bytes, cudf::get_default_stream());
@@ -64,7 +64,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
                               num_items,
                               cuda::minimum{},
                               init,
-                              cudf::get_default_stream().get());
+                              cudf::get_default_stream().value());
 
     evaluate(expected, dev_result, "cub test");
   }

--- a/cpp/tests/iterator/value_iterator_test_strings.cu
+++ b/cpp/tests/iterator/value_iterator_test_strings.cu
@@ -14,7 +14,6 @@
 
 #include <cuda/iterator>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 auto strings_to_string_views(std::vector<std::string>& input_strings)

--- a/cpp/tests/iterator/value_iterator_test_strings.cu
+++ b/cpp/tests/iterator/value_iterator_test_strings.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "iterator_tests.cuh"
@@ -10,11 +10,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/host_vector.h>
 
 auto strings_to_string_views(std::vector<std::string>& input_strings)

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -2381,7 +2381,8 @@ TEST_F(JoinTest, HashJoinLargeOutputSize)
   // self-join a table of zeroes to generate an output row count that would overflow int32_t
   std::size_t col_size = 65567;
   rmm::device_buffer zeroes(col_size * sizeof(int32_t), cudf::get_default_stream());
-  CUDF_CUDA_TRY(cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), cudf::get_default_stream().get()));
+  CUDF_CUDA_TRY(
+    cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), cudf::get_default_stream().value()));
   cudf::column_view col_zeros(
     cudf::data_type{cudf::type_id::INT32}, col_size, zeroes.data(), nullptr, 0);
   cudf::table_view tview{{col_zeros}};

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -2381,8 +2381,7 @@ TEST_F(JoinTest, HashJoinLargeOutputSize)
   // self-join a table of zeroes to generate an output row count that would overflow int32_t
   std::size_t col_size = 65567;
   rmm::device_buffer zeroes(col_size * sizeof(int32_t), cudf::get_default_stream());
-  CUDF_CUDA_TRY(
-    cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), cudf::get_default_stream().value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), cudf::get_default_stream().get()));
   cudf::column_view col_zeros(
     cudf::data_type{cudf::type_id::INT32}, col_size, zeroes.data(), nullptr, 0);
   cudf::table_view tview{{col_zeros}};

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -29,7 +29,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 #include <algorithm>
 #include <future>

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -29,7 +29,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <future>

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -20,7 +20,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace {
 struct percentile_approx_dispatch {

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -14,9 +14,7 @@
 #include <cudf/groupby.hpp>
 #include <cudf/quantiles.hpp>
 #include <cudf/reduction.hpp>
-#include <cudf/sorting.hpp>
 #include <cudf/tdigest/tdigest_column_view.hpp>
-#include <cudf/transform.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -24,73 +22,7 @@
 #include <cuda/iterator>
 #include <cuda/stream_ref>
 
-#include <arrow/api.h>
-#include <arrow/compute/api.h>
-#include <arrow/compute/initialize.h>
-
 namespace {
-std::unique_ptr<cudf::column> arrow_percentile_approx(cudf::column_view const& _values,
-                                                      int delta,
-                                                      std::vector<double> const& percentages)
-{
-  static auto const _arrow_init_status = arrow::compute::Initialize();
-  EXPECT_TRUE(_arrow_init_status.ok());
-
-  cuda::stream_ref stream = cudf::get_default_stream();
-
-  // sort the incoming values using the same settings that groupby does.
-  // this is a little weak because null_order::AFTER is hardcoded internally to groupby.
-  cudf::table_view t({_values});
-  auto sorted_t      = cudf::sort(t, {}, {cudf::null_order::AFTER}, stream);
-  auto sorted_values = sorted_t->get_column(0).view();
-
-  std::vector<double> h_values(sorted_values.size());
-  CUDF_CUDA_TRY(cudaMemcpyAsync(h_values.data(),
-                                sorted_values.data<double>(),
-                                sizeof(double) * sorted_values.size(),
-                                cudaMemcpyDefault,
-                                stream.get()));
-  std::vector<char> h_validity(sorted_values.size());
-  if (sorted_values.null_mask() != nullptr) {
-    auto validity = cudf::mask_to_bools(sorted_values.null_mask(), 0, sorted_values.size(), stream);
-    CUDF_CUDA_TRY(cudaMemcpyAsync(h_validity.data(),
-                                  (validity->view().data<char>()),
-                                  sizeof(char) * sorted_values.size(),
-                                  cudaMemcpyDefault,
-                                  stream.get()));
-  }
-
-  // generate the tdigest
-  arrow::DoubleBuilder builder;
-  for (size_t idx = 0; idx < h_values.size(); idx++) {
-    if (sorted_values.null_mask() == nullptr || h_validity[idx]) {
-      EXPECT_TRUE(builder.Append(h_values[idx]).ok());
-    }
-  }
-  std::shared_ptr<arrow::Array> array;
-  EXPECT_TRUE(builder.Finish(&array).ok());
-
-  auto const udelta = static_cast<uint32_t>(delta);
-  auto const usize  = static_cast<uint32_t>(h_values.size()) * 2;
-  arrow::compute::TDigestOptions options{percentages, udelta, usize};
-
-  auto arrow_result = arrow::compute::CallFunction("tdigest", {array}, &options);
-  auto result_array = arrow_result.ValueOrDie().array_as<arrow::DoubleArray>();
-
-  // copy the percentiles and stuff them into a list column
-  std::vector<double> h_result;
-  h_result.reserve(percentages.size());
-  std::transform(
-    result_array->begin(), result_array->end(), std::back_inserter(h_result), [](auto p) {
-      return p.value();
-    });
-  cudf::test::fixed_width_column_wrapper<double> result(h_result.begin(), h_result.end());
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{
-    0, static_cast<cudf::size_type>(percentages.size())};
-  stream.sync();
-  return cudf::make_lists_column(1, offsets.release(), result.release(), 0, {});
-}
-
 struct percentile_approx_dispatch {
   template <typename T, typename Func>
   std::unique_ptr<cudf::column> operator()(Func op,
@@ -129,7 +61,7 @@ void percentile_approx_test(cudf::column_view const& _keys,
                             std::vector<double> const& percentages,
                             cudf::size_type ulps)
 {
-  auto stream                                 = cudf::get_default_stream();
+  cuda::stream_ref stream                     = cudf::get_default_stream();
   bool is_cpu_cluster_computation_disabled[2] = {true, false};
   for (int idx = 0; idx < 2; idx++) {
     cudf::tdigest::detail::is_cpu_cluster_computation_disabled =

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -14,14 +14,82 @@
 #include <cudf/groupby.hpp>
 #include <cudf/quantiles.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/sorting.hpp>
 #include <cudf/tdigest/tdigest_column_view.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/iterator>
 
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+#include <arrow/compute/initialize.h>
+
 namespace {
+std::unique_ptr<cudf::column> arrow_percentile_approx(cudf::column_view const& _values,
+                                                      int delta,
+                                                      std::vector<double> const& percentages)
+{
+  static auto const _arrow_init_status = arrow::compute::Initialize();
+  EXPECT_TRUE(_arrow_init_status.ok());
+
+  auto stream = cudf::get_default_stream();
+
+  // sort the incoming values using the same settings that groupby does.
+  // this is a little weak because null_order::AFTER is hardcoded internally to groupby.
+  cudf::table_view t({_values});
+  auto sorted_t      = cudf::sort(t, {}, {cudf::null_order::AFTER}, stream);
+  auto sorted_values = sorted_t->get_column(0).view();
+
+  std::vector<double> h_values(sorted_values.size());
+  CUDF_CUDA_TRY(cudaMemcpyAsync(h_values.data(),
+                                sorted_values.data<double>(),
+                                sizeof(double) * sorted_values.size(),
+                                cudaMemcpyDefault,
+                                stream.get()));
+  std::vector<char> h_validity(sorted_values.size());
+  if (sorted_values.null_mask() != nullptr) {
+    auto validity = cudf::mask_to_bools(sorted_values.null_mask(), 0, sorted_values.size(), stream);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(h_validity.data(),
+                                  (validity->view().data<char>()),
+                                  sizeof(char) * sorted_values.size(),
+                                  cudaMemcpyDefault,
+                                  stream.get()));
+  }
+
+  // generate the tdigest
+  arrow::DoubleBuilder builder;
+  for (size_t idx = 0; idx < h_values.size(); idx++) {
+    if (sorted_values.null_mask() == nullptr || h_validity[idx]) {
+      EXPECT_TRUE(builder.Append(h_values[idx]).ok());
+    }
+  }
+  std::shared_ptr<arrow::Array> array;
+  EXPECT_TRUE(builder.Finish(&array).ok());
+
+  auto const udelta = static_cast<uint32_t>(delta);
+  auto const usize  = static_cast<uint32_t>(h_values.size()) * 2;
+  arrow::compute::TDigestOptions options{percentages, udelta, usize};
+
+  auto arrow_result = arrow::compute::CallFunction("tdigest", {array}, &options);
+  auto result_array = arrow_result.ValueOrDie().array_as<arrow::DoubleArray>();
+
+  // copy the percentiles and stuff them into a list column
+  std::vector<double> h_result;
+  h_result.reserve(percentages.size());
+  std::transform(
+    result_array->begin(), result_array->end(), std::back_inserter(h_result), [](auto p) {
+      return p.value();
+    });
+  cudf::test::fixed_width_column_wrapper<double> result(h_result.begin(), h_result.end());
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{
+    0, static_cast<cudf::size_type>(percentages.size())};
+  stream.sync();
+  return cudf::make_lists_column(1, offsets.release(), result.release(), 0, {});
+}
+
 struct percentile_approx_dispatch {
   template <typename T, typename Func>
   std::unique_ptr<cudf::column> operator()(Func op,
@@ -98,7 +166,7 @@ void percentile_approx_test(cudf::column_view const& _keys,
         aggregations.push_back(cudf::make_tdigest_aggregation<cudf::groupby_aggregation>(delta));
         requests.push_back({values, std::move(aggregations)});
         auto result = std::move(gb.aggregate(requests, stream).second[0].results[0]);
-        stream.synchronize();
+        stream.sync();
         return result;
       };
       groupby_parts.push_back(cudf::type_dispatcher(values[v_idx].type(),
@@ -118,7 +186,7 @@ void percentile_approx_test(cudf::column_view const& _keys,
                        cudf::data_type{cudf::type_id::STRUCT},
                        stream);
         auto tbl = static_cast<cudf::struct_scalar const*>(scalar_result.get())->view();
-        stream.synchronize();
+        stream.sync();
         std::vector<std::unique_ptr<cudf::column>> cols;
         std::transform(
           tbl.begin(), tbl.end(), std::back_inserter(cols), [](cudf::column_view const& col) {
@@ -134,7 +202,7 @@ void percentile_approx_test(cudf::column_view const& _keys,
                                                    delta,
                                                    percentages,
                                                    ulps));
-      stream.synchronize();
+      stream.sync();
     }
 
     // second pass. run the percentile_approx with all the keys in one pass and make sure we get the
@@ -165,7 +233,7 @@ void percentile_approx_test(cudf::column_view const& _keys,
                                                                  percentages.end());
     cudf::tdigest::tdigest_column_view tdv(*(gb_result.second[0].results[0]));
     auto result = cudf::percentile_approx(tdv, g_percentages, stream);
-    stream.synchronize();
+    stream.sync();
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *result);
   }
@@ -179,7 +247,7 @@ void simple_test(cudf::data_type input_type, std::vector<std::pair<int, int>> pa
   auto keys = cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_id::INT32}, values->size(), cudf::mask_state::UNALLOCATED);
   CUDF_CUDA_TRY(cudaMemsetAsync(
-    keys->mutable_view().data<int32_t>(), 0, values->size() * sizeof(int32_t), stream.value()));
+    keys->mutable_view().data<int32_t>(), 0, values->size() * sizeof(int32_t), stream.get()));
 
   // runs both groupby and reduce paths
   std::for_each(params.begin(), params.end(), [&](std::pair<int, int> const& params) {
@@ -206,7 +274,7 @@ void grouped_test(cudf::data_type input_type, std::vector<std::pair<int, int>> p
                                 h_keys.data(),
                                 h_keys.size() * sizeof(int32_t),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
 
   std::for_each(params.begin(), params.end(), [&](std::pair<int, int> const& params) {
     percentile_approx_test(
@@ -253,7 +321,7 @@ void grouped_with_nulls_test(cudf::data_type input_type, std::vector<std::pair<i
                                 h_keys.data(),
                                 h_keys.size() * sizeof(int32_t),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
 
   // add a null mask
   auto mask = make_null_mask(*values);

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -22,6 +22,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 
 #include <arrow/api.h>
 #include <arrow/compute/api.h>
@@ -35,7 +36,7 @@ std::unique_ptr<cudf::column> arrow_percentile_approx(cudf::column_view const& _
   static auto const _arrow_init_status = arrow::compute::Initialize();
   EXPECT_TRUE(_arrow_init_status.ok());
 
-  auto stream = cudf::get_default_stream();
+  cuda::stream_ref stream = cudf::get_default_stream();
 
   // sort the incoming values using the same settings that groupby does.
   // this is a little weak because null_order::AFTER is hardcoded internally to groupby.
@@ -241,8 +242,8 @@ void percentile_approx_test(cudf::column_view const& _keys,
 
 void simple_test(cudf::data_type input_type, std::vector<std::pair<int, int>> params)
 {
-  auto stream = cudf::get_default_stream();
-  auto values = cudf::test::generate_standardized_percentile_distribution(input_type);
+  cuda::stream_ref stream = cudf::get_default_stream();
+  auto values             = cudf::test::generate_standardized_percentile_distribution(input_type);
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_id::INT32}, values->size(), cudf::mask_state::UNALLOCATED);
@@ -262,8 +263,8 @@ struct group_index {
 
 void grouped_test(cudf::data_type input_type, std::vector<std::pair<int, int>> params)
 {
-  auto stream = cudf::get_default_stream();
-  auto values = cudf::test::generate_standardized_percentile_distribution(input_type);
+  cuda::stream_ref stream = cudf::get_default_stream();
+  auto values             = cudf::test::generate_standardized_percentile_distribution(input_type);
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_id::INT32}, values->size(), cudf::mask_state::UNALLOCATED);
@@ -309,8 +310,8 @@ void simple_with_nulls_test(cudf::data_type input_type, std::vector<std::pair<in
 
 void grouped_with_nulls_test(cudf::data_type input_type, std::vector<std::pair<int, int>> params)
 {
-  auto stream = cudf::get_default_stream();
-  auto values = cudf::test::generate_standardized_percentile_distribution(input_type);
+  cuda::stream_ref stream = cudf::get_default_stream();
+  auto values             = cudf::test::generate_standardized_percentile_distribution(input_type);
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_id::INT32}, values->size(), cudf::mask_state::UNALLOCATED);

--- a/cpp/tests/reshape/table_to_array_tests.cpp
+++ b/cpp/tests/reshape/table_to_array_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,10 +16,10 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 
 template <typename T>
 struct TableToDeviceArrayTypedTest : public cudf::test::BaseFixture {};

--- a/cpp/tests/reshape/table_to_array_tests.cpp
+++ b/cpp/tests/reshape/table_to_array_tests.cpp
@@ -19,7 +19,6 @@
 #include <rmm/device_buffer.hpp>
 
 #include <cuda/functional>
-#include <cuda/stream_ref>
 
 template <typename T>
 struct TableToDeviceArrayTypedTest : public cudf::test::BaseFixture {};

--- a/cpp/tests/row_operator/row_operator_tests.cu
+++ b/cpp/tests/row_operator/row_operator_tests.cu
@@ -17,10 +17,10 @@
 #include <cudf/hashing/detail/xxhash_64.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 template <typename T>
@@ -34,21 +34,21 @@ template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> self_comparison(cudf::table_view input,
                                               std::vector<cudf::order> const& column_order,
                                               PhysicalElementComparator comparator,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> two_table_comparison(cudf::table_view lhs,
                                                    cudf::table_view rhs,
                                                    std::vector<cudf::order> const& column_order,
                                                    PhysicalElementComparator comparator,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> two_table_equality(cudf::table_view lhs,
                                                  cudf::table_view rhs,
                                                  std::vector<cudf::order> const& column_order,
                                                  PhysicalElementComparator comparator,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> sorted_order(
@@ -56,7 +56,7 @@ std::unique_ptr<cudf::column> sorted_order(
   cudf::size_type num_rows,
   bool has_nested,
   PhysicalElementComparator comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 
 TYPED_TEST(TypedTableViewTest, TestLexicographicalComparatorTwoTables)

--- a/cpp/tests/row_operator/row_operator_tests.cu
+++ b/cpp/tests/row_operator/row_operator_tests.cu
@@ -20,7 +20,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 template <typename T>

--- a/cpp/tests/row_operator/row_operator_tests.cu
+++ b/cpp/tests/row_operator/row_operator_tests.cu
@@ -20,7 +20,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 template <typename T>

--- a/cpp/tests/row_operator/row_operator_tests_utilities.hpp
+++ b/cpp/tests/row_operator/row_operator_tests_utilities.hpp
@@ -9,7 +9,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <vector>
 

--- a/cpp/tests/row_operator/row_operator_tests_utilities.hpp
+++ b/cpp/tests/row_operator/row_operator_tests_utilities.hpp
@@ -9,7 +9,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 
 #include <vector>
 

--- a/cpp/tests/row_operator/row_operator_tests_utilities.hpp
+++ b/cpp/tests/row_operator/row_operator_tests_utilities.hpp
@@ -9,7 +9,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <vector>
 
@@ -22,21 +22,21 @@ template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> self_comparison(cudf::table_view input,
                                               std::vector<cudf::order> const& column_order,
                                               PhysicalElementComparator comparator,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> two_table_comparison(cudf::table_view lhs,
                                                    cudf::table_view rhs,
                                                    std::vector<cudf::order> const& column_order,
                                                    PhysicalElementComparator comparator,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> two_table_equality(cudf::table_view lhs,
                                                  cudf::table_view rhs,
                                                  std::vector<cudf::order> const& column_order,
                                                  PhysicalElementComparator comparator,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  cudf::memory_resources mr);
 template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> sorted_order(
@@ -44,5 +44,5 @@ std::unique_ptr<cudf::column> sorted_order(
   cudf::size_type num_rows,
   bool has_nested,
   PhysicalElementComparator comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);

--- a/cpp/tests/row_operator/self_comparison_utilities.cu
+++ b/cpp/tests/row_operator/self_comparison_utilities.cu
@@ -8,10 +8,10 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 // Including this declaration/defintion in two_table_comparison_utilities.cu causes
@@ -21,7 +21,7 @@ template <typename PhysicalElementComparator>
 std::unique_ptr<cudf::column> self_comparison(cudf::table_view input,
                                               std::vector<cudf::order> const& column_order,
                                               PhysicalElementComparator comparator,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               cudf::memory_resources mr)
 {
   auto const table_comparator =
@@ -55,11 +55,11 @@ template std::unique_ptr<cudf::column> self_comparison<physical_comparator_t>(
   cudf::table_view input,
   std::vector<cudf::order> const& column_order,
   physical_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 template std::unique_ptr<cudf::column> self_comparison<sorting_comparator_t>(
   cudf::table_view input,
   std::vector<cudf::order> const& column_order,
   sorting_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);

--- a/cpp/tests/row_operator/self_comparison_utilities.cu
+++ b/cpp/tests/row_operator/self_comparison_utilities.cu
@@ -11,7 +11,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 // Including this declaration/defintion in two_table_comparison_utilities.cu causes

--- a/cpp/tests/row_operator/self_comparison_utilities.cu
+++ b/cpp/tests/row_operator/self_comparison_utilities.cu
@@ -11,7 +11,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 // Including this declaration/defintion in two_table_comparison_utilities.cu causes

--- a/cpp/tests/row_operator/two_table_comparison_utilities.cu
+++ b/cpp/tests/row_operator/two_table_comparison_utilities.cu
@@ -12,7 +12,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>

--- a/cpp/tests/row_operator/two_table_comparison_utilities.cu
+++ b/cpp/tests/row_operator/two_table_comparison_utilities.cu
@@ -12,7 +12,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>

--- a/cpp/tests/row_operator/two_table_comparison_utilities.cu
+++ b/cpp/tests/row_operator/two_table_comparison_utilities.cu
@@ -10,9 +10,9 @@
 #include <cudf/detail/row_operator/equality.cuh>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
@@ -22,7 +22,7 @@ std::unique_ptr<cudf::column> two_table_comparison(cudf::table_view lhs,
                                                    cudf::table_view rhs,
                                                    std::vector<cudf::order> const& column_order,
                                                    PhysicalElementComparator comparator,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    cudf::memory_resources mr)
 {
   // TODO: lexicographic::two_table_comparator still allocates from the current device resource.
@@ -60,14 +60,14 @@ template std::unique_ptr<cudf::column> two_table_comparison<physical_comparator_
   cudf::table_view rhs,
   std::vector<cudf::order> const& column_order,
   physical_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 template std::unique_ptr<cudf::column> two_table_comparison<sorting_comparator_t>(
   cudf::table_view lhs,
   cudf::table_view rhs,
   std::vector<cudf::order> const& column_order,
   sorting_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 
 template <typename PhysicalElementComparator>
@@ -76,7 +76,7 @@ std::unique_ptr<cudf::column> sorted_order(
   cudf::size_type num_rows,
   bool has_nested,
   PhysicalElementComparator comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr)
 {
   auto output = cudf::make_numeric_column(cudf::data_type(cudf::type_to_id<cudf::size_type>()),
@@ -112,12 +112,12 @@ template std::unique_ptr<cudf::column> sorted_order<physical_comparator_t>(
   cudf::size_type num_rows,
   bool has_nested,
   physical_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 template std::unique_ptr<cudf::column> sorted_order<sorting_comparator_t>(
   std::shared_ptr<cudf::detail::row::lexicographic::preprocessed_table> preprocessed_input,
   cudf::size_type num_rows,
   bool has_nested,
   sorting_comparator_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);

--- a/cpp/tests/row_operator/two_table_equality_utilities.cu
+++ b/cpp/tests/row_operator/two_table_equality_utilities.cu
@@ -8,9 +8,9 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 template <typename PhysicalElementComparator>
@@ -18,7 +18,7 @@ std::unique_ptr<cudf::column> two_table_equality(cudf::table_view lhs,
                                                  cudf::table_view rhs,
                                                  std::vector<cudf::order> const& column_order,
                                                  PhysicalElementComparator comparator,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  cudf::memory_resources mr)
 {
   auto const table_comparator =
@@ -62,12 +62,12 @@ template std::unique_ptr<cudf::column> two_table_equality<physical_equality_t>(
   cudf::table_view rhs,
   std::vector<cudf::order> const& column_order,
   physical_equality_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);
 template std::unique_ptr<cudf::column> two_table_equality<nan_equality_t>(
   cudf::table_view lhs,
   cudf::table_view rhs,
   std::vector<cudf::order> const& column_order,
   nan_equality_t comparator,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   cudf::memory_resources mr);

--- a/cpp/tests/row_operator/two_table_equality_utilities.cu
+++ b/cpp/tests/row_operator/two_table_equality_utilities.cu
@@ -10,7 +10,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 template <typename PhysicalElementComparator>

--- a/cpp/tests/row_operator/two_table_equality_utilities.cu
+++ b/cpp/tests/row_operator/two_table_equality_utilities.cu
@@ -10,7 +10,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 template <typename PhysicalElementComparator>

--- a/cpp/tests/scalar/scalar_device_view_test.cu
+++ b/cpp/tests/scalar/scalar_device_view_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,14 +51,14 @@ TYPED_TEST(TypedScalarDeviceViewTest, Value)
   auto scalar_device_view1 = cudf::get_scalar_device_view(s1);
   cudf::detail::device_scalar<bool> result{cudf::get_default_stream()};
 
-  test_set_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view,
-                                                                  scalar_device_view1);
+  test_set_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view,
+                                                                scalar_device_view1);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_EQ(s1.value(), value);
   EXPECT_TRUE(s1.is_valid());
 
-  test_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(
+  test_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(
     scalar_device_view, scalar_device_view1, result.data());
   CUDF_CHECK_CUDA(0);
 
@@ -78,7 +78,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, ConstructNull)
   auto scalar_device_view = cudf::get_scalar_device_view(s);
   cudf::detail::device_scalar<bool> result{cudf::get_default_stream()};
 
-  test_null<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view, result.data());
+  test_null<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view, result.data());
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(result.value(cudf::get_default_stream()));
@@ -98,7 +98,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, SetNull)
   s.set_valid_async(true);
   EXPECT_TRUE(s.is_valid());
 
-  test_setnull<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view);
+  test_setnull<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(s.is_valid());
@@ -125,7 +125,7 @@ TEST_F(StringScalarDeviceViewTest, Value)
                                                    cudf::get_default_stream(),
                                                    cudf::get_current_device_resource_ref());
 
-  test_string_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(
+  test_string_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(
     scalar_device_view, value_v.data(), value.size(), result.data());
   CUDF_CHECK_CUDA(0);
 

--- a/cpp/tests/scalar/scalar_device_view_test.cu
+++ b/cpp/tests/scalar/scalar_device_view_test.cu
@@ -51,14 +51,14 @@ TYPED_TEST(TypedScalarDeviceViewTest, Value)
   auto scalar_device_view1 = cudf::get_scalar_device_view(s1);
   cudf::detail::device_scalar<bool> result{cudf::get_default_stream()};
 
-  test_set_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view,
-                                                                scalar_device_view1);
+  test_set_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view,
+                                                                  scalar_device_view1);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_EQ(s1.value(), value);
   EXPECT_TRUE(s1.is_valid());
 
-  test_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(
+  test_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(
     scalar_device_view, scalar_device_view1, result.data());
   CUDF_CHECK_CUDA(0);
 
@@ -78,7 +78,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, ConstructNull)
   auto scalar_device_view = cudf::get_scalar_device_view(s);
   cudf::detail::device_scalar<bool> result{cudf::get_default_stream()};
 
-  test_null<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view, result.data());
+  test_null<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view, result.data());
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(result.value(cudf::get_default_stream()));
@@ -98,7 +98,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, SetNull)
   s.set_valid_async(true);
   EXPECT_TRUE(s.is_valid());
 
-  test_setnull<<<1, 1, 0, cudf::get_default_stream().get()>>>(scalar_device_view);
+  test_setnull<<<1, 1, 0, cudf::get_default_stream().value()>>>(scalar_device_view);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(s.is_valid());
@@ -125,7 +125,7 @@ TEST_F(StringScalarDeviceViewTest, Value)
                                                    cudf::get_default_stream(),
                                                    cudf::get_current_device_resource_ref());
 
-  test_string_value<<<1, 1, 0, cudf::get_default_stream().get()>>>(
+  test_string_value<<<1, 1, 0, cudf::get_default_stream().value()>>>(
     scalar_device_view, value_v.data(), value.size(), result.data());
   CUDF_CHECK_CUDA(0);
 

--- a/cpp/tests/streams/pool_test.cu
+++ b/cpp/tests/streams/pool_test.cu
@@ -9,7 +9,6 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
-#include <cuda/stream_ref>
 
 class StreamPoolTest : public cudf::test::BaseFixture {};
 

--- a/cpp/tests/streams/pool_test.cu
+++ b/cpp/tests/streams/pool_test.cu
@@ -9,7 +9,6 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
-
 class StreamPoolTest : public cudf::test::BaseFixture {};
 
 CUDF_KERNEL void do_nothing_kernel() {}

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -20,7 +20,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/transform.h>
 
 #include <vector>

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -20,7 +20,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 #include <vector>

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -18,9 +18,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/transform.h>
 
 #include <vector>
@@ -33,7 +33,7 @@ void row_comparison(cudf::table_view input1,
                     cudf::mutable_column_view output,
                     std::vector<cudf::order> const& column_order)
 {
-  rmm::cuda_stream_view stream{cudf::get_default_stream()};
+  cuda::stream_ref stream{cudf::get_default_stream()};
 
   auto const comparator = cudf::detail::row::lexicographic::two_table_comparator{
     input1, input2, column_order, {}, stream};

--- a/cpp/tests/types/type_dispatcher_test.cu
+++ b/cpp/tests/types/type_dispatcher_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -69,8 +69,8 @@ TYPED_TEST(TypedDispatcherTest, DeviceDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector<bool>(
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
-  dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(
-    cudf::type_to_id<TypeParam>(), result.data());
+  dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(cudf::type_to_id<TypeParam>(),
+                                                                      result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::get_default_stream()));
 }
@@ -136,7 +136,7 @@ TYPED_TEST(TypedDoubleDispatcherTest, DeviceDoubleDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector<bool>(
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
-  double_dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(
+  double_dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(
     cudf::type_to_id<TypeParam>(), cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::get_default_stream()));

--- a/cpp/tests/types/type_dispatcher_test.cu
+++ b/cpp/tests/types/type_dispatcher_test.cu
@@ -69,8 +69,8 @@ TYPED_TEST(TypedDispatcherTest, DeviceDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector<bool>(
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
-  dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(cudf::type_to_id<TypeParam>(),
-                                                                      result.data());
+  dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(
+    cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::get_default_stream()));
 }
@@ -136,7 +136,7 @@ TYPED_TEST(TypedDoubleDispatcherTest, DeviceDoubleDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector<bool>(
     1, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
-  double_dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(
+  double_dispatch_test_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(
     cudf::type_to_id<TypeParam>(), cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::get_default_stream()));

--- a/cpp/tests/utilities/debug_utilities.cu
+++ b/cpp/tests/utilities/debug_utilities.cu
@@ -39,9 +39,9 @@ namespace detail {
  */
 std::string to_string(cudf::column_view const& col,
                       std::string const& delimiter,
-                      std::string const& indent    = "",
-                      rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-                      cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+                      std::string const& indent = "",
+                      cuda::stream_ref stream   = cudf::test::get_default_stream(),
+                      cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Formats a null mask as a string
@@ -89,9 +89,9 @@ std::string to_string(std::vector<bitmask_type> const& null_mask,
  */
 std::vector<std::string> to_strings(
   cudf::column_view const& col,
-  std::string const& indent    = "",
-  rmm::cuda_stream_view stream = cudf::test::get_default_stream(),
-  cudf::memory_resources mr    = cudf::get_current_device_resource_ref());
+  std::string const& indent = "",
+  cuda::stream_ref stream   = cudf::test::get_default_stream(),
+  cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
 }  // namespace detail
 
@@ -147,7 +147,7 @@ std::string get_nested_type_str(cudf::column_view const& view)
 
 template <typename NestedColumnView>
 std::string nested_offsets_to_string(NestedColumnView const& c,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      cudf::memory_resources mr,
                                      std::string const& delimiter = ", ")
 {
@@ -184,7 +184,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const&,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(is_numeric<Element>())
   {
@@ -213,7 +213,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const& indent,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(is_timestamp<Element>())
   {
@@ -243,7 +243,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const&,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(cudf::is_fixed_point<Element>())
   {
@@ -269,7 +269,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const&,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<Element, cudf::string_view>)
   {
@@ -312,7 +312,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const&,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<Element, cudf::dictionary32>)
   {
@@ -341,7 +341,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const&,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(is_duration<Element>())
   {
@@ -371,7 +371,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const& indent,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<Element, cudf::list_view>)
   {
@@ -406,7 +406,7 @@ struct column_view_printer {
   void operator()(cudf::column_view const& col,
                   std::vector<std::string>& out,
                   std::string const& indent,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   cudf::memory_resources mr)
     requires(std::is_same_v<Element, cudf::struct_view>)
   {
@@ -455,7 +455,7 @@ namespace detail {
  */
 std::vector<std::string> to_strings(cudf::column_view const& col,
                                     std::string const& indent,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     cudf::memory_resources mr)
 {
   std::vector<std::string> reply;
@@ -471,7 +471,7 @@ std::vector<std::string> to_strings(cudf::column_view const& col,
 std::string to_string(cudf::column_view const& col,
                       std::string const& delimiter,
                       std::string const& indent,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       cudf::memory_resources mr)
 {
   std::ostringstream buffer;
@@ -507,7 +507,7 @@ std::string to_string(std::vector<bitmask_type> const& null_mask,
 }  // namespace detail
 
 std::vector<std::string> to_strings(cudf::column_view const& col,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     cudf::memory_resources mr)
 {
   return detail::to_strings(col, "", stream, mr);
@@ -515,7 +515,7 @@ std::vector<std::string> to_strings(cudf::column_view const& col,
 
 std::string to_string(cudf::column_view const& col,
                       std::string const& delimiter,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       cudf::memory_resources mr)
 {
   return detail::to_string(col, delimiter, "", stream, mr);
@@ -528,7 +528,7 @@ std::string to_string(std::vector<bitmask_type> const& null_mask, size_type null
 
 void print(cudf::column_view const& col,
            std::ostream& os,
-           rmm::cuda_stream_view stream,
+           cuda::stream_ref stream,
            cudf::memory_resources mr)
 {
   os << to_string(col, ",", stream, mr) << std::endl;

--- a/cpp/tests/utilities/default_stream.cpp
+++ b/cpp/tests/utilities/default_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 namespace cudf {
 namespace test {
 
-rmm::cuda_stream_view const get_default_stream() { return cudf::get_default_stream(); }
+cuda::stream_ref const get_default_stream() { return cudf::get_default_stream(); }
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -7,7 +7,7 @@
 
 #include <rmm/cuda_stream.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime.h>
 
 #include <dlfcn.h>

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -6,8 +6,8 @@
 #include <cudf/detail/utilities/stream_pool.hpp>
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime.h>
 
 #include <dlfcn.h>
@@ -48,7 +48,7 @@ namespace cudf {
 namespace test {
 #endif
 
-rmm::cuda_stream_view const get_default_stream()
+cuda::stream_ref const get_default_stream()
 {
   static rmm::cuda_stream stream{};
   return stream;
@@ -68,6 +68,10 @@ namespace detail {
 class test_cuda_stream_pool : public cuda_stream_pool {
  public:
   cuda::stream_ref get_stream() override { return cudf::test::get_default_stream(); }
+  [[maybe_unused]] cuda::stream_ref get_stream(stream_id_type stream_id) override
+  {
+    return cudf::test::get_default_stream();
+  }
 
   std::vector<cuda::stream_ref> get_streams(std::size_t count) override
   {
@@ -86,12 +90,12 @@ bool stream_is_invalid(cudaStream_t stream)
 {
 #ifdef STREAM_MODE_TESTING
   // In this mode the _only_ valid stream is the one returned by cudf::test::get_default_stream.
-  return (stream != cudf::test::get_default_stream().value());
+  return (stream != cudf::test::get_default_stream().get());
 #else
   // We explicitly list the possibilities rather than using
-  // `cudf::get_default_stream().value()` because there is no guarantee that
+  // `cudf::get_default_stream().get()` because there is no guarantee that
   // `thrust::device` and the default value of
-  // `cudf::get_default_stream().value()` are actually the same. At present, the
+  // `cudf::get_default_stream().get()` are actually the same. At present, the
   // former is `cudaStreamLegacy` while the latter is 0.
   return (stream == cudaStreamDefault) || (stream == cudaStreamLegacy) ||
          (stream == cudaStreamPerThread);

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -7,7 +7,7 @@
 
 #include <rmm/cuda_stream.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime.h>
 
 #include <dlfcn.h>

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -68,10 +68,6 @@ namespace detail {
 class test_cuda_stream_pool : public cuda_stream_pool {
  public:
   cuda::stream_ref get_stream() override { return cudf::test::get_default_stream(); }
-  [[maybe_unused]] cuda::stream_ref get_stream(stream_id_type stream_id) override
-  {
-    return cudf::test::get_default_stream();
-  }
 
   std::vector<cuda::stream_ref> get_streams(std::size_t count) override
   {

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -89,9 +89,9 @@ bool stream_is_invalid(cudaStream_t stream)
   return (stream != cudf::test::get_default_stream().get());
 #else
   // We explicitly list the possibilities rather than using
-  // `cudf::get_default_stream().get()` because there is no guarantee that
+  // `cudf::get_default_stream().value()` because there is no guarantee that
   // `thrust::device` and the default value of
-  // `cudf::get_default_stream().get()` are actually the same. At present, the
+  // `cudf::get_default_stream().value()` are actually the same. At present, the
   // former is `cudaStreamLegacy` while the latter is 0.
   return (stream == cudaStreamDefault) || (stream == cudaStreamLegacy) ||
          (stream == cudaStreamPerThread);

--- a/cpp/tests/utilities/roaring_bitmap_test.cpp
+++ b/cpp/tests/utilities/roaring_bitmap_test.cpp
@@ -12,7 +12,6 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
-#include <cuda/stream_ref>
 
 #include <vector>
 

--- a/cpp/tests/utilities/roaring_bitmap_test.cpp
+++ b/cpp/tests/utilities/roaring_bitmap_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <vector>
 
@@ -62,7 +62,7 @@ TYPED_TEST(RoaringBitmapTest, Basics)
     auto result_col = bitmap.contains_async(keys_col, stream, mr);
     auto results    = cudf::detail::make_host_vector_async(
       cudf::device_span<bool const>(result_col->view().template data<bool>(), num_keys), stream);
-    stream.synchronize();
+    stream.sync();
     EXPECT_TRUE(std::equal(results.begin(), results.end(), is_even));
   }
 
@@ -73,7 +73,7 @@ TYPED_TEST(RoaringBitmapTest, Basics)
     bitmap.contains_async(keys_col, result_col->mutable_view(), stream);
     auto results = cudf::detail::make_host_vector_async(
       cudf::device_span<bool const>(result_col->view().template data<bool>(), num_keys), stream);
-    stream.synchronize();
+    stream.sync();
     EXPECT_TRUE(std::equal(results.begin(), results.end(), is_even));
   }
 }

--- a/cpp/tests/utilities/roaring_bitmap_test.cpp
+++ b/cpp/tests/utilities/roaring_bitmap_test.cpp
@@ -12,6 +12,8 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
+#include <cuda/stream_ref>
+
 #include <vector>
 
 template <typename T>
@@ -45,8 +47,8 @@ TYPED_TEST(RoaringBitmapTest, Basics)
     }
   }();
 
-  auto const stream = cudf::get_default_stream();
-  auto const mr     = cudf::get_current_device_resource_ref();
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
 
   auto bitmap = cudf::roaring_bitmap(bitmap_type, serialized_bitmap_data);
 

--- a/cpp/tests/utilities/roaring_bitmap_test.cpp
+++ b/cpp/tests/utilities/roaring_bitmap_test.cpp
@@ -12,7 +12,6 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
-
 #include <vector>
 
 template <typename T>

--- a/cpp/tests/utilities/roaring_bitmap_test.cpp
+++ b/cpp/tests/utilities/roaring_bitmap_test.cpp
@@ -12,7 +12,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <vector>
 

--- a/cpp/tests/utilities/table_utilities.cu
+++ b/cpp/tests/utilities/table_utilities.cu
@@ -16,7 +16,7 @@ void expect_table_properties_equal(cudf::table_view lhs, cudf::table_view rhs)
 
 void expect_tables_equal(cudf::table_view lhs,
                          cudf::table_view rhs,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          cudf::memory_resources mr)
 {
   expect_table_properties_equal(lhs, rhs);
@@ -31,7 +31,7 @@ void expect_tables_equal(cudf::table_view lhs,
  */
 void expect_tables_equivalent(cudf::table_view lhs,
                               cudf::table_view rhs,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               cudf::memory_resources mr)
 {
   auto num_columns = lhs.num_columns();

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -19,6 +19,7 @@
 #include <rmm/device_vector.hpp>
 
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
@@ -237,7 +238,7 @@ TEST(SpanTest, CanUseDeviceSpan)
 
   auto d_span = device_span<bool>(d_message.data(), d_message.size());
 
-  simple_device_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(d_span);
+  simple_device_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(d_span);
 
   ASSERT_TRUE(d_message.element(0, cudf::get_default_stream()));
 }
@@ -283,8 +284,8 @@ TEST(MdSpanTest, DeviceReadWrite)
 {
   auto vector = hostdevice_2dvector<int>(11, 23, cudf::get_default_stream());
 
-  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(vector);
-  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
   vector.device_to_host(cudf::get_default_stream());
   EXPECT_EQ(vector[5][6], 30);
 }
@@ -407,8 +408,8 @@ TEST(HostDeviceSpanTest, CanCopySpan)
 
 TEST(HostDeviceSpanTest, CanSendToDevice)
 {
-  auto original_message = get_test_hostdevice_vector();
-  auto stream           = cudf::get_default_stream();
+  auto original_message   = get_test_hostdevice_vector();
+  cuda::stream_ref stream = cudf::get_default_stream();
 
   original_message.host_to_device_async(stream);
 

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -19,7 +19,7 @@
 #include <rmm/device_vector.hpp>
 
 #include <cuda/std/span>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -237,7 +237,7 @@ TEST(SpanTest, CanUseDeviceSpan)
 
   auto d_span = device_span<bool>(d_message.data(), d_message.size());
 
-  simple_device_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(d_span);
+  simple_device_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(d_span);
 
   ASSERT_TRUE(d_message.element(0, cudf::get_default_stream()));
 }
@@ -283,8 +283,8 @@ TEST(MdSpanTest, DeviceReadWrite)
 {
   auto vector = hostdevice_2dvector<int>(11, 23, cudf::get_default_stream());
 
-  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
-  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().get()>>>(vector);
   vector.device_to_host(cudf::get_default_stream());
   EXPECT_EQ(vector[5][6], 30);
 }
@@ -417,8 +417,8 @@ TEST(HostDeviceSpanTest, CanSendToDevice)
                   original_message.device_ptr(),
                   original_message.size(),
                   cudaMemcpyDefault,
-                  stream.value());
-  stream.synchronize();
+                  stream.get());
+  stream.sync();
 
   EXPECT_EQ(got_message, hello_world_message);
 }

--- a/cpp/tests/utilities_tests/stream_pool_tests.cpp
+++ b/cpp/tests/utilities_tests/stream_pool_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -23,7 +23,6 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
 #include <thrust/logical.h>
 #include <thrust/sequence.h>
 

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -20,10 +20,10 @@
 #include <cudf/wrappers/durations.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/logical.h>
 #include <thrust/sequence.h>
 


### PR DESCRIPTION
## Description
This split batch migrates libcudf test code and `cudf_test` helper APIs from `rmm::cuda_stream_view` to `cuda::stream_ref`.

This follows the core libcudf API migration in https://github.com/NVIDIA/cudf/pull/23691 and is part of the first downstream wave before the central helper migration.

Replaces the closed draft https://github.com/NVIDIA/cudf/pull/23696.

Contributes to https://github.com/NVIDIA/cudf/issues/23636

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.