### PR TITLE
Add parquet DELTA read tests and nested benchmark axis

### DIFF
--- a/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
@@ -38,6 +38,22 @@ cudf::io::column_encoding retrieve_column_encoding_enum(std::string_view encodin
   CUDF_FAIL("Unsupported column encoding: " + std::string(encoding_string));
 }
 
+// The writer only honours an encoding request on the schema node whose physical type matches, and
+// for a LIST the encoded values live on the element node, not the top-level column (it skips nodes
+// named "list", and walks lists_column_view::child_column_index for the element). So push the
+// request down to the leaves rather than setting it only on the outermost column.
+void set_encoding_recursive(cudf::io::column_in_metadata& col_meta,
+                            cudf::io::column_encoding encoding)
+{
+  if (col_meta.num_children() == 0) {
+    col_meta.set_encoding(encoding);
+    return;
+  }
+  for (cudf::size_type i = 0; i < col_meta.num_children(); i++) {
+    set_encoding_recursive(col_meta.child(i), encoding);
+  }
+}
+
 void bench_read_encoding(nvbench::state& state, std::vector<cudf::type_id> const& d_types)
 {
   auto const encoding    = retrieve_column_encoding_enum(state.get_string("encoding"));
@@ -45,18 +61,26 @@ void bench_read_encoding(nvbench::state& state, std::vector<cudf::type_id> const
   auto const data_size   = static_cast<size_t>(state.get_int64("data_size"));
   auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
   auto const run_length  = static_cast<cudf::size_type>(state.get_int64("run_length"));
+  // 0 keeps the flat columns this benchmark has always used; >0 wraps the leaf type in that many
+  // levels of LIST, which is what puts the decoder on its nested (repetition) path.
+  auto const nesting = static_cast<cudf::size_type>(state.get_int64("nesting"));
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
-    auto const tbl = create_random_table(
-      cycle_dtypes(d_types, num_cols),
-      table_size_bytes{data_size},
-      data_profile_builder().cardinality(cardinality).avg_run_length(run_length));
+    auto profile = data_profile_builder().cardinality(cardinality).avg_run_length(run_length);
+    auto types   = d_types;
+    if (nesting > 0) {
+      // one LIST column per leaf type, so the flat and nested variants stay comparable
+      profile.list_depth(nesting).list_type(d_types.front());
+      types = std::vector<cudf::type_id>(d_types.size(), cudf::type_id::LIST);
+    }
+    auto const tbl =
+      create_random_table(cycle_dtypes(types, num_cols), table_size_bytes{data_size}, profile);
     auto const view = tbl->view();
 
     cudf::io::table_input_metadata metadata(view);
     for (auto& col_meta : metadata.column_metadata) {
-      col_meta.set_encoding(encoding);
+      set_encoding_recursive(col_meta, encoding);
     }
 
     cudf::io::parquet_writer_options write_opts =
@@ -91,6 +115,7 @@ NVBENCH_BENCH(BM_parquet_read_delta_binary)
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("nesting", {0, 1})
   .add_int64_axis("data_size", {512 << 20});
 
 NVBENCH_BENCH(BM_parquet_read_delta_string)
@@ -100,4 +125,5 @@ NVBENCH_BENCH(BM_parquet_read_delta_string)
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("nesting", {0, 1})
   .add_int64_axis("data_size", {512 << 20});

--- a/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
@@ -38,10 +38,10 @@ cudf::io::column_encoding retrieve_column_encoding_enum(std::string_view encodin
   CUDF_FAIL("Unsupported column encoding: " + std::string(encoding_string));
 }
 
-// The writer only honours an encoding request on the schema node whose physical type matches, and
-// for a LIST the encoded values live on the element node, not the top-level column (it skips nodes
-// named "list", and walks lists_column_view::child_column_index for the element). So push the
-// request down to the leaves rather than setting it only on the outermost column.
+// The writer only honours an encoding request on the schema node whose
+// physical type matches, and for a LIST the encoded values live on the element
+// node, not the top-level column, so this function pushes the request down to
+// the leaves.
 void set_encoding_recursive(cudf::io::column_in_metadata& col_meta,
                             cudf::io::column_encoding encoding)
 {
@@ -61,9 +61,7 @@ void bench_read_encoding(nvbench::state& state, std::vector<cudf::type_id> const
   auto const data_size   = static_cast<size_t>(state.get_int64("data_size"));
   auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
   auto const run_length  = static_cast<cudf::size_type>(state.get_int64("run_length"));
-  // 0 keeps the flat columns this benchmark has always used; >0 wraps the leaf type in that many
-  // levels of LIST, which is what puts the decoder on its nested (repetition) path.
-  auto const nesting = static_cast<cudf::size_type>(state.get_int64("nesting"));
+  auto const nesting     = static_cast<cudf::size_type>(state.get_int64("nesting"));
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {

--- a/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_encoding.cpp
@@ -14,6 +14,8 @@
 
 #include <nvbench/nvbench.cuh>
 
+#include <algorithm>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -54,6 +56,58 @@ void set_encoding_recursive(cudf::io::column_in_metadata& col_meta,
   }
 }
 
+data_profile make_profile(cudf::size_type cardinality, cudf::size_type run_length)
+{
+  return data_profile_builder().cardinality(cardinality).avg_run_length(run_length);
+}
+
+data_profile make_list_profile(cudf::size_type cardinality,
+                               cudf::size_type run_length,
+                               cudf::size_type nesting,
+                               cudf::type_id leaf_type)
+{
+  return data_profile_builder()
+    .cardinality(cardinality)
+    .avg_run_length(run_length)
+    .list_depth(nesting)
+    .list_type(leaf_type);
+}
+
+std::unique_ptr<cudf::table> create_nested_table(std::vector<cudf::type_id> const& leaf_types,
+                                                 size_t data_size,
+                                                 cudf::size_type cardinality,
+                                                 cudf::size_type run_length,
+                                                 cudf::size_type nesting)
+{
+  auto const target_column_size = std::max<size_t>(data_size / leaf_types.size(), 1);
+  std::vector<cudf::size_type> row_counts;
+  row_counts.reserve(leaf_types.size());
+
+  for (auto const leaf_type : leaf_types) {
+    auto const profile = make_list_profile(0, run_length, nesting, leaf_type);
+    row_counts.push_back(
+      create_random_table({cudf::type_id::LIST}, table_size_bytes{target_column_size}, profile)
+        ->num_rows());
+  }
+
+  auto const num_rows = *std::min_element(row_counts.cbegin(), row_counts.cend());
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.reserve(leaf_types.size());
+  for (std::size_t col_idx = 0; col_idx < leaf_types.size(); col_idx++) {
+    // Keep the requested leaf cardinality, but avoid the top-level LIST distinct-row path when
+    // small smoke runs have fewer rows than the cardinality axis. That path appends an INT32 list
+    // suffix and is only type-compatible with INT32 leaves.
+    auto const list_cardinality =
+      cardinality == 0 ? 0 : std::min<cudf::size_type>(cardinality, num_rows - 1);
+    auto const profile =
+      make_list_profile(list_cardinality, run_length, nesting, leaf_types[col_idx]);
+    columns.push_back(create_random_column(
+      cudf::type_id::LIST, row_count{num_rows}, profile, static_cast<unsigned>(col_idx + 1)));
+  }
+
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
 void bench_read_encoding(nvbench::state& state, std::vector<cudf::type_id> const& d_types)
 {
   auto const encoding    = retrieve_column_encoding_enum(state.get_string("encoding"));
@@ -65,15 +119,12 @@ void bench_read_encoding(nvbench::state& state, std::vector<cudf::type_id> const
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
-    auto profile = data_profile_builder().cardinality(cardinality).avg_run_length(run_length);
-    auto types   = d_types;
-    if (nesting > 0) {
-      // one LIST column per leaf type, so the flat and nested variants stay comparable
-      profile.list_depth(nesting).list_type(d_types.front());
-      types = std::vector<cudf::type_id>(d_types.size(), cudf::type_id::LIST);
-    }
+    auto const leaf_types = cycle_dtypes(d_types, num_cols);
     auto const tbl =
-      create_random_table(cycle_dtypes(types, num_cols), table_size_bytes{data_size}, profile);
+      nesting > 0
+        ? create_nested_table(leaf_types, data_size, cardinality, run_length, nesting)
+        : create_random_table(
+            leaf_types, table_size_bytes{data_size}, make_profile(cardinality, run_length));
     auto const view = tbl->view();
 
     cudf::io::table_input_metadata metadata(view);

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -3262,6 +3262,9 @@ TEST_F(ParquetReaderTest, DeltaSkipRowsWithNulls)
 
 TEST_F(ParquetReaderTest, DeltaBinaryBoundaryWordMerge)
 {
+  // Write two 33-row nullable DELTA_BINARY_PACKED pages so each page ends just past a
+  // 32-bit validity-mask word. Reading the file back verifies that page-local validity
+  // masks are merged into the output mask without shifting bits at word boundaries.
   using cudf::io::column_encoding;
   constexpr cudf::size_type page_rows = 33;
   constexpr cudf::size_type num_rows  = 2 * page_rows;

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -10,6 +10,7 @@
 #include "parquet_delta_test_utils.hpp"
 
 #include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/io_metadata_utilities.hpp>
 #include <cudf_test/iterator_utilities.hpp>
@@ -3257,6 +3258,48 @@ TEST_F(ParquetReaderTest, DeltaSkipRowsWithNulls)
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(result.tbl->view(), result2.tbl->view());
   }
+}
+
+TEST_F(ParquetReaderTest, DeltaBinaryBoundaryWordMerge)
+{
+  using cudf::io::column_encoding;
+  constexpr cudf::size_type page_rows = 33;
+  constexpr cudf::size_type num_rows  = 2 * page_rows;
+
+  auto const values = cuda::counting_iterator<int64_t>{0};
+  auto const valids =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2) == 0; });
+  cudf::test::fixed_width_column_wrapper<int64_t> col(values, values + num_rows, valids);
+  cudf::table_view tbl({col});
+
+  auto input_metadata = cudf::io::table_input_metadata{tbl};
+  input_metadata.column_metadata[0].set_encoding(column_encoding::DELTA_BINARY_PACKED);
+
+  auto const filepath = temp_env->get_temp_filepath("DeltaBinaryBoundaryWordMerge.parquet");
+  auto const out_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, tbl)
+      .metadata(input_metadata)
+      .compression(cudf::io::compression_type::NONE)
+      .dictionary_policy(cudf::io::dictionary_policy::NEVER)
+      .row_group_size_rows(num_rows)
+      .max_page_size_rows(page_rows)
+      .write_v2_headers(true)
+      .build();
+  cudf::io::write_parquet(out_opts);
+
+  auto const in_opts =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath}).build();
+  auto const result = cudf::io::read_parquet(in_opts);
+  auto const column = result.tbl->view().column(0);
+
+  EXPECT_EQ(column.null_count(), 33);
+
+  auto const host_column = cudf::test::to_host<int64_t>(column);
+  auto const& null_mask  = host_column.second;
+  ASSERT_EQ(null_mask.size(), 3);
+  EXPECT_EQ(null_mask[0], cudf::bitmask_type{0x55555555});
+  EXPECT_EQ(null_mask[1], cudf::bitmask_type{0x55555555});
+  EXPECT_EQ(null_mask[2] & cudf::bitmask_type{0x3}, cudf::bitmask_type{0x1});
 }
 
 TEST_F(ParquetReaderTest, DeltaByteArraySkipAllValid)

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -2327,6 +2327,9 @@ TEST_F(ParquetWriterTest, DeltaBinaryStartsWithNulls)
 
 TEST_F(ParquetWriterTest, DeltaBinaryNzIdxTailIteration33)
 {
+  // Exercise a non-null DELTA_BINARY_PACKED column whose row count crosses one 32-value
+  // non-null index word. This guards the writer tail path from dropping or corrupting the
+  // final value after the last full word.
   constexpr int num_rows = 33;
 
   auto const values = cuda::counting_iterator<int32_t>{0};

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -2325,6 +2325,28 @@ TEST_F(ParquetWriterTest, DeltaBinaryStartsWithNulls)
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
 }
 
