### PR TITLE
cudf_polars: preserve existing executor and engine options across _reset()

### DIFF
--- a/python/cudf_polars/cudf_polars/engine/dask.py
+++ b/python/cudf_polars/cudf_polars/engine/dask.py
@@ -1052,16 +1052,15 @@ class DaskEngine(StreamingEngine):
             executor_options=executor_options,
             engine_options=engine_options,
         )
-        executor_options = executor_options or {}
         existing_executor_options = self.config.get("executor_options", {})
         if isinstance(existing_executor_options, dict):
-            existing_quent_context = existing_executor_options.get("quent_context")
-            if existing_quent_context is not None:
-                executor_options.setdefault("quent_context", existing_quent_context)
-            existing_kvikio_nthreads = existing_executor_options.get("kvikio_nthreads")
-            if existing_kvikio_nthreads is not None:
-                executor_options.setdefault("kvikio_nthreads", existing_kvikio_nthreads)
-        engine_options = engine_options or {}
+            merged_executor_options = {**existing_executor_options, **(executor_options or {})}
+        else:
+            merged_executor_options = dict(executor_options or {})
+        executor_options = merged_executor_options
+
+        existing_engine_options = {k: v for k, v in self.config.items() if k not in ("executor", "executor_options")}
+        engine_options = {**existing_engine_options, **(engine_options or {})}
 
         rapidsmpf_options_as_bytes = resolve_rapidsmpf_options(
             rapidsmpf_options

--- a/python/cudf_polars/cudf_polars/engine/ray.py
+++ b/python/cudf_polars/cudf_polars/engine/ray.py
@@ -879,16 +879,15 @@ class RayEngine(StreamingEngine):
             executor_options=executor_options,
             engine_options=engine_options,
         )
-        executor_options = executor_options or {}
         existing_executor_options = self.config.get("executor_options", {})
         if isinstance(existing_executor_options, dict):
-            existing_quent_context = existing_executor_options.get("quent_context")
-            if existing_quent_context is not None:
-                executor_options.setdefault("quent_context", existing_quent_context)
-            existing_kvikio_nthreads = existing_executor_options.get("kvikio_nthreads")
-            if existing_kvikio_nthreads is not None:
-                executor_options.setdefault("kvikio_nthreads", existing_kvikio_nthreads)
-        engine_options = engine_options or {}
+            merged_executor_options = {**existing_executor_options, **(executor_options or {})}
+        else:
+            merged_executor_options = dict(executor_options or {})
+        executor_options = merged_executor_options
+
+        existing_engine_options = {k: v for k, v in self.config.items() if k not in ("executor", "executor_options")}
+        engine_options = {**existing_engine_options, **(engine_options or {})}
         rapidsmpf_options_as_bytes = resolve_rapidsmpf_options(
             rapidsmpf_options
         ).serialize()

--- a/python/cudf_polars/cudf_polars/engine/spmd.py
+++ b/python/cudf_polars/cudf_polars/engine/spmd.py
@@ -602,17 +602,17 @@ class SPMDEngine(StreamingEngine):
             executor_options=executor_options,
             engine_options=engine_options,
         )
-        executor_options = executor_options or {}
         existing_executor_options = self.config.get("executor_options", {})
         if isinstance(existing_executor_options, dict):
-            existing_quent_context = existing_executor_options.get("quent_context")
-            if existing_quent_context is not None:
-                executor_options.setdefault("quent_context", existing_quent_context)
-            existing_kvikio_nthreads = existing_executor_options.get("kvikio_nthreads")
-            if existing_kvikio_nthreads is not None:
-                executor_options.setdefault("kvikio_nthreads", existing_kvikio_nthreads)
+            merged_executor_options = {**existing_executor_options, **(executor_options or {})}
+        else:
+            merged_executor_options = dict(executor_options or {})
+        executor_options = merged_executor_options
+
+        existing_engine_options = {k: v for k, v in self.config.items() if k not in ("executor", "executor_options")}
+        engine_options = {**existing_engine_options, **(engine_options or {})}
+
         kvikio.defaults.set("num_threads", executor_options["kvikio_nthreads"])
-        engine_options = engine_options or {}
         quent_context: cudf_polars.quent.QuentContext | None = executor_options.get(
             "quent_context"
         )

--- a/python/cudf_polars/tests/streaming/test_spmd.py
+++ b/python/cudf_polars/tests/streaming/test_spmd.py
@@ -459,6 +459,19 @@ def test_reset_rejects_construction_time_engine_options(
             engine._reset(engine_options={"memory_resource_config": None})
 
 
+def test_reset_preserves_unrelated_options(comm: Communicator) -> None:
+    """``_reset`` preserves previously configured options not specified in the reset call."""
+    with SPMDEngine(
+        comm=comm,
+        executor_options={"max_rows_per_partition": 500},
+        engine_options={"raise_on_fail": True},
+    ) as engine:
+        engine._reset(executor_options={"fallback_mode": "raise"})
+        assert engine.config["executor_options"]["max_rows_per_partition"] == 500
+        assert engine.config["executor_options"]["fallback_mode"] == "raise"
+        assert engine.config["raise_on_fail"] is True
+
+
 def test_quent_context_user_provided(spmd_engine: SPMDEngine) -> None:
     # Ensure that the user-provided quent context is used if provided
     quent_context = cudf_polars.quent.QuentContext(


### PR DESCRIPTION
## Description
Fixes an issue where `_reset()` on `SPMDEngine`, `DaskEngine`, and `RayEngine` replaced `executor_options` and `engine_options` wholesale, reverting any previously configured options that were not explicitly re-specified back to their defaults.

## Changes
- In `SPMDEngine._reset`, `DaskEngine._reset`, and `RayEngine._reset`: merge `executor_options` and `engine_options` with existing options from `self.config` so previously configured settings (such as `max_rows_per_partition`, `fallback_mode`, `raise_on_fail`, etc.) are preserved across resets.
- Added regression test `test_reset_preserves_unrelated_options` in `python/cudf_polars/tests/streaming/test_spmd.py`.

Closes #23742