### PR TITLE
Skip upstream polars test `test_scan_ndjson_streaming_decompression`

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -33,6 +33,8 @@ DESELECTED_TESTS=(
     "tests/unit/io/test_write.py::test_write_async[read_parquet-<lambda>]" # kvikio file creation error in CI
     "tests/unit/io/test_write.py::test_write_async[<lambda>-<lambda>0]" # kvikio file creation error in CI
     "tests/unit/io/test_write.py::test_write_async[<lambda>-<lambda>2]" # kvikio file creation error in CI
+    "tests/unit/io/test_scan.py::test_scan_ndjson_streaming_decompression[schema0]" # polars bug: decompresses entire stream instead of stopping at slice limit, see https://github.com/pola-rs/polars/issues/28954
+    "tests/unit/io/test_scan.py::test_scan_ndjson_streaming_decompression[None]" # polars bug: decompresses entire stream instead of stopping at slice limit, see https://github.com/pola-rs/polars/issues/28954
     "tests/unit/operations/test_random.py::test_shuffle_group_by_reseed" # https://github.com/NVIDIA/cudf/issues/22964
 )
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Discovered in https://github.com/NVIDIA/cudf/pull/23517

Lets skip it for now until the bug is fixed in Polars.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