+TEST_F(ParquetWriterTest, DeltaBinaryNzIdxTailIteration33)
+{
+  constexpr int num_rows = 33;
+
+  auto const values = cuda::counting_iterator<int32_t>{0};
+  auto const col =
+    cudf::test::fixed_width_column_wrapper<int32_t>{values, values + num_rows, no_nulls()};
+  auto const expected = table_view({col});
+
+  auto const filepath = temp_env->get_temp_filepath("DeltaBinaryNzIdxTailIteration33.parquet");
+  cudf::io::parquet_writer_options out_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, expected)
+      .write_v2_headers(true)
+      .dictionary_policy(cudf::io::dictionary_policy::NEVER);
+  cudf::io::write_parquet(out_opts);
+
+  cudf::io::parquet_reader_options in_opts =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath});
+  auto result = cudf::io::read_parquet(in_opts);
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
 std::pair<std::unique_ptr<cudf::table>, cudf::io::table_input_metadata>
 make_byte_stream_split_table(bool as_struct)
 {


### PR DESCRIPTION
## Description
This PR adds focused parquet DELTA_BINARY_PACKED regression coverage and expands the DELTA read benchmark coverage. It adds a flat 33-row writer roundtrip that exercises the non-null index tail path after one full 32-value word, and a nullable reader regression that writes two 33-row pages to validate validity-mask merging across 32-bit word boundaries. These help catch some multi-warp and cross-word errors. It also adds a `nesting` axis to the DELTA parquet read benchmark so LIST-wrapped columns exercise the nested repetition path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
