### PR TITLE
[FEA] Use a common base architecture as LTO IR target

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -181,7 +181,28 @@ set(CUDF_CXX_FLAGS "")
 set(CUDF_CUDA_FLAGS "")
 set(CUDF_CXX_DEFINITIONS "")
 set(CUDF_CUDA_DEFINITIONS "")
-set(CUDF_LTO_ARCHITECTURE 75)
+
+# LTO IR can only be linked for targets greater than or equal to its architecture. An explicit
+# override must therefore not exceed the architecture of any target GPU on which it will be linked.
+set(
+  CUDF_LTO_ARCHITECTURE
+  ""
+  CACHE STRING "LTO fragment architecture; empty selects the minimum supported by the toolkit"
+)
+
+if(CUDF_LTO_ARCHITECTURE STREQUAL "")
+  foreach(architecture IN LISTS CMAKE_CUDA_ARCHITECTURES_ALL)
+    string(REGEX MATCH "^[0-9]+" architecture "${architecture}")
+    if(architecture AND (NOT CUDF_LTO_ARCHITECTURE OR architecture LESS CUDF_LTO_ARCHITECTURE))
+      set(CUDF_LTO_ARCHITECTURE "${architecture}")
+    endif()
+  endforeach()
+endif()
+
+if(NOT CUDF_LTO_ARCHITECTURE MATCHES "^[0-9]+$")
+  message(FATAL_ERROR "CUDF_LTO_ARCHITECTURE must be a numeric architecture")
+endif()
+message(VERBOSE "CUDF: Using ${CUDF_LTO_ARCHITECTURE} as the common LTO architecture")
 
 # For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
 # version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -181,6 +181,7 @@ set(CUDF_CXX_FLAGS "")
 set(CUDF_CUDA_FLAGS "")
 set(CUDF_CXX_DEFINITIONS "")
 set(CUDF_CUDA_DEFINITIONS "")
+set(CUDF_LTO_ARCHITECTURE 75)
 
 # For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
 # version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
@@ -430,6 +431,9 @@ if(NOT BUILD_SHARED_LIBS)
     install(TARGETS conda_env EXPORT cudf-exports)
   endif()
 endif()
+
+# ##################################################################################################
+# * JIT embedding ----------------------------------------------------------------------------------
 
 rtcx_add_embed(cudf_cuda_embed)
 
@@ -1218,8 +1222,10 @@ target_include_directories(
 )
 
 target_compile_definitions(
-  cudf PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"
-              "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_DEFINITIONS}>>"
+  cudf
+  PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"
+         "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_DEFINITIONS}>>"
+         "CUDF_LTO_ARCHITECTURE=${CUDF_LTO_ARCHITECTURE}"
 )
 
 # Per-thread default stream

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -184,10 +184,9 @@ set(CUDF_CUDA_DEFINITIONS "")
 
 # LTO IR can only be linked for targets greater than or equal to its architecture. An explicit
 # override must therefore not exceed the architecture of any target GPU on which it will be linked.
