### PR TITLE
[BUG] Fix null handling in mixed semi joins

### DIFF
--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -139,8 +139,11 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
   auto const row_comparator_conditional_right = cudf::detail::row::equality::two_table_comparator{
     preprocessed_right_condtional, preprocessed_right_condtional};
   auto const right_conditional_nulls = cudf::nullate::DYNAMIC{cudf::has_nulls(right_conditional)};
+  // `compare_nulls` governs the equality tables. This comparator only deduplicates identical
+  // right conditional rows, so it must remain reflexive when those rows contain nulls. Treating
+  // nulls as unequal would insert every otherwise identical null row into the linear-probing set.
   auto const equality_right_conditional =
-    row_comparator_conditional_right.equal_to<false>(right_conditional_nulls, compare_nulls);
+    row_comparator_conditional_right.equal_to<false>(right_conditional_nulls, null_equality::EQUAL);
 
   hash_set_type row_set{{static_cast<std::size_t>(right.num_rows())},
                         cudf::detail::CUCO_DESIRED_LOAD_FACTOR,

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -138,8 +138,9 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
     cudf::detail::row::equality::preprocessed_table::create(right_conditional, stream, temp_mr);
   auto const row_comparator_conditional_right = cudf::detail::row::equality::two_table_comparator{
     preprocessed_right_condtional, preprocessed_right_condtional};
+  auto const right_conditional_nulls = cudf::nullate::DYNAMIC{cudf::has_nulls(right_conditional)};
   auto const equality_right_conditional =
-    row_comparator_conditional_right.equal_to<false>(right_nulls, compare_nulls);
+    row_comparator_conditional_right.equal_to<false>(right_conditional_nulls, compare_nulls);
 
   hash_set_type row_set{{static_cast<std::size_t>(right.num_rows())},
                         cudf::detail::CUCO_DESIRED_LOAD_FACTOR,

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -1838,6 +1838,66 @@ TYPED_TEST(MixedLeftSemiJoinTest, BasicNullEqualityUnequal)
                    cudf::null_equality::UNEQUAL);
 };
 
+using MixedLeftSemiJoinTest_int32 = MixedLeftSemiJoinTest<int32_t>;
+
+TEST_F(MixedLeftSemiJoinTest_int32, NullableConditionalWithNonNullableEqualityKeys)
+{
+  auto const left_conditional  = cudf::ast::column_reference(1, cudf::ast::table_reference::LEFT);
+  auto const right_conditional = cudf::ast::column_reference(1, cudf::ast::table_reference::RIGHT);
+  auto const predicate =
+    cudf::ast::operation(cudf::ast::ast_operator::NOT_EQUAL, left_conditional, right_conditional);
+
+  auto constexpr num_rows = cudf::size_type{30};
+  std::vector<int32_t> equality_keys(num_rows);
+
+  for (auto const null_first : {false, true}) {
+    std::vector<int32_t> conditional_values(num_rows);
+    std::vector<bool> conditional_validity(num_rows);
+    std::vector<cudf::size_type> expected_indices;
+
+    for (cudf::size_type i = 0; i < num_rows; ++i) {
+      auto const residue = i % 3;
+      equality_keys[i]   = i / 3;
+      if (null_first) {
+        conditional_values[i]   = residue == 0 ? 0 : residue - 1;
+        conditional_validity[i] = residue != 0;
+      } else {
+        conditional_values[i]   = residue == 2 ? 0 : residue;
+        conditional_validity[i] = residue != 2;
+      }
+      if (conditional_validity[i]) { expected_indices.push_back(i); }
+    }
+
+    cudf::test::fixed_width_column_wrapper<int32_t> left_keys(equality_keys.begin(),
+                                                              equality_keys.end());
+    cudf::test::fixed_width_column_wrapper<int32_t> right_keys(equality_keys.begin(),
+                                                               equality_keys.end());
+    cudf::test::fixed_width_column_wrapper<int32_t> left_conditionals(
+      conditional_values.begin(), conditional_values.end(), conditional_validity.begin());
+    cudf::test::fixed_width_column_wrapper<int32_t> right_conditionals(
+      conditional_values.begin(), conditional_values.end(), conditional_validity.begin());
+
+    auto const left_table  = cudf::table_view{{left_keys, left_conditionals}};
+    auto const right_table = cudf::table_view{{right_keys, right_conditionals}};
+    auto const result      = cudf::mixed_left_semi_join(left_table.select({0}),
+                                                   right_table.select({0}),
+                                                   left_table,
+                                                   right_table,
+                                                   predicate,
+                                                   cudf::null_equality::UNEQUAL);
+
+    std::vector<cudf::size_type> actual_indices;
+    actual_indices.reserve(result->size());
+    for (std::size_t i = 0; i < result->size(); ++i) {
+      actual_indices.push_back(result->element(i, cudf::get_default_stream()));
+    }
+    std::sort(actual_indices.begin(), actual_indices.end());
+
+    SCOPED_TRACE(null_first ? "null-first order" : "null-last order");
+    EXPECT_EQ(actual_indices, expected_indices);
+  }
+}
+
 TYPED_TEST(MixedLeftSemiJoinTest, AsymmetricEquality)
 {
   this->test({{0, 2, 1}, {3, 5, 4}, {10, 30, 20}},

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -1838,14 +1838,16 @@ TYPED_TEST(MixedLeftSemiJoinTest, BasicNullEqualityUnequal)
                    cudf::null_equality::UNEQUAL);
 };
 
