### PR TITLE
Add max size_type overflow check in cudf::interleave_columns

### DIFF
--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -240,7 +240,7 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
   CUDF_EXPECTS(input.num_columns() > 0, "input must have at least one column to determine dtype.");
   CUDF_EXPECTS(static_cast<int64_t>(input.num_rows()) * static_cast<int64_t>(input.num_columns()) <=
                  static_cast<int64_t>(std::numeric_limits<size_type>::max()),
-               "Output column size exceeds maximum column size",
+               "Output column size exceeds the column size limit",
                std::overflow_error);
 
   auto const dtype = input.column(0).type();

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -238,6 +238,10 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
                                            rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.num_columns() > 0, "input must have at least one column to determine dtype.");
+  CUDF_EXPECTS(static_cast<int64_t>(input.num_rows()) * static_cast<int64_t>(input.num_columns()) <=
+                 static_cast<int64_t>(std::numeric_limits<size_type>::max()),
+               "Output column size exceeds maximum column size",
+               std::overflow_error);
 
   auto const dtype = input.column(0).type();
   CUDF_EXPECTS(std::all_of(std::cbegin(input),


### PR DESCRIPTION
## Description
Adds a check to `cudf::interleave_columns()` to ensure the `input.num_rows() * input.num_columns()` does not exceed the column size limit `max(size_type)`.

Closes #23832

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
