### PR TITLE
Fix style check in rolling utils module

### DIFF
--- a/python/cudf/cudf/core/udf/rolling_utils.py
+++ b/python/cudf/cudf/core/udf/rolling_utils.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+"""Helpers for JIT-compiling and running user-defined rolling window functions."""
+
 from __future__ import annotations
 
 import functools
@@ -94,6 +96,12 @@ def jit_rolling_apply(
     func : callable
         The user-defined function. Receives a 1D array (the window) and
         returns a scalar.
+
+    Returns
+    -------
+    ColumnBase
+        A column of the results, with nulls where ``min_periods`` was
+        not satisfied.
     """
     value_dtype = source_column.dtype
     kernel, return_dtype = _compile_or_get_kernel(func, value_dtype)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follows up #23598 

Fixes the style check job currently failing cudf CI

```
python/cudf/cudf/core/udf/rolling_utils.py:1: GL08 The object does not have a docstring

python/cudf/cudf/core/udf/rolling_utils.py:74: RT01 No Returns section found

```
Eg. https://github.com/NVIDIA/cudf/actions/runs/32924428538/job/98044335306?pr=23823#step:7:347
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