-using MixedLeftSemiJoinTest_int32 = MixedLeftSemiJoinTest<int32_t>;
+struct MixedLeftSemiAndAntiJoinTest : public cudf::test::BaseFixture {};
 
-TEST_F(MixedLeftSemiJoinTest_int32, NullableConditionalWithNonNullableEqualityKeys)
+TEST_F(MixedLeftSemiAndAntiJoinTest, NullableConditionalWithNonNullableEqualityKeys)
 {
   auto const left_conditional  = cudf::ast::column_reference(1, cudf::ast::table_reference::LEFT);
   auto const right_conditional = cudf::ast::column_reference(1, cudf::ast::table_reference::RIGHT);
-  auto const predicate =
+  auto const not_equal =
     cudf::ast::operation(cudf::ast::ast_operator::NOT_EQUAL, left_conditional, right_conditional);
+  auto const right_is_null =
+    cudf::ast::operation(cudf::ast::ast_operator::IS_NULL, right_conditional);
 
   auto constexpr num_rows = cudf::size_type{30};
   std::vector<int32_t> equality_keys(num_rows);
@@ -1853,7 +1855,10 @@ TEST_F(MixedLeftSemiJoinTest_int32, NullableConditionalWithNonNullableEqualityKe
   for (auto const null_first : {false, true}) {
     std::vector<int32_t> conditional_values(num_rows);
     std::vector<bool> conditional_validity(num_rows);
-    std::vector<cudf::size_type> expected_indices;
+    std::vector<cudf::size_type> non_null_indices;
+    std::vector<cudf::size_type> null_indices;
+    std::vector<cudf::size_type> all_indices(num_rows);
+    std::iota(all_indices.begin(), all_indices.end(), 0);
 
     for (cudf::size_type i = 0; i < num_rows; ++i) {
       auto const residue = i % 3;
@@ -1865,7 +1870,7 @@ TEST_F(MixedLeftSemiJoinTest_int32, NullableConditionalWithNonNullableEqualityKe
         conditional_values[i]   = residue == 2 ? 0 : residue;
         conditional_validity[i] = residue != 2;
       }
-      if (conditional_validity[i]) { expected_indices.push_back(i); }
+      (conditional_validity[i] ? non_null_indices : null_indices).push_back(i);
     }
 
     cudf::test::fixed_width_column_wrapper<int32_t> left_keys(equality_keys.begin(),
@@ -1879,22 +1884,63 @@ TEST_F(MixedLeftSemiJoinTest_int32, NullableConditionalWithNonNullableEqualityKe
 
     auto const left_table  = cudf::table_view{{left_keys, left_conditionals}};
     auto const right_table = cudf::table_view{{right_keys, right_conditionals}};
-    auto const result      = cudf::mixed_left_semi_join(left_table.select({0}),
-                                                   right_table.select({0}),
-                                                   left_table,
-                                                   right_table,
-                                                   predicate,
-                                                   cudf::null_equality::UNEQUAL);
 
-    std::vector<cudf::size_type> actual_indices;
-    actual_indices.reserve(result->size());
-    for (std::size_t i = 0; i < result->size(); ++i) {
-      actual_indices.push_back(result->element(i, cudf::get_default_stream()));
+    auto const expect_indices = [](SingleJoinReturn const& result,
+                                   std::vector<cudf::size_type> const& expected_indices) {
+      std::vector<cudf::size_type> actual_indices;
+      actual_indices.reserve(result->size());
+      for (std::size_t i = 0; i < result->size(); ++i) {
+        actual_indices.push_back(result->element(i, cudf::get_default_stream()));
+      }
+      std::sort(actual_indices.begin(), actual_indices.end());
+      EXPECT_EQ(actual_indices, expected_indices);
+    };
+
+    for (auto const compare_nulls : {cudf::null_equality::EQUAL, cudf::null_equality::UNEQUAL}) {
+      SCOPED_TRACE(null_first ? "null-first order" : "null-last order");
+      SCOPED_TRACE(compare_nulls == cudf::null_equality::EQUAL ? "nulls equal" : "nulls unequal");
+
+      {
+        SCOPED_TRACE("NOT_EQUAL left semi");
+        auto const result = cudf::mixed_left_semi_join(left_table.select({0}),
+                                                       right_table.select({0}),
+                                                       left_table,
+                                                       right_table,
+                                                       not_equal,
+                                                       compare_nulls);
+        expect_indices(result, non_null_indices);
+      }
+      {
+        SCOPED_TRACE("NOT_EQUAL left anti");
+        auto const result = cudf::mixed_left_anti_join(left_table.select({0}),
+                                                       right_table.select({0}),
+                                                       left_table,
+                                                       right_table,
+                                                       not_equal,
+                                                       compare_nulls);
+        expect_indices(result, null_indices);
+      }
+      {
+        SCOPED_TRACE("IS_NULL left semi");
+        auto const result = cudf::mixed_left_semi_join(left_table.select({0}),
+                                                       right_table.select({0}),
+                                                       left_table,
+                                                       right_table,
+                                                       right_is_null,
+                                                       compare_nulls);
+        expect_indices(result, all_indices);
+      }
+      {
+        SCOPED_TRACE("IS_NULL left anti");
+        auto const result = cudf::mixed_left_anti_join(left_table.select({0}),
+                                                       right_table.select({0}),
+                                                       left_table,
+                                                       right_table,
+                                                       right_is_null,
+                                                       compare_nulls);
+        expect_indices(result, {});
+      }
     }
-    std::sort(actual_indices.begin(), actual_indices.end());
-
-    SCOPED_TRACE(null_first ? "null-first order" : "null-last order");
-    EXPECT_EQ(actual_indices, expected_indices);
   }
 }
 


### PR DESCRIPTION
## Description

Closes #23860.

`mixed_join_semi` builds separate right-side comparators for the equality and conditional tables. The conditional comparator was using the null-state derived from the equality table, so nullable conditional values could be compared as non-null whenever the equality keys contained no nulls. This made right-side representative selection order-dependent and could produce an incorrect left-semi or left-anti gather map.

This change:

- derives the conditional comparator's null-state from `right_conditional`;
- uses null-equal semantics for conditional-row deduplication, independently of the equality-key `compare_nulls` setting, so the hash-set comparator remains reflexive and duplicate null rows do not form a long linear-probing cluster;
- expands regression coverage across left-semi and left-anti joins, `EQUAL` and `UNEQUAL`, null-first and null-last row order, and predicates that both reject and require null representatives.

The added `has_nulls` call is a host-side metadata scan over the conditional columns; it does not add a device pass.

Related downstream report: [NVIDIA/cudf-spark#14076](https://github.com/NVIDIA/cudf-spark/issues/14076).

Validation performed locally on an NVIDIA RTX 5880 Ada Generation GPU:

- `pre-commit run --files cpp/src/join/mixed_join_semi.cu cpp/tests/join/mixed_join_tests.cu`: all applicable hooks passed
- Expanded regression matrix: 1/1 passed
- Expanded regression matrix repeated 100 times: 100/100 passed
- All mixed left-semi/anti tests: 113/113 passed
- Complete `JOIN_TEST`: 810 passed, 2 skipped
- Focused `compute-sanitizer --tool memcheck`: 0 errors
- 30,000 duplicate-null right rows sharing one equality key, one left row, 10 iterations: `EQUAL` 31-33 ms and `UNEQUAL` 30-31 ms after the fix. Before the follow-up deduplication fix, `UNEQUAL` took 829-831 ms for the same input.

The same 30-row harness was also run on GH200 against the exact cuDF revision from the downstream failing build (`a6bd95e24bebc35c5ea92283410df4f48bf3be89`): the original implementation failed all 1,000 null-first iterations, while the patched object failed 0/1,000.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
