### PR TITLE
Add sync calls for row-operator host-to-device vector copying

### DIFF
--- a/cpp/src/row_operator/row_operators.cu
+++ b/cpp/src/row_operator/row_operators.cu
@@ -707,13 +707,15 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(
     }();
 
   auto const has_ranked_children = !transformed_columns.empty();
-  return create(transformed_input,
-                std::move(verticalized_col_depths),
-                std::move(transformed_columns),
-                new_column_order,
-                new_null_precedence,
-                has_ranked_children,
-                stream);
+  auto result                    = create(transformed_input,
+                       std::move(verticalized_col_depths),
+                       std::move(transformed_columns),
+                       new_column_order,
+                       new_null_precedence,
+                       has_ranked_children,
+                       stream);
+  cudf::detail::sync_stream(stream);  // new_column_order and new_null_precedence go out of scope
+  return result;
 }
 
 std::pair<std::shared_ptr<preprocessed_table>, std::shared_ptr<preprocessed_table>>
@@ -777,20 +779,22 @@ preprocessed_table::create(table_view const& lhs,
   auto const has_ranked_children_lhs = !transformed_columns_lhs.empty();
   auto const has_ranked_children_rhs = !transformed_columns_rhs.empty();
 
-  return {create(transformed_lhs,
-                 std::move(verticalized_col_depths_lhs),
-                 std::move(transformed_columns_lhs),
-                 new_column_order_lhs,
-                 new_null_precedence_lhs,
-                 has_ranked_children_lhs,
-                 stream),
-          create(transformed_rhs,
-                 std::move(verticalized_col_depths_rhs),
-                 std::move(transformed_columns_rhs),
-                 new_column_order_lhs,
-                 new_null_precedence_lhs,
-                 has_ranked_children_rhs,
-                 stream)};
+  auto result = std::pair{create(transformed_lhs,
+                                 std::move(verticalized_col_depths_lhs),
+                                 std::move(transformed_columns_lhs),
+                                 new_column_order_lhs,
+                                 new_null_precedence_lhs,
+                                 has_ranked_children_lhs,
+                                 stream),
+                          create(transformed_rhs,
+                                 std::move(verticalized_col_depths_rhs),
+                                 std::move(transformed_columns_rhs),
+                                 new_column_order_lhs,
+                                 new_null_precedence_lhs,
+                                 has_ranked_children_rhs,
+                                 stream)};
+  cudf::detail::sync_stream(stream);  // new_column_order_* and new_null_prec_* go out of scope
+  return result;
 }
 
 preprocessed_table::preprocessed_table(


### PR DESCRIPTION
## Description
Adds synchronize calls to row_operator functions that copy host vector values to device vectors to ensure the temporary host vectors are not destroyed before the copy completes.
Part of the work for https://github.com/NVIDIA/cudf/pull/23517

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
