### PR TITLE
Fix flaky `StreamPoolTest.ConcurrentThreadsGetDistinctStreams`

### DIFF
--- a/cpp/tests/utilities_tests/stream_pool_tests.cpp
+++ b/cpp/tests/utilities_tests/stream_pool_tests.cpp
@@ -40,9 +40,12 @@ TEST_F(StreamPoolTest, ConcurrentThreadsGetDistinctStreams)
   auto constexpr num_streams  = 8;
 
   // Repeated requests make a shared round-robin counter very likely to hand the same stream to both
-  // threads. The latch makes them overlap; a thread starting after the other exited would adopt its
-  // retired pool and see the same streams.
+  // threads. Each thread takes its pool before the latch: a pool is created on first use and
+  // returned to the free list when its thread exits, so a thread that made its first request after
+  // the other one exited would adopt the retired pool and see the same streams.
   auto collect = [](std::unordered_set<cudaStream_t>& out, std::latch& ready) {
+    auto const first = get_hashable_streams(num_streams);
+    out.insert(first.begin(), first.end());
     ready.arrive_and_wait();
     for (auto request = 0; request < num_requests; request++) {
       auto const streams = get_hashable_streams(num_streams);


### PR DESCRIPTION
## Description

`ConcurrentThreadsGetDistinctStreams` relied on a latch to keep its two threads overlapping, but the latch only guarantees that both threads have started, not that both have acquired a stream pool.

Each thread now takes its pool before waiting on the latch, so both pools are live at the same time.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.