### PR TITLE
Fix cudf::strings::to_timestamp handling of %U format specifier

### DIFF
--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -335,16 +335,16 @@ struct parse_datetime {
     auto const days = [timeparts, this] {
       // week and weekday prioritize over month/day
       if ((timeparts.week > 0) && (timeparts.weekday > 0)) {
-        auto const y = cuda::std::chrono::year{timeparts.year};
+        auto const y         = cuda::std::chrono::year{timeparts.year};
+        auto const first_day = static_cast<uint32_t>(format_contains('W'));
         // clang-format off
-        auto const start = format_contains('U')
+        auto const start = first_day==0
           ? cuda::std::chrono::sys_days{cuda::std::chrono::Sunday[1]/cuda::std::chrono::January/y}
           : cuda::std::chrono::sys_days{cuda::std::chrono::Monday[1]/cuda::std::chrono::January/y};
         // clang-format on
         auto const days =  // compute days from year, weeks and weekday
           start + cuda::std::chrono::weeks(timeparts.week - 1) - cuda::std::chrono::weeks{1} +
-          (cuda::std::chrono::weekday(timeparts.weekday) -
-           cuda::std::chrono::weekday{1});  // cuda::std::chrono::Monday causes compile error here
+          (cuda::std::chrono::weekday(timeparts.weekday) - cuda::std::chrono::weekday{first_day});
         return days.time_since_epoch().count();
       }
       auto const ymd =  // chrono class handles the leap year calculations for us

--- a/cpp/tests/strings/datetime_tests.cpp
+++ b/cpp/tests/strings/datetime_tests.cpp
@@ -232,13 +232,13 @@ TEST_F(StringsDatetimeTest, ToTimestampYear)
 TEST_F(StringsDatetimeTest, ToTimestampWeeks)
 {
   cudf::test::strings_column_wrapper input{
-    "2012-01/3", "2012-04/4", "2023-01/1", "2012-52/5", "2020-44/2", "1960-20/0", "1986-04/6"};
+    "2012-01/3", "2012-04/4", "2018-01/3", "2012-52/5", "2020-44/2", "1960-20/0", "1986-04/6"};
 
   auto format  = std::string("%Y-%W/%w");
   auto results = cudf::strings::to_timestamps(
     cudf::strings_column_view(input), cudf::data_type{cudf::type_id::TIMESTAMP_DAYS}, format);
   auto expected = cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep>{
-    15343, 15365, 19359, 15702, 18569, -3511, 5875};
+    15343, 15365, 17534, 15702, 18569, -3511, 5875};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results          = cudf::strings::is_timestamp(cudf::strings_column_view(input), format);
@@ -246,13 +246,13 @@ TEST_F(StringsDatetimeTest, ToTimestampWeeks)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, is_expected);
 
   cudf::test::strings_column_wrapper input_iso{
-    "2012-01/3", "2012-04/4", "2023-01/1", "2012-52/5", "2020-44/2", "1960-20/7", "1986-04/6"};
+    "2012-01/3", "2012-04/4", "2018-01/3", "2012-52/5", "2020-44/2", "1960-20/7", "1986-04/6"};
 
   format  = std::string("%Y-%U/%u");
   results = cudf::strings::to_timestamps(
     cudf::strings_column_view(input_iso), cudf::data_type{cudf::type_id::TIMESTAMP_DAYS}, format);
   expected = cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep>{
-    15342, 15364, 19358, 15701, 18568, -3512, 5874};
+    15343, 15365, 17541, 15702, 18569, -3518, 5875};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results = cudf::strings::is_timestamp(cudf::strings_column_view(input_iso), format);


### PR DESCRIPTION
## Description
Fixes the parsing logic for `cudf::strings::to_timestamp` handling of format specifier `%U` which is Sunday-based.
The logic had incorrectly adjusted for Monday. Updated the gtest to include a date where `%U` and `%W` (Monday-based) values differ for the same input.

Closes #23805


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