-set(
-  CUDF_LTO_ARCHITECTURE
-  ""
-  CACHE STRING "LTO fragment architecture; empty selects the minimum supported by the toolkit"
+set(CUDF_LTO_ARCHITECTURE
+    ""
+    CACHE STRING "LTO fragment architecture; empty selects the minimum supported by the toolkit"
 )
 
 if(CUDF_LTO_ARCHITECTURE STREQUAL "")

--- a/cpp/cmake/Modules/AddFragment.cmake
+++ b/cpp/cmake/Modules/AddFragment.cmake
@@ -67,6 +67,7 @@ macro(add_fragment)
                CUDA_STANDARD 20
                CUDA_STANDARD_REQUIRED ON
                CUDA_VISIBILITY_PRESET hidden
+               CUDA_ARCHITECTURES ${CUDF_LTO_ARCHITECTURE}
   )
   target_link_libraries(
     ${OBJECT_ID}

--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -201,6 +201,8 @@ constexpr int32_t MIN_NVRTC_VERSION_PCH =
   make_cuda_version(12, 8, 0);  // minimum CUDA version for the "--pch" NVRTC flag
 constexpr int32_t MIN_NVRTC_VERSION_MINIMAL =
   make_cuda_version(12, 8, 0);  // minimum CUDA version for the "--minimal" NVRTC flag
+constexpr int32_t LTO_ARCHITECTURE =
+  CUDF_LTO_ARCHITECTURE;  // target architecture for LTO IR compilation
 
 std::tuple<rtcx::library, rtcx::blob> compile_library(
   char const* name,
@@ -293,11 +295,9 @@ rtcx::blob compile_fragment(char const* name,
 {
   CUDF_FUNC_RANGE();
 
-  auto& ctx               = cudf::get_context();
-  auto& cfg               = ctx.config();
-  auto& bundle            = ctx.jit_bundle();
-  auto& device_properties = ctx.get_device_properties();
-  auto sm                 = device_properties.compute_capability;
+  auto& ctx    = cudf::get_context();
+  auto& cfg    = ctx.config();
+  auto& bundle = ctx.jit_bundle();
 
   auto include_dirs = bundle.get_include_directories();
   auto pch_dir      = ctx.get_jit_pch_dir();
@@ -313,12 +313,12 @@ rtcx::blob compile_fragment(char const* name,
     options.emplace_back(std::format("-I{}", include_dir));
   }
 
-  options.emplace_back(std::format("--gpu-architecture=sm_{}", sm));
+  options.emplace_back(std::format("--gpu-architecture=sm_{}", LTO_ARCHITECTURE));
 
   options.emplace_back("--diag-suppress=47");
   options.emplace_back("--device-int128");
 
-  if (sm >= 100) { options.emplace_back("--device-float128"); }
+  if (LTO_ARCHITECTURE >= 100) { options.emplace_back("--device-float128"); }
 
   options.emplace_back("-std=c++20");
   options.emplace_back("--device-as-default-execution-space");
@@ -446,7 +446,6 @@ rtcx::blob get_kernel_fragment(std::string const& name,
   auto& device_properties = ctx.get_device_properties();
   auto runtime            = device_properties.runtime_version;
   auto driver             = device_properties.driver_version;
-  auto sm                 = device_properties.compute_capability;
   auto bundle_hash        = bundle.get_hash();
 
   auto source_file = std::format("{}/{}", bundle.get_directory(), source_file_id);
@@ -464,7 +463,7 @@ kernel_instance={}
                           name,
                           runtime,
                           driver,
-                          sm,
+                          LTO_ARCHITECTURE,
                           bundle_hash,
                           source_file,
                           kernel_instance);


### PR DESCRIPTION
## Description

Use the minimum compute capability supported by the toolkit as a common base architecture for LTO IR fragments.

Previously, CMake-generated fragments were emitted for every architecture in the RAPIDS architecture set, while runtime NVRTC fragments were compiled for the current device. This generated redundant embedded LTO variants and made runtime fragment cache entries device-architecture-specific even though nvJitLink targets the current device when producing the final cubin.

This change:

- Defines `CUDF_LTO_ARCHITECTURE` as the minimum cc supported by the toolkit.
- Uses that architecture for CMake-generated LTO fragments.
- Uses the same architecture for runtime NVRTC LTO fragment compilation and cache keys.
- Continues to pass the current device architecture to nvJitLink when producing the final cubin.

### Size and runtime impact

Measurements were collected with CUDA 13.3 on an NVIDIA RTX A6000 (SM86).

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Embedded fragment payload | 3,221,984 B | 529,128 B | -83.6% |
| `libcudf.so` size | 476,732,488 B | 474,041,416 B | -2,691,072 B (-0.56%) |
| Cold runtime LTO link, median | 43.882 ms | 44.054 ms | +0.39% |
| Final nvJitLink phase, median | 22.922 ms | 22.862 ms | -0.26% |


Runtime-link measurements used 30 cold `TransformLTOTest.InvSqrt` processes per configuration with the RTCX and CUDA caches disabled. The differences are within run-to-run variation, indicating no measurable JIT-link regression.

Steady-state execution performance was compared between `main` (`c2c4e85881a`) and this PR (`e7269657f4d`) using the `BINARYOP_NVBENCH` `jit_binary_op_ADD_float_float_float_jit` benchmark with `use_lto=true`. This benchmark invokes `cudf::transform_lto` once before timing each state, so the JIT link and in-process caches are fully warm. Measurements were collected on an NVIDIA RTX A6000 (SM86); negative deltas favor this PR.

| Rows | `main` GPU time | This PR GPU time | Change | NvBench noise (`main` / PR) |
|---:|---:|---:|---:|---:|
| 1 | 31.148 us | 31.339 us | +0.61% | 4.55% / 11.32% |
| 10 | 31.323 us | 31.455 us | +0.42% | 3.87% / 6.16% |
| 100 | 31.032 us | 31.120 us | +0.28% | 3.78% / 6.62% |
| 1,000 | 31.748 us | 31.693 us | -0.17% | 7.70% / 8.14% |
| 10,000 | 34.617 us | 34.675 us | +0.17% | 18.54% / 20.39% |
| 100,000 | 40.699 us | 40.657 us | -0.10% | 5.70% / 7.49% |
| 1,000,000 | 56.208 us | 56.919 us | +1.27% | 6.25% / 10.42% |
| 10,000,000 | 214.743 us | 215.155 us | +0.19% | 1.67% / 2.08% |


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
