### PR TITLE
Java: throw IllegalArgumentException for null/empty Table columns

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -71,7 +71,9 @@ public final class Table implements AutoCloseable {
    * @param cudfColumns - Array of nativeHandles
    */
   public Table(long[] cudfColumns) {
-    assert cudfColumns != null && cudfColumns.length > 0 : "CudfColumns can't be null or empty";
+    if (cudfColumns == null || cudfColumns.length == 0) {
+      throw new IllegalArgumentException("cudfColumns can't be null or empty");
+    }
     this.columns = ColumnVector.getColumnVectorsFromPointers(cudfColumns);
     try {
       long[] views = new long[columns.length];

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -1508,6 +1508,20 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testReadParquetMissingColumnThrowsIllegalArgumentException() {
+    ParquetOptions opts = ParquetOptions.builder()
+        .includeColumn("doesnotexist")
+        .build();
+    assertThrows(IllegalArgumentException.class, () -> Table.readParquet(opts, TEST_PARQUET_FILE));
+  }
+
+  @Test
+  void testTableConstructorRejectsNullOrEmptyColumns() {
+    assertThrows(IllegalArgumentException.class, () -> new Table((long[]) null));
+    assertThrows(IllegalArgumentException.class, () -> new Table(new long[0]));
+  }
+
+  @Test
   void testReadParquetFromDataSource() throws IOException {
     ParquetOptions opts = ParquetOptions.builder()
             .includeColumn("loan_id")


### PR DESCRIPTION
## Summary

Fixes #11278. Loading a Parquet column that does not exist throws `ArrayIndexOutOfBoundsException` from `Table.<init>` instead of a clear error.

## Root cause

`Table(long[] cudfColumns)` guards against a null or empty array with a Java `assert`, which is disabled by default at runtime (no `-ea`):

```java
assert cudfColumns != null && cudfColumns.length > 0 : "CudfColumns can't be null or empty";
```

When the native Parquet reader returns zero columns because the requested column name does not exist, this check never fires, and execution reaches `this.rows = columns[0].getRowCount();` with an empty `columns` array, which is the real source of the reported `ArrayIndexOutOfBoundsException: 0`.

## Fix

Replace the assert with a real, always enforced check that throws `IllegalArgumentException` before any further processing, matching the pattern already used elsewhere in this class (`concatenate requires 2 or more tables`, `column count mismatch`, etc).

## Verification

This environment does not have a CUDA toolchain, so I could not run the actual test suite (`mvn test` builds the native library via cmake as part of its own lifecycle, confirmed by trying it here and seeing the cmake exec step fail before reaching pure Java compilation). What I could and did verify:

- Read the real call graph: confirmed no other caller of `new Table(long[])` in `java/src/main/java` passes an intentionally empty array, so making the check unconditional matches every existing caller's actual usage, not just the reported one.
- Compiled the entire `java/src/main/java` and `java/src/test/java` tree together with `javac` against the Maven resolved dependency jars (bypasses the antrun/cmake plugin, which is Maven specific, not something `javac` invokes). Zero errors, including the two new test methods added below. Only pre-existing warnings, unrelated to this change.

Added two tests to `TableTest.java`:

- `testTableConstructorRejectsNullOrEmptyColumns`, a direct, minimal test of the fixed constructor.
- `testReadParquetMissingColumnThrowsIllegalArgumentException`, the exact scenario from this issue, reading `TEST_PARQUET_FILE` with a nonexistent `includeColumn`.

Both should run cleanly wherever this repo's own CI already has the native library built; I was not able to execute them myself in this environment, and want to be upfront about that rather than claim more than I actually verified.
