### PR TITLE
Lazily initialize streaming groupby aggregation kinds

### DIFF
--- a/cpp/src/groupby/streaming_groupby/aggregate.cu
+++ b/cpp/src/groupby/streaming_groupby/aggregate.cu
@@ -60,7 +60,7 @@ void streaming_groupby::impl::do_aggregate(table_view const& data, cuda::stream_
     cuda::counting_iterator<int64_t>(0),
     static_cast<int64_t>(batch_size) * num_agg_cols,
     detail::hash::compute_single_pass_aggs_dense_output_fn{
-      result.target_indices.begin(), _d_agg_kinds.data(), *d_values, *_d_agg_results});
+      result.target_indices.begin(), _d_agg_kinds->data(), *d_values, *_d_agg_results});
 }
 
 }  // namespace cudf::groupby

--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -296,7 +296,7 @@ struct streaming_groupby::impl {
    */
   std::unique_ptr<mutable_table_device_view, void (*)(mutable_table_device_view*)> _d_agg_results;
   std::vector<size_type> _value_col_indices;
-  rmm::device_uvector<aggregation::Kind> _d_agg_kinds;
+  std::unique_ptr<rmm::device_uvector<aggregation::Kind>> _d_agg_kinds;
 
   std::unique_ptr<streaming_set_t> _key_set;
 

--- a/cpp/src/groupby/streaming_groupby/impl.cu
+++ b/cpp/src/groupby/streaming_groupby/impl.cu
@@ -89,7 +89,6 @@ streaming_groupby::impl::impl(host_span<size_type const> key_indices,
   : _max_distinct_keys{max_distinct_keys},
     _null_handling{null_handling},
     _mr{std::move(mr)},
-    _d_agg_kinds{0, cuda::stream_ref{cudaStreamLegacy}, cudf::get_current_device_resource_ref()},
     _d_agg_results{nullptr, +[](mutable_table_device_view*) {}}
 {
   CUDF_EXPECTS(max_distinct_keys > 0, "max_distinct_keys must be positive.", std::invalid_argument);
@@ -170,7 +169,8 @@ void streaming_groupby::impl::initialize(table_view const& data, cuda::stream_re
       decltype(_d_agg_results){raii.release(), +[](mutable_table_device_view* t) { t->destroy(); }};
   }
 
-  _d_agg_kinds = cudf::detail::make_device_uvector_async(_agg_kinds, stream, mr);
+  _d_agg_kinds = std::make_unique<rmm::device_uvector<aggregation::Kind>>(
+    cudf::detail::make_device_uvector_async(_agg_kinds, stream, mr));
 
   // Map each column in `values_view` back to its index in `data`.
   _value_col_indices.reserve(values_view.num_columns());

--- a/cpp/src/groupby/streaming_groupby/merge.cu
+++ b/cpp/src/groupby/streaming_groupby/merge.cu
@@ -138,7 +138,7 @@ void streaming_groupby::impl::do_merge(impl const& other, cuda::stream_ref strea
     cuda::counting_iterator<int64_t>(0),
     static_cast<int64_t>(other_distinct_keys) * num_agg_cols,
     merge_single_pass_aggs_fn{
-      result.target_indices.begin(), _d_agg_kinds.data(), *d_source, *_d_agg_results});
+      result.target_indices.begin(), _d_agg_kinds->data(), *d_source, *_d_agg_results});
 }
 
 }  // namespace cudf::groupby


### PR DESCRIPTION
## Description
Construct the streaming groupby's device aggregation kinds when the first non-empty batch initializes the rest of its device state. This removes the zero-length placeholder allocation on the legacy default stream and uses the operation's stream instead.

The device vector is stored in a `std::unique_ptr`, consistent with the other lazily initialized device state in `streaming_groupby::impl`. There is no public API change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
