### PR TITLE
Add missing include for std::cerr in debug build

### DIFF
--- a/cpp/src/utilities/stream_pool.cpp
+++ b/cpp/src/utilities/stream_pool.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iostream>
 #include <mutex>
 #include <span>
 #include <utility>


### PR DESCRIPTION
## Description
Fixes debug build error by adding a missing include for `std::cerr`:

```
/cudf/cpp/src/utilities/stream_pool.cpp: In destructor 'virtual cudf::detail::cuda_event::~cuda_event()':
/cudf/cpp/src/utilities/stream_pool.cpp:49:12: error: 'cerr' is not a member of 'std'
   49 |       std::cerr << "CUDA Error detected. " << cudaGetErrorName(status__) << " " \
      |            ^~~~
/cudf/cpp/src/utilities/stream_pool.cpp:62:27: note: in expansion of macro 'CUDF_ASSERT_CUDA_SUCCESS'
   62 |   virtual ~cuda_event() { CUDF_ASSERT_CUDA_SUCCESS(cudaEventDestroy(e_)); }
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~
/cudf/cpp/src/utilities/stream_pool.cpp:18:1: note: 'std::cerr' is defined in header '<iostream>'; this is probably fixable by adding '#include <iostream>'
```



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
