### PR TITLE
fix(update-version): make numba-cuda upper pin creation idempotent

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -125,10 +125,10 @@ except Exception:
     for FILE in dependencies.yaml conda/recipes/cudf/recipe.yaml; do
       for f in $FILE; do
         [[ -f "$f" ]] || continue
-        sed_runner "s/numba-cuda>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*/numba-cuda${NUMBA_CUDA_SPEC}/g" "$f"
-        sed_runner "s/numba-cuda\[cu12\]>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*/numba-cuda[cu12]${NUMBA_CUDA_SPEC}/g" "$f"
-        sed_runner "s/numba-cuda\[cu13\]>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*/numba-cuda[cu13]${NUMBA_CUDA_SPEC}/g" "$f"
-        sed_runner "s/numba-cuda >=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*/numba-cuda ${NUMBA_CUDA_SPEC}/g" "$f"
+        sed_runner "s/numba-cuda>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\(,<[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\)\?/numba-cuda${NUMBA_CUDA_SPEC}/g" "$f"
+        sed_runner "s/numba-cuda\[cu12\]>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\(,<[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\)\?/numba-cuda[cu12]${NUMBA_CUDA_SPEC}/g" "$f"
+        sed_runner "s/numba-cuda\[cu13\]>=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\(,<[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\)\?/numba-cuda[cu13]${NUMBA_CUDA_SPEC}/g" "$f"
+        sed_runner "s/numba-cuda >=[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\(,<[0-9]\+\.[0-9]\+\.[0-9][0-9.]*\)\?/numba-cuda ${NUMBA_CUDA_SPEC}/g" "$f"
       done
     done
   else


### PR DESCRIPTION
## Description
While working on a hotfix release, I had to stop and manually update some upper-pins, since `numba-cuda` had duplicate upper-pins added, e.g.

```
numba-cuda>=0.22.2,<0.31.0,<0.31.0
```

This is because the `update-version.sh` script looks only for the `>=` bound
when adding the upper pin in.  This is usually not a problem, but does cause
issues when applying `update-version.sh` as a hotfix.

This PR checks for an optional pre-existing upper bound and doesn't add on a
second upper bound.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
