### PR TITLE
Hybrid scan avoids nullable cols unless pruning pages

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -40,6 +40,9 @@ namespace {
 [[nodiscard]] std::vector<FileMetaData> parquet_metadatas_from_footer_bytes(
   cudf::host_span<cudf::host_span<uint8_t const> const> footer_bytes)
 {
+  CUDF_EXPECTS(
+    not footer_bytes.empty(), "At least one source must be provided", std::invalid_argument);
+
   std::vector<FileMetaData> parquet_metadatas;
   parquet_metadatas.reserve(footer_bytes.size());
   std::transform(footer_bytes.begin(),
@@ -147,6 +150,8 @@ aggregate_reader_metadata::aggregate_reader_metadata(
       use_arrow_schema,
       has_cols_from_mismatched_srcs)
 {
+  CUDF_EXPECTS(
+    not parquet_metadatas.empty(), "At least one source must be provided", std::invalid_argument);
 }
 
 std::vector<text::byte_range_info> aggregate_reader_metadata::page_index_byte_ranges() const

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -40,9 +40,6 @@ namespace {
 [[nodiscard]] std::vector<FileMetaData> parquet_metadatas_from_footer_bytes(
   cudf::host_span<cudf::host_span<uint8_t const> const> footer_bytes)
 {
-  CUDF_EXPECTS(
-    not footer_bytes.empty(), "At least one source must be provided", std::invalid_argument);
-
   std::vector<FileMetaData> parquet_metadatas;
   parquet_metadatas.reserve(footer_bytes.size());
   std::transform(footer_bytes.begin(),
@@ -139,6 +136,8 @@ aggregate_reader_metadata::aggregate_reader_metadata(
                                    use_arrow_schema,
                                    has_cols_from_mismatched_srcs)
 {
+  CUDF_EXPECTS(
+    not footer_bytes.empty(), "At least one source must be provided", std::invalid_argument);
 }
 
 aggregate_reader_metadata::aggregate_reader_metadata(

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -143,38 +143,6 @@ aggregate_reader_metadata::aggregate_reader_metadata(
   initialize_internals(use_arrow_schema, has_cols_from_mismatched_srcs);
 }
 
-void aggregate_reader_metadata::initialize_internals(bool use_arrow_schema,
-                                                     bool has_cols_from_mismatched_srcs)
-{
-  keyval_maps     = collect_keyval_metadata();
-  schema_idx_maps = init_schema_idx_maps(has_cols_from_mismatched_srcs);
-  num_rows        = calc_num_rows();
-  num_row_groups  = calc_num_row_groups();
-
-  // Force all non-nullable (REQUIRED) columns to be nullable without modifying REPEATED columns to
-  // preserve list structures
-  std::for_each(per_file_metadata.begin(), per_file_metadata.end(), [](auto& pfm) {
-    auto& schema = pfm.schema;
-    std::for_each(schema.begin() + 1, schema.end(), [](auto& col) {
-      // TODO: Store information of whichever column schema we modified here and restore it to
-      // `REQUIRED` if we end up not pruning any pages out of it
-      if (col.repetition_type == FieldRepetitionType::REQUIRED) {
-        col.repetition_type = FieldRepetitionType::OPTIONAL;
-      }
-    });
-  });
-
-  // Collect and apply arrow:schema from Parquet's key value metadata section
-  if (use_arrow_schema) {
-    apply_arrow_schema();
-
-    // Erase ARROW_SCHEMA_KEY from the output pfm if exists
-    std::for_each(keyval_maps.begin(), keyval_maps.end(), [](auto& pfm) {
-      pfm.erase(cudf::io::parquet::detail::ARROW_SCHEMA_KEY);
-    });
-  }
-}
-
 std::vector<text::byte_range_info> aggregate_reader_metadata::page_index_byte_ranges() const
 {
   std::vector<text::byte_range_info> page_index_byte_ranges;

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -36,6 +36,22 @@ using text::byte_range_info;
 
 namespace {
 
+// Construct a vector of FileMetaData from the input footer bytes
+[[nodiscard]] std::vector<FileMetaData> parquet_metadatas_from_footer_bytes(
+  cudf::host_span<cudf::host_span<uint8_t const> const> footer_bytes)
+{
+  std::vector<FileMetaData> parquet_metadatas;
+  parquet_metadatas.reserve(footer_bytes.size());
+  std::transform(footer_bytes.begin(),
+                 footer_bytes.end(),
+                 std::back_inserter(parquet_metadatas),
+                 [](auto const& footer_bytes) {
+                   metadata parsed_metadata{footer_bytes};
+                   return FileMetaData{std::move(parsed_metadata)};
+                 });
+  return parquet_metadatas;
+}
+
 // Construct a vector of all row group indices from the input vectors
 [[nodiscard]] auto all_row_group_indices(
   std::span<std::vector<cudf::size_type> const> row_group_indices)
@@ -116,31 +132,21 @@ aggregate_reader_metadata::aggregate_reader_metadata(
   cudf::host_span<cudf::host_span<uint8_t const> const> footer_bytes,
   bool use_arrow_schema,
   bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base(host_span<std::unique_ptr<datasource> const>{}, false, false)
+  : aggregate_reader_metadata_base(parquet_metadatas_from_footer_bytes(footer_bytes),
+                                   use_arrow_schema,
+                                   has_cols_from_mismatched_srcs)
 {
-  CUDF_EXPECTS(not footer_bytes.empty(), "At least one source must be provided");
-  per_file_metadata.reserve(footer_bytes.size());
-  std::transform(footer_bytes.begin(),
-                 footer_bytes.end(),
-                 std::back_inserter(per_file_metadata),
-                 [](auto const& fb) { return metadata{fb}; });
-  initialize_internals(use_arrow_schema, has_cols_from_mismatched_srcs);
 }
 
 aggregate_reader_metadata::aggregate_reader_metadata(
   cudf::host_span<FileMetaData const> parquet_metadatas,
   bool use_arrow_schema,
   bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base(host_span<std::unique_ptr<datasource> const>{}, false, false)
+  : aggregate_reader_metadata_base(
+      std::vector<FileMetaData>{parquet_metadatas.begin(), parquet_metadatas.end()},
+      use_arrow_schema,
+      has_cols_from_mismatched_srcs)
 {
-  CUDF_EXPECTS(not parquet_metadatas.empty(), "At least one source must be provided");
-  per_file_metadata.reserve(parquet_metadatas.size());
-  // Just copy over the FileMetaData structs to the internal metadata structs
-  std::transform(parquet_metadatas.begin(),
-                 parquet_metadatas.end(),
-                 std::back_inserter(per_file_metadata),
-                 [](auto const& parquet_metadata) { return metadata{parquet_metadata}; });
-  initialize_internals(use_arrow_schema, has_cols_from_mismatched_srcs);
 }
 
 std::vector<text::byte_range_info> aggregate_reader_metadata::page_index_byte_ranges() const

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
@@ -79,19 +79,6 @@ class aggregate_reader_metadata : public aggregate_reader_metadata_base {
 
  public:
   /**
-   * @brief Check whether selected columns have column and offset indexes
-   *
-   * Schema indices are mapped to each source before locating the column chunks.
-   *
-   * @param row_group_indices Row group indices, one vector per source
-   * @param schema_indices Schema indices from the first source
-   * @return A pair indicating column-index and offset-index presence, respectively
-   */
-  [[nodiscard]] std::pair<bool, bool> page_index_presence(
-    std::span<std::vector<size_type> const> row_group_indices,
-    std::span<size_type const> schema_indices) const;
-
-  /**
    * @brief Constructor for aggregate_reader_metadata
    *
    * @param footer_bytes Host span of Parquet file footer buffer bytes, one per source
@@ -119,11 +106,6 @@ class aggregate_reader_metadata : public aggregate_reader_metadata_base {
   aggregate_reader_metadata& operator=(aggregate_reader_metadata&&)      = default;
 
   /**
-   * @brief Initialize the internal variables
-   */
-  void initialize_internals(bool use_arrow_schema, bool has_cols_from_mismatched_srcs);
-
-  /**
    * @brief Fetch the byte range of the page index in each Parquet file
    *
    * @return Vector of byte ranges of the page index, one per source
@@ -136,6 +118,19 @@ class aggregate_reader_metadata : public aggregate_reader_metadata_base {
    * @return Vector of file metadata, one per source
    */
   [[nodiscard]] std::vector<FileMetaData> parquet_metadatas() const;
+
+  /**
+   * @brief Check whether selected columns have column and offset indexes
+   *
+   * Schema indices are mapped to each source before locating the column chunks.
+   *
+   * @param row_group_indices Row group indices, one vector per source
+   * @param schema_indices Schema indices from the first source
+   * @return A pair indicating column-index and offset-index presence, respectively
+   */
+  [[nodiscard]] std::pair<bool, bool> page_index_presence(
+    std::span<std::vector<size_type> const> row_group_indices,
+    std::span<size_type const> schema_indices) const;
 
   /**
    * @brief Setup and populate the page index structs in every source's `FileMetaData`

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -121,20 +121,27 @@ namespace {
 
 void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
 {
-  auto const& pass               = *_pass_itm_data;
-  auto buffers_with_pruned_pages = std::vector<bool>(_output_buffers.size(), false);
+  // Initialize flags for buffers with pruned pages
+  if (_buffers_with_pruned_pages.size() != _output_buffers.size()) {
+    _buffers_with_pruned_pages.resize(_output_buffers.size(), false);
+  }
 
-  // Helper to get pruned page indices
-  auto pruned_page_indices =
-    std::views::iota(std::size_t{0}, _pass_page_mask.size()) |
-    std::views::filter([&](auto page_idx) { return not _pass_page_mask[page_idx]; });
+  // Mark pruned buffers for this pass
+  if (_pass_itm_data) {
+    auto const& pass = *_pass_itm_data;
 
-  // Mark buffers with pruned pages
-  std::ranges::for_each(pruned_page_indices, [&](auto page_idx) {
-    auto const& chunk        = pass.chunks[pass.pages[page_idx].chunk_idx];
-    auto const& input_column = _input_columns[chunk.src_col_index];
-    buffers_with_pruned_pages[input_column.nesting.front()] = true;
-  });
+    // Helper to get pruned page indices
+    auto pruned_page_indices =
+      std::views::iota(std::size_t{0}, _pass_page_mask.size()) |
+      std::views::filter([&](auto page_idx) { return not _pass_page_mask[page_idx]; });
+
+    // Mark buffers with pruned pages
+    std::ranges::for_each(pruned_page_indices, [&](auto page_idx) {
+      auto const& chunk        = pass.chunks[pass.pages[page_idx].chunk_idx];
+      auto const& input_column = _input_columns[chunk.src_col_index];
+      _buffers_with_pruned_pages[input_column.nesting.front()] = true;
+    });
+  }
 
   // Helper to mark a buffer and its children nullable
   auto const mark_buffers_nullable = [](auto const& self,
@@ -151,13 +158,10 @@ void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
   // Mark buffers with pruned pages as nullable
   auto buffers_with_pruned_page_indices =
     std::views::iota(std::size_t{0}, _output_buffers.size()) |
-    std::views::filter([&](auto buffer_idx) { return buffers_with_pruned_pages[buffer_idx]; });
+    std::views::filter([&](auto buffer_idx) { return _buffers_with_pruned_pages[buffer_idx]; });
   std::ranges::for_each(buffers_with_pruned_page_indices, [&](auto buffer_idx) {
     mark_buffers_nullable(mark_buffers_nullable,
                           std::span<inline_column_buffer>{&_output_buffers[buffer_idx], 1});
-    mark_buffers_nullable(
-      mark_buffers_nullable,
-      std::span<inline_column_buffer>{&_output_buffers_template[buffer_idx], 1});
   });
 }
 
@@ -1124,6 +1128,7 @@ void hybrid_scan_reader_impl::reset_internal_state()
   _pass_itm_data.reset();
   _pass_page_mask.clear();
   _subpass_page_mask.reset();
+  _buffers_with_pruned_pages.clear();
   _output_metadata.reset();
   _sparse_page_io = false;
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <iterator>
 #include <numeric>
+#include <ranges>
 #include <tuple>
 #include <utility>
 
@@ -120,9 +121,24 @@ namespace {
 
 void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
 {
-  if (std::all_of(_pass_page_mask.begin(), _pass_page_mask.end(), std::identity{})) { return; }
+  auto const& pass               = *_pass_itm_data;
+  auto buffers_with_pruned_pages = std::vector<bool>(_output_buffers.size(), false);
 
-  auto const mark_buffers_nullable = [](auto const& self, std::span<inline_column_buffer> buffers) {
+  // Helper to get pruned page indices
+  auto pruned_page_indices =
+    std::views::iota(std::size_t{0}, _pass_page_mask.size()) |
+    std::views::filter([&](auto page_idx) { return not _pass_page_mask[page_idx]; });
+
+  // Mark buffers with pruned pages
+  std::ranges::for_each(pruned_page_indices, [&](auto page_idx) {
+    auto const& chunk        = pass.chunks[pass.pages[page_idx].chunk_idx];
+    auto const& input_column = _input_columns[chunk.src_col_index];
+    buffers_with_pruned_pages[input_column.nesting.front()] = true;
+  });
+
+  // Helper to mark a buffer and its children nullable
+  auto const mark_buffers_nullable = [](auto const& self,
+                                        std::span<inline_column_buffer> buffers) -> void {
     for (auto& buffer : buffers) {
       // Page pruning synthesizes null rows at every nesting level except list elements.
       if ((buffer.user_data & parquet::detail::PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT) == 0) {
@@ -132,9 +148,17 @@ void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
     }
   };
 
-  // Mark both the output and template buffers nullable when page pruning synthesizes null rows
-  mark_buffers_nullable(mark_buffers_nullable, _output_buffers);
-  mark_buffers_nullable(mark_buffers_nullable, _output_buffers_template);
+  // Mark buffers with pruned pages as nullable
+  auto buffers_with_pruned_page_indices =
+    std::views::iota(std::size_t{0}, _output_buffers.size()) |
+    std::views::filter([&](auto buffer_idx) { return buffers_with_pruned_pages[buffer_idx]; });
+  std::ranges::for_each(buffers_with_pruned_page_indices, [&](auto buffer_idx) {
+    mark_buffers_nullable(mark_buffers_nullable,
+                          std::span<inline_column_buffer>{&_output_buffers[buffer_idx], 1});
+    mark_buffers_nullable(
+      mark_buffers_nullable,
+      std::span<inline_column_buffer>{&_output_buffers_template[buffer_idx], 1});
+  });
 }
 
 hybrid_scan_reader_impl::hybrid_scan_reader_impl(

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -118,6 +118,25 @@ namespace {
 
 }  // namespace
 
+void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
+{
+  if (std::all_of(_pass_page_mask.begin(), _pass_page_mask.end(), std::identity{})) { return; }
+
+  auto const mark_buffers_nullable = [](auto const& self, std::span<inline_column_buffer> buffers) {
+    for (auto& buffer : buffers) {
+      // Page pruning synthesizes null rows at every nesting level except list elements.
+      if ((buffer.user_data & parquet::detail::PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT) == 0) {
+        buffer.is_nullable = true;
+      }
+      self(self, buffer.children);
+    }
+  };
+
+  // Mark both the output and template buffers nullable when page pruning synthesizes null rows
+  mark_buffers_nullable(mark_buffers_nullable, _output_buffers);
+  mark_buffers_nullable(mark_buffers_nullable, _output_buffers_template);
+}
+
 hybrid_scan_reader_impl::hybrid_scan_reader_impl(
   cudf::host_span<cudf::host_span<uint8_t const> const> footer_bytes,
   parquet_reader_options const& options)
@@ -1439,6 +1458,9 @@ void hybrid_scan_reader_impl::set_pass_page_mask(std::span<bool const> data_page
   // Make sure we inserted exactly the number of pages for this pass
   CUDF_EXPECTS(_pass_page_mask.size() == pass->pages.size(),
                "Encountered mismatch in number of pass pages and page mask size");
+
+  // Mark output buffers nullable when page pruning produces nulls
+  mark_buffers_nullable_for_pruned_pages();
 }
 
 void hybrid_scan_reader_impl::set_sparse_pass_page_mask(
@@ -1487,6 +1509,9 @@ void hybrid_scan_reader_impl::set_sparse_pass_page_mask(
   // Make sure we inserted exactly the number of pages for this pass.
   CUDF_EXPECTS(_pass_page_mask.size() == pass->pages.size(),
                "Encountered mismatch in number of pass pages and page mask size");
+
+  // Mark output buffers nullable when page pruning produces nulls
+  mark_buffers_nullable_for_pruned_pages();
 }
 
 }  // namespace cudf::io::parquet::experimental::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -80,6 +80,24 @@ namespace {
 }
 
 /**
+ * @brief Construct a vector of empty-like buffers from the input buffers
+ *
+ * @param buffers Input buffers
+ * @return Vector of empty-like buffers
+ */
+[[nodiscard]] std::vector<inline_column_buffer> make_empty_like_column_buffers(
+  std::span<inline_column_buffer const> buffers)
+{
+  std::vector<inline_column_buffer> empty_buffers;
+  empty_buffers.reserve(buffers.size());
+  std::transform(
+    buffers.begin(), buffers.end(), std::back_inserter(empty_buffers), [](auto const& buffer) {
+      return inline_column_buffer::empty_like(buffer);
+    });
+  return empty_buffers;
+}
+
+/**
  * @brief Count the number of row groups in the input
  *
  * @param row_group_indices Row group indices
@@ -121,27 +139,16 @@ namespace {
 
 void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
 {
-  // Initialize flags for buffers with pruned pages
-  if (_buffers_with_pruned_pages.size() != _output_buffers.size()) {
-    _buffers_with_pruned_pages.resize(_output_buffers.size(), false);
-  }
-
-  // Mark pruned buffers for this pass
-  if (_pass_itm_data) {
-    auto const& pass = *_pass_itm_data;
-
-    // Helper to get pruned page indices
-    auto pruned_page_indices =
-      std::views::iota(std::size_t{0}, _pass_page_mask.size()) |
-      std::views::filter([&](auto page_idx) { return not _pass_page_mask[page_idx]; });
-
-    // Mark buffers with pruned pages
-    std::ranges::for_each(pruned_page_indices, [&](auto page_idx) {
-      auto const& chunk        = pass.chunks[pass.pages[page_idx].chunk_idx];
-      auto const& input_column = _input_columns[chunk.src_col_index];
-      _buffers_with_pruned_pages[input_column.nesting.front()] = true;
-    });
-  }
+  auto const& pass               = *_pass_itm_data;
+  auto buffers_with_pruned_pages = std::vector<bool>(_output_buffers.size(), false);
+  auto pruned_page_indices =
+    std::views::iota(std::size_t{0}, _pass_page_mask.size()) |
+    std::views::filter([&](auto page_idx) { return not _pass_page_mask[page_idx]; });
+  std::ranges::for_each(pruned_page_indices, [&](auto page_idx) {
+    auto const& chunk        = pass.chunks[pass.pages[page_idx].chunk_idx];
+    auto const& input_column = _input_columns[chunk.src_col_index];
+    buffers_with_pruned_pages[input_column.nesting.front()] = true;
+  });
 
   // Helper to mark a buffer and its children nullable
   auto const mark_buffers_nullable = [](auto const& self,
@@ -158,10 +165,13 @@ void hybrid_scan_reader_impl::mark_buffers_nullable_for_pruned_pages()
   // Mark buffers with pruned pages as nullable
   auto buffers_with_pruned_page_indices =
     std::views::iota(std::size_t{0}, _output_buffers.size()) |
-    std::views::filter([&](auto buffer_idx) { return _buffers_with_pruned_pages[buffer_idx]; });
+    std::views::filter([&](auto buffer_idx) { return buffers_with_pruned_pages[buffer_idx]; });
   std::ranges::for_each(buffers_with_pruned_page_indices, [&](auto buffer_idx) {
     mark_buffers_nullable(mark_buffers_nullable,
                           std::span<inline_column_buffer>{&_output_buffers[buffer_idx], 1});
+    mark_buffers_nullable(
+      mark_buffers_nullable,
+      std::span<inline_column_buffer>{&_output_buffers_template[buffer_idx], 1});
   });
 }
 
@@ -271,14 +281,16 @@ void hybrid_scan_reader_impl::select_columns(read_columns_mode read_columns_mode
 
   CUDF_EXPECTS(_input_columns.size() > 0 and _output_buffers.size() > 0, "No columns selected");
 
-  // Clear the output buffers templates
-  _output_buffers_template.clear();
+  // Save original output-buffer schema for reuse across materialization passes.
+  _original_output_buffers_template = make_empty_like_column_buffers(_output_buffers);
 
-  // Save the states of the output buffers for reuse.
-  std::transform(_output_buffers.begin(),
-                 _output_buffers.end(),
-                 std::back_inserter(_output_buffers_template),
-                 [](auto const& buff) { return inline_column_buffer::empty_like(buff); });
+  // Initialize mutable output-buffer template for this materialization pass.
+  reset_output_buffers_template();
+}
+
+void hybrid_scan_reader_impl::reset_output_buffers_template()
+{
+  _output_buffers_template = make_empty_like_column_buffers(_original_output_buffers_template);
 }
 
 std::vector<std::vector<size_type>> hybrid_scan_reader_impl::all_row_groups(
@@ -323,6 +335,7 @@ void hybrid_scan_reader_impl::prepare_materialization(read_columns_mode read_col
   reset_internal_state();
   initialize_options(options, num_sources, stream, mr);
   select_columns(read_columns_mode, options);
+  reset_output_buffers_template();
 }
 
 std::vector<std::vector<cudf::size_type>>
@@ -1128,7 +1141,6 @@ void hybrid_scan_reader_impl::reset_internal_state()
   _pass_itm_data.reset();
   _pass_page_mask.clear();
   _subpass_page_mask.reset();
-  _buffers_with_pruned_pages.clear();
   _output_metadata.reset();
   _sparse_page_io = false;
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -621,6 +621,8 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
 
   std::optional<std::vector<std::string>> _filter_columns_names;
 
+  std::vector<bool> _buffers_with_pruned_pages;
+
   cudf::size_type _row_mask_offset{0};
   bool _output_chunk_produced{false};
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -400,6 +400,11 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
   void mark_buffers_nullable_for_pruned_pages();
 
   /**
+   * @brief Initialize the mutable output-buffer template for this materialization
+   */
+  void reset_output_buffers_template();
+
+  /**
    * @brief Select the columns to be read based on the read mode
    *
    * @param read_columns_mode Read mode indicating if we are reading filter or payload columns
@@ -621,7 +626,7 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
 
   std::optional<std::vector<std::string>> _filter_columns_names;
 
-  std::vector<bool> _buffers_with_pruned_pages;
+  std::vector<cudf::io::detail::inline_column_buffer> _original_output_buffers_template;
 
   cudf::size_type _row_mask_offset{0};
   bool _output_chunk_produced{false};

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -395,6 +395,11 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
   void set_sparse_pass_page_mask(std::span<cudf::device_span<uint8_t const> const> page_data);
 
   /**
+   * @brief Mark output buffers nullable when page pruning synthesizes null rows
+   */
+  void mark_buffers_nullable_for_pruned_pages();
+
+  /**
    * @brief Select the columns to be read based on the read mode
    *
    * @param read_columns_mode Read mode indicating if we are reading filter or payload columns

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -956,8 +956,6 @@ aggregate_reader_metadata::aggregate_reader_metadata(std::vector<FileMetaData>&&
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
 {
-  CUDF_EXPECTS(not parquet_metadatas.empty(), "At least one source must be provided");
-
   per_file_metadata.reserve(parquet_metadatas.size());
   std::transform(std::make_move_iterator(parquet_metadatas.begin()),
                  std::make_move_iterator(parquet_metadatas.end()),

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -956,6 +956,8 @@ aggregate_reader_metadata::aggregate_reader_metadata(std::vector<FileMetaData>&&
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
 {
+  CUDF_EXPECTS(not parquet_metadatas.empty(), "At least one source must be provided");
+
   per_file_metadata.reserve(parquet_metadatas.size());
   std::transform(std::make_move_iterator(parquet_metadatas.begin()),
                  std::make_move_iterator(parquet_metadatas.end()),

--- a/cpp/tests/io/experimental/hybrid_scan_multifile_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_multifile_test.cpp
@@ -8,6 +8,7 @@
 #include "tests/io/parquet_common.hpp"
 
 #include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/ast/expressions.hpp>
@@ -471,4 +472,55 @@ TEST_F(HybridScanMultifileTest, SparsePayloadEmptyAndAllPrunedPageData)
     EXPECT_EQ(result.metadata.num_input_row_groups, 8);
     EXPECT_FALSE(reader->has_next_table_chunk());
   }
+}
+TEST_F(HybridScanMultifileTest, ChunkedAllColumnsPreservesRequiredNullability)
+{
+  // Use several pages so a nullable output would require a non-trivial validity allocation.
+  auto constexpr num_rows = 2 * page_size_for_ordered_tests;
+  auto values             = cuda::counting_iterator<int64_t>{0};
+  cudf::test::fixed_width_column_wrapper<int64_t> required_column(values, values + num_rows);
+  auto const input_table = cudf::table_view{{required_column}};
+
+  cudf::io::table_input_metadata metadata(input_table);
+  metadata.column_metadata[0].set_name("required");
+  metadata.column_metadata[0].set_nullability(false);
+
+  std::vector<char> parquet_buffer;
+  auto const write_options =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&parquet_buffer}, input_table)
+      .metadata(metadata)
+      .max_page_size_rows(page_size_for_ordered_tests)
+      .build();
+  cudf::io::write_parquet(write_options);
+
+  auto const source_info = build_source_info({parquet_buffer});
+  auto const options     = cudf::io::parquet_reader_options::builder().build();
+  auto inputs            = multifile_inputs(source_info);
+  auto reader =
+    cudf::io::parquet::experimental::hybrid_scan_multifile{inputs.footer_byte_spans, options};
+
+  ASSERT_EQ(reader.parquet_metadatas().front().schema[1].repetition_type,
+            cudf::io::parquet::FieldRepetitionType::REQUIRED);
+
+  auto const row_groups = reader.all_row_groups(options);
+  auto const stream     = cudf::get_default_stream();
+  auto const mr         = cudf::get_current_device_resource_ref();
+  auto column_data      = fetch_multisource_device_data(
+    inputs, reader.all_column_chunks_byte_ranges(row_groups, options), stream, mr);
+  reader.setup_chunking_for_all_columns(
+    0, 0, row_groups, column_data.flat_spans, options, stream, mr);
+
+  ASSERT_TRUE(reader.has_next_table_chunk());
+  auto const result = reader.materialize_all_columns_chunk();
+  EXPECT_FALSE(reader.has_next_table_chunk());
+
+  auto const result_column = result.tbl->view().column(0);
+  EXPECT_EQ(result_column.null_count(), 0);
+  EXPECT_FALSE(result_column.nullable());
+  EXPECT_EQ(result_column.null_mask(), nullptr);
+
+  auto const standard_result = cudf::io::read_parquet(
+    cudf::io::parquet_reader_options::builder(source_info).build(), stream, mr);
+  EXPECT_FALSE(standard_result.tbl->view().column(0).nullable());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input_table, result.tbl->view());
 }

--- a/cpp/tests/io/experimental/hybrid_scan_multifile_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_multifile_test.cpp
@@ -473,54 +473,31 @@ TEST_F(HybridScanMultifileTest, SparsePayloadEmptyAndAllPrunedPageData)
     EXPECT_FALSE(reader->has_next_table_chunk());
   }
 }
-TEST_F(HybridScanMultifileTest, ChunkedAllColumnsPreservesRequiredNullability)
+
+TEST_F(HybridScanMultifileTest, AllColumnsPreservesRequiredNullability)
 {
-  // Use several pages so a nullable output would require a non-trivial validity allocation.
-  auto constexpr num_rows = 2 * page_size_for_ordered_tests;
-  auto values             = cuda::counting_iterator<int64_t>{0};
-  cudf::test::fixed_width_column_wrapper<int64_t> required_column(values, values + num_rows);
-  auto const input_table = cudf::table_view{{required_column}};
-
-  cudf::io::table_input_metadata metadata(input_table);
-  metadata.column_metadata[0].set_name("required");
-  metadata.column_metadata[0].set_nullability(false);
-
-  std::vector<char> parquet_buffer;
-  auto const write_options =
-    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&parquet_buffer}, input_table)
-      .metadata(metadata)
-      .max_page_size_rows(page_size_for_ordered_tests)
-      .build();
-  cudf::io::write_parquet(write_options);
-
-  auto const source_info = build_source_info({parquet_buffer});
-  auto const options     = cudf::io::parquet_reader_options::builder().build();
-  auto inputs            = multifile_inputs(source_info);
+  auto const [input_table, parquet_buffer] = create_parquet_with_stats<int64_t, 1>();
+  auto const parquet_buffers               = std::vector<std::vector<char>>{parquet_buffer};
+  auto const source_info                   = build_source_info(parquet_buffers);
+  auto const options                       = cudf::io::parquet_reader_options::builder().build();
+  auto inputs                              = multifile_inputs(source_info);
   auto reader =
     cudf::io::parquet::experimental::hybrid_scan_multifile{inputs.footer_byte_spans, options};
 
+  // Check footer metadata
   ASSERT_EQ(reader.parquet_metadatas().front().schema[1].repetition_type,
             cudf::io::parquet::FieldRepetitionType::REQUIRED);
 
+  // Materialize all columns
   auto const row_groups = reader.all_row_groups(options);
   auto const stream     = cudf::get_default_stream();
   auto const mr         = cudf::get_current_device_resource_ref();
   auto column_data      = fetch_multisource_device_data(
     inputs, reader.all_column_chunks_byte_ranges(row_groups, options), stream, mr);
-  reader.setup_chunking_for_all_columns(
-    0, 0, row_groups, column_data.flat_spans, options, stream, mr);
+  auto const result =
+    reader.materialize_all_columns(row_groups, column_data.flat_spans, options, stream, mr);
 
-  ASSERT_TRUE(reader.has_next_table_chunk());
-  auto const result = reader.materialize_all_columns_chunk();
-  EXPECT_FALSE(reader.has_next_table_chunk());
-
-  auto const result_column = result.tbl->view().column(0);
-  EXPECT_EQ(result_column.null_count(), 0);
-  EXPECT_FALSE(result_column.nullable());
-  EXPECT_EQ(result_column.null_mask(), nullptr);
-
-  auto const standard_result = cudf::io::read_parquet(
-    cudf::io::parquet_reader_options::builder(source_info).build(), stream, mr);
-  EXPECT_FALSE(standard_result.tbl->view().column(0).nullable());
-  CUDF_TEST_EXPECT_TABLES_EQUAL(input_table, result.tbl->view());
+  // Check results
+  EXPECT_FALSE(result.tbl->view().column(0).nullable());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input_table->view(), result.tbl->view());
 }


### PR DESCRIPTION
## Description

This PR enables the Hybrid scan reader to not mark REQUIRED columns as OPTIONAL unless page pruning is active (produces nulls)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
