### PR TITLE
Keep io varint decoding defined on overlong input

### DIFF
--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -20,9 +20,9 @@ uint64_t container::get_encoded()
     // 64-bit int since shift left is upto 64.
     uint64_t const byte = get_raw<uint8_t>();
     val |= (byte & 0x7f) << len;
-    if (byte < 0x80) break;
+    if (byte < 0x80) return val;
   }
-  return val;
+  CUDF_FAIL("Invalid varint: exceeds maximum encoded length");
 }
 
 template <>

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 namespace CUDF_EXPORT cudf {
@@ -48,13 +49,16 @@ class CompactProtocolReader {
   }
 
   // returns a varint encoded integer
+  // Shifts are bounded by the width of T so that overlong encodings truncate instead of shifting
+  // out of range, while the byte stream consumption stays identical to the unbounded loop.
   template <typename T>
   T get_varint() noexcept
   {
+    static_assert(std::is_unsigned_v<T>, "varints are decoded into unsigned types");
     T v = 0;
     for (uint32_t l = 0;; l += 7) {
       T c = getb();
-      v |= (c & 0x7f) << l;
+      if (l < sizeof(T) * 8) { v |= (c & 0x7f) << l; }
       if (c < 0x80) { break; }
     }
     return v;

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -56,9 +56,12 @@ class CompactProtocolReader {
   {
     static_assert(std::is_unsigned_v<T>, "varints are decoded into unsigned types");
     T v = 0;
-    for (uint32_t l = 0;; l += 7) {
+    for (uint32_t l = 0;;) {
       T c = getb();
-      if (l < sizeof(T) * 8) { v |= (c & 0x7f) << l; }
+      if (l < sizeof(T) * 8) {
+        v |= (c & 0x7f) << l;
+        l += 7;
+      }
       if (c < 0x80) { break; }
     }
     return v;

--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -66,8 +66,10 @@ inline __device__ uleb128_t get_uleb128(uint8_t const*& cur, uint8_t const* end)
   uleb128_t v = 0, l = 0, c;
   while (cur < end) {
     c = *cur++;
-    v |= (c & 0x7f) << l;
-    l += 7;
+    if (l < 64) {
+      v |= (c & 0x7f) << l;
+      l += 7;
+    }
     if ((c & 0x80) == 0) { return v; }
   }
   return v;

--- a/cpp/src/io/parquet/page_hdr.cu
+++ b/cpp/src/io/parquet/page_hdr.cu
@@ -81,8 +81,10 @@ __device__ uint32_t get_u32(byte_stream_s* bs)
   uint32_t v = 0, l = 0, c;
   do {
     c = getb(bs);
-    v |= (c & 0x7f) << l;
-    l += 7;
+    if (l < 32) {
+      v |= (c & 0x7f) << l;
+      l += 7;
+    }
   } while (c & 0x80);
   return v;
 }

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -315,6 +315,7 @@ ConfigureTest(
 # ##################################################################################################
 # * io tests --------------------------------------------------------------------------------------
 ConfigureTest(COMPRESSION_TEST io/comp/comp_test.cpp)
+ConfigureTest(AVRO_TEST io/avro_test.cpp)
 ConfigureTest(ROW_SELECTION_TEST io/row_selection_test.cpp)
 ConfigureTest(FILEPATH_SOURCE_TEST io/filepath_source_test.cpp)
 

--- a/cpp/tests/io/avro_test.cpp
+++ b/cpp/tests/io/avro_test.cpp
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/cudf_gtest.hpp>
+
+#include <cudf/io/avro.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<uint8_t> length_prefixed_string(std::string const& text)
+{
+  std::vector<uint8_t> out;
+  // Avro strings are preceded by a zigzag-encoded byte length.
+  uint64_t encoded_length = static_cast<uint64_t>(text.size()) << 1;
+  while (encoded_length >= 0x80) {
+    out.push_back(static_cast<uint8_t>(0x80u | (encoded_length & 0x7fu)));
+    encoded_length >>= 7;
+  }
+  out.push_back(static_cast<uint8_t>(encoded_length));
+  out.insert(out.end(), text.begin(), text.end());
+  return out;
+}
+
+// Builds a minimal valid one-row Avro file with a single int column "a" holding the value 0.
+std::vector<uint8_t> make_valid_avro_file()
+{
+  std::string const schema = R"({"type":"record","name":"r","fields":[{"name":"a","type":"int"}]})";
+
+  std::vector<uint8_t> data{'O', 'b', 'j', 0x01};
+  auto metadata_item  = length_prefixed_string("avro.schema");
+  auto metadata_value = length_prefixed_string(schema);
+  data.push_back(0x02);  // one metadata entry, zigzag encoded
+  data.insert(data.end(), metadata_item.begin(), metadata_item.end());
+  data.insert(data.end(), metadata_value.begin(), metadata_value.end());
+  data.push_back(0x00);               // end of the metadata map
+  data.insert(data.end(), 16, 0x00);  // sync marker
+
+  data.push_back(0x02);               // one row in the block, zigzag encoded
+  data.push_back(0x02);               // one byte of row data
+  data.push_back(0x00);               // row value: int 0
+  data.insert(data.end(), 16, 0x00);  // block sync marker
+  return data;
+}
+
+}  // namespace
+
+struct AvroReaderTest : public cudf::test::BaseFixture {};
+
+TEST_F(AvroReaderTest, ValidSingleRowFile)
+{
+  auto data          = make_valid_avro_file();
+  auto const options = cudf::io::avro_reader_options::builder(
+                         cudf::io::source_info(cudf::host_span<uint8_t>(data.data(), data.size())))
+                         .build();
+
+  auto const result = cudf::io::read_avro(options);
+  EXPECT_EQ(result.tbl->num_rows(), 1);
+  ASSERT_EQ(result.tbl->num_columns(), 1);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0),
+                                 cudf::test::fixed_width_column_wrapper<int32_t>{{0}});
+}
+
+TEST_F(AvroReaderTest, OverlongMetadataVarintThrows)
+{
+  // Avro magic followed by a metadata item count encoded as an over-long varint: more
+  // continuation bytes than fit in an int64.
+  std::vector<uint8_t> data{'O', 'b', 'j', 0x01};
+  for (int i = 0; i < 12; ++i) {
+    data.push_back(0x80);
+  }
+  data.push_back(0x01);
+
+  auto const options = cudf::io::avro_reader_options::builder(
+                         cudf::io::source_info(cudf::host_span<uint8_t>(data.data(), data.size())))
+                         .build();
+
+  try {
+    cudf::io::read_avro(options);
+    FAIL() << "expected cudf::logic_error";
+  } catch (cudf::logic_error const& e) {
+    EXPECT_NE(std::strstr(e.what(), "Invalid varint"), nullptr)
+      << "unexpected error message: " << e.what();
+  }
+}

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -1764,9 +1764,11 @@ TEST_F(ParquetReaderTest, VarintDecodingBoundaries)
 {
   using cudf::io::parquet::detail::CompactProtocolReader;
 
-  // longest valid encoding of a uint64: nine continuation bytes plus terminator
+  // longest valid encoding of a uint64: nine continuation bytes plus terminator; each
+  // continuation byte deposits zero and the terminator sets bit 63, so the value is exactly
+  // 1 << 63 rather than the all-ones pattern that nine 0xFF bytes would produce
   std::array<uint8_t, 10> max_varint{};
-  max_varint.fill(0xFF);
+  max_varint.fill(0x80);
   max_varint[9] = 0x01;
   CompactProtocolReader reader(max_varint.data(), max_varint.size());
   EXPECT_EQ(reader.get_varint<uint64_t>(), uint64_t{1} << 63);

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -28,6 +28,7 @@
 
 #include <cuda/iterator>
 
+#include <src/io/parquet/compact_protocol_reader.hpp>
 #include <src/io/parquet/parquet_gpu.hpp>
 #include <src/io/parquet/stats_filter_helpers.hpp>
 
@@ -1757,6 +1758,34 @@ TEST_F(ParquetReaderTest, StructByteArray)
   auto result = cudf::io::read_parquet(in_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
+TEST_F(ParquetReaderTest, VarintDecodingBoundaries)
+{
+  using cudf::io::parquet::detail::CompactProtocolReader;
+
+  // longest valid encoding of a uint64: nine continuation bytes plus terminator
+  std::array<uint8_t, 10> max_varint{};
+  max_varint.fill(0xFF);
+  max_varint[9] = 0x01;
+  CompactProtocolReader reader(max_varint.data(), max_varint.size());
+  EXPECT_EQ(reader.get_varint<uint64_t>(), uint64_t{1} << 63);
+  EXPECT_EQ(reader.bytecount(), 10);
+
+  // overlong encodings keep consuming bytes until a terminator but stop shifting into the value
+  std::array<uint8_t, 13> overlong64{};
+  overlong64.fill(0xFF);
+  overlong64[12] = 0x00;
+  CompactProtocolReader overlong_reader(overlong64.data(), overlong64.size());
+  EXPECT_EQ(overlong_reader.get_varint<uint64_t>(), std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(overlong_reader.bytecount(), 13);
+
+  std::array<uint8_t, 7> overlong32{};
+  overlong32.fill(0xFF);
+  overlong32[6] = 0x7F;
+  CompactProtocolReader reader32(overlong32.data(), overlong32.size());
+  EXPECT_EQ(reader32.get_varint<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(reader32.bytecount(), 7);
 }
 
 TEST_F(ParquetReaderTest, NestingOptimizationTest)


### PR DESCRIPTION
## Description
closes #23478

Several varint decoders shifted accumulated bits past the width of the target type when fed more continuation bytes than fit. That is undefined behavior, and malformed ORC/Avro/Parquet metadata could decode to arbitrary values instead of failing cleanly.

- `cpp/src/io/parquet/page_hdr.cu` `get_u32`: shift accumulation is now guarded by `l < 32`. Termination is unchanged: reading past the end returns 0, which lacks the continuation bit.
- `cpp/src/io/parquet/compact_protocol_reader.hpp` `get_varint<T>`: the accumulation is bounded by `sizeof(T) * 8`, but the loop still consumes every byte of the encoding, so stream positions are identical for all inputs and only the accumulated value becomes a deterministic truncation. A `static_assert` restricts it to unsigned types; `<type_traits>` added.
- `cpp/src/io/parquet/delta_binary.cuh` `get_uleb128`: same guard with the bound `l < 64`; consumption unchanged, so the existing post-read validation in the DELTA kernels still sees the same positions.
- `cpp/src/io/avro/avro.cpp` `container::get_encoded<uint64_t>`: throws `cudf::logic_error` ("Invalid varint: exceeds maximum encoded length") when no terminating byte arrives within the encodable length, matching the guard the ORC protobuf reader got in #22186.

The ORC stripe decoders use bounded unrolled shifts by construction and are unchanged. The unguarded first-byte read in `get_vlq32` predates this change and needs caller-side validation work; it is left as-is here.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test Plan

New `AVRO_TEST` gtest target with two cases:

- `ValidSingleRowFile`: a hand-assembled minimal one-row Avro file (one int column) parses and returns exactly that row, guarding against over-eager failure on valid input.
- `OverlongMetadataVarintThrows`: Avro magic followed by a metadata item count encoded as twelve continuation bytes must throw `cudf::logic_error` with message containing "Invalid varint". Before this change the same input silently parsed as an empty table.

Compile-level verification performed locally (libcudf 26.10.00a302 headers, CCCL 3.6, CUDA 12.9, sm_120):

```
nvcc -std=c++20 -O1 -arch=sm_120 --extended-lambda -c \
  src/io/parquet/page_hdr.cu            -> pass
  src/io/parquet/compact_protocol_reader.cpp -> pass
  src/io/parquet/decode_fixed.cu        -> pass   (includes rle_stream.cuh)
  src/io/parquet/page_delta_decode.cu   -> pass   (includes delta_binary.cuh)
  src/io/avro/avro.cpp                  -> pass
  tests/io/avro_test.cpp                -> pass
```

`clang-format --dry-run --Werror` on all touched files: pass.

The new gtest was not executed locally because running it requires a full libcudf build; CI will run it. The UB shift sites themselves have no deterministic before/after runtime signature (that is what makes them UB), which is why the verification here is by construction plus compile checks.
