### PR TITLE
Fix RMM race conditions from deferred H2D copies in pylibcudf tests

### DIFF
--- a/python/pylibcudf/tests/io/test_experimental_hybrid_scan.py
+++ b/python/pylibcudf/tests/io/test_experimental_hybrid_scan.py
@@ -867,14 +867,18 @@ def test_hybrid_scan_filter_row_groups_with_dictionary_pages_negation(
         _, dictionary_ranges = reader.secondary_filters_byte_ranges(
             all_row_groups, simple_parquet_options
         )
+        # the caller is responsible for keeping the source bytes alive until
+        # synchronize_stream() below runs.
+        # See https://github.com/rapidsai/rmm/issues/2521
+        dict_page_bytes = [
+            simple_parquet_bytes[r.offset : r.offset + r.size]
+            for r in dictionary_ranges
+        ]
         dictionary_data = [
             plc.gpumemoryview(
-                rmm.DeviceBuffer.to_device(
-                    simple_parquet_bytes[r.offset : r.offset + r.size],
-                    plc.utils._get_stream(),
-                )
+                rmm.DeviceBuffer.to_device(b, plc.utils._get_stream())
             )
-            for r in dictionary_ranges
+            for b in dict_page_bytes
         ]
         synchronize_stream()
         return reader.filter_row_groups_with_dictionary_pages(

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -282,12 +282,14 @@ def test_read_parquet_from_device_buffers(
         binary_source_or_sink, pa_table, **_COMMON_PARQUET_SOURCE_KWARGS
     )
 
-    rmm_buf = DeviceBuffer.to_device(
-        get_bytes_from_source(source), plc.utils._get_stream(stream)
-    )
-    buf = FooSpan(rmm_buf) if use_foo_span else rmm_buf
-
+    # to_device() is documented as fully async on a non-default stream, and
+    # the caller is responsible for keeping the source bytes alive until
+    # synchronize_stream() below runs.
+    # See https://github.com/rapidsai/rmm/issues/2521
+    src_bytes = get_bytes_from_source(source)
+    rmm_buf = DeviceBuffer.to_device(src_bytes, plc.utils._get_stream(stream))
     synchronize_stream(stream)
+    buf = FooSpan(rmm_buf) if use_foo_span else rmm_buf
 
     options = plc.io.parquet.ParquetReaderOptions.builder(
         plc.io.SourceInfo([buf] * num_buffers)

--- a/python/pylibcudf/tests/test_column_from_device.py
+++ b/python/pylibcudf/tests/test_column_from_device.py
@@ -102,11 +102,13 @@ def test_cuda_array_interface_with_mask_raises():
 
 
 def test_from_rmm_buffer():
+    # the caller is responsible for keeping the source bytes alive until
+    # the H2D copy completes (e.g. when the buffer is accessed below).
+    # See https://github.com/rapidsai/rmm/issues/2521
     result = pa.array([1, 2, 3], type=pa.int32())
+    data_bytes = result.buffers()[1].to_pybytes()
     expected = plc.Column.from_rmm_buffer(
-        rmm.DeviceBuffer.to_device(
-            result.buffers()[1].to_pybytes(), plc.utils._get_stream()
-        ),
+        rmm.DeviceBuffer.to_device(data_bytes, plc.utils._get_stream()),
         plc.DataType.from_arrow(result.type),
         len(result),
         [],
@@ -114,16 +116,16 @@ def test_from_rmm_buffer():
     assert_column_eq(result, expected)
 
     result = pa.array(["a", "b", "c"], type=pa.string())
+    offsets_bytes = result.buffers()[1].to_pybytes()
+    data_bytes = result.buffers()[2].to_pybytes()
     expected = plc.Column.from_rmm_buffer(
-        rmm.DeviceBuffer.to_device(
-            result.buffers()[2].to_pybytes(), plc.utils._get_stream()
-        ),
+        rmm.DeviceBuffer.to_device(data_bytes, plc.utils._get_stream()),
         plc.DataType.from_arrow(result.type),
         len(result),
         [
             plc.Column.from_rmm_buffer(
                 rmm.DeviceBuffer.to_device(
-                    result.buffers()[1].to_pybytes(), plc.utils._get_stream()
+                    offsets_bytes, plc.utils._get_stream()
                 ),
                 plc.DataType(plc.TypeId.INT32),
                 4,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Split out from #23517.

`DeviceBuffer.to_device(bytes, stream)` reads host memory asynchronously (rapidsai/rmm#2511). If the bytes object isn't kept alive past the copy, Python can free it before the GPU reads it.

The PR keeps those bytes alive through the copy by making an explicit reference. This fixes the immediate problem but it not the end of this problem. Let's use rapidsai/rmm#2521 to discuss a more general solution or at minimum document the current behavior.


I tested these changes in https://github.com/NVIDIA/cudf/pull/23517 (which reliably reproduced the bug). And the failing tests fixed in this PR are now passing.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
