### PR TITLE
DNM: explicitly install librapidsmpf 26.08.01 to verify it's available in the cache

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,346 +11,346 @@ jobs:
   # Please keep pr-builder as the top job here
   pr-builder:
     needs:
-      - check-nightly-ci
-      - changed-files
-      - checks
-      - cmake-tests
+      # - check-nightly-ci
+      # - changed-files
+      # - checks
+      # - cmake-tests
       - conda-cpp-build
-      - cpp-linters
-      - conda-cpp-checks
-      - conda-cpp-tests
-      - conda-python-build
-      - conda-python-build-noarch
-      - conda-python-cudf-tests
-      - conda-python-other-tests
-      - conda-java-tests
-      - java-build-matrix
-      - java-build
-      - java-tests
-      - conda-notebook-tests
-      - docs-build
-      - wheel-build-libcudf
-      - wheel-build-libcudf-streaming
-      - wheel-build-cudf-streaming
-      - wheel-tests-cudf-streaming
-      - wheel-build-pylibcudf
-      - wheel-build-cudf
-      - wheel-tests-cudf
-      - wheel-build-cudf-polars
-      - wheel-tests-cudf-polars
-      - cudf-polars-polars-tests
-      - wheel-build-dask-cudf
-      - wheel-tests-dask-cudf
-      - devcontainer
-      - unit-tests-cudf-pandas
-      - pandas-tests
-      - narwhals-tests
-      - telemetry-setup
-      - third-party-integration-tests-cudf-pandas
+      # - cpp-linters
+      # - conda-cpp-checks
+      # - conda-cpp-tests
+      # - conda-python-build
+      # - conda-python-build-noarch
+      # - conda-python-cudf-tests
+      # - conda-python-other-tests
+      # - conda-java-tests
+      # - java-build-matrix
+      # - java-build
+      # - java-tests
+      # - conda-notebook-tests
+      # - docs-build
+      # - wheel-build-libcudf
+      # - wheel-build-libcudf-streaming
+      # - wheel-build-cudf-streaming
+      # - wheel-tests-cudf-streaming
+      # - wheel-build-pylibcudf
+      # - wheel-build-cudf
+      # - wheel-tests-cudf
+      # - wheel-build-cudf-polars
+      # - wheel-tests-cudf-polars
+      # - cudf-polars-polars-tests
+      # - wheel-build-dask-cudf
+      # - wheel-tests-dask-cudf
+      # - devcontainer
+      # - unit-tests-cudf-pandas
+      # - pandas-tests
+      # - narwhals-tests
+      # - telemetry-setup
+      # - third-party-integration-tests-cudf-pandas
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.08
     permissions:
       contents: read
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
-  telemetry-setup:
-    permissions:
-      id-token: write
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    env:
-      OTEL_SERVICE_NAME: 'pr-cudf'
-    steps:
-      - name: Telemetry setup
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
-        uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
-  check-nightly-ci:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      id-token: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Get PR Info
-        id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
-      - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
-        with:
-          repo: ${{ github.repository }}
-          target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
-          max-days-without-success: 14
-  changed-files:
-    permissions:
-      actions: read
-      contents: read
-      packages: read
-      pull-requests: read
-    needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@release/26.08
-    with:
-      files_yaml: |
-        build_docs:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!ci/build_wheel*.sh'
-          - '!ci/check_style.sh'
-          - '!ci/discover_libcudf_tests.sh'
-          - '!ci/release/update-version.sh'
-          - '!ci/run_*.sh'
-          - '!ci/test_*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!codecov.yml'
-          - '!SECURITY.md'
-        test_cpp:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/build_docs.sh'
-          - '!ci/build_python*.sh'
-          - '!ci/build_wheel*.sh'
-          - '!ci/check_style.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_python*.sh'
-          - '!ci/test_wheel*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!docs/**'
-          - '!img/**'
-          - '!java/**'
-          - '!notebooks/**'
-          - '!python/**'
-        test_cudf_pandas:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_java.sh'
-          - '!ci/validate_wheel.sh'
-          - '!docs/**'
-          - '!img/**'
-          - '!java/**'
-          - '!notebooks/**'
-        test_java:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/build_docs.sh'
-          - '!ci/build_wheel*.sh'
-          - '!ci/check_style.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_wheel*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!ci/release/update-version.sh'
-          - '!codecov.yml'
-          - '!docs/**'
-          - '!img/**'
-          - '!notebooks/**'
-          - '!python/**'
-        test_notebooks:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/build_wheel*.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_wheel*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!codecov.yml'
-          - '!java/**'
-        test_python_conda:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/build_docs.sh'
-          - '!ci/build_wheel*.sh'
-          - '!ci/check_style.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_java.sh'
-          - '!ci/test_wheel*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!docs/**'
-          - '!img/**'
-          - '!java/**'
-          - '!notebooks/**'
-        test_python_wheels:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/build_cpp.sh'
-          - '!ci/build_docs.sh'
-          - '!ci/build_python_noarch.sh'
-          - '!ci/build_python.sh'
-          - '!ci/check-style.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_cpp.sh'
-          - '!ci/test_cpp_common.sh'
-          - '!ci/test_cpp_memcheck.sh'
-          - '!ci/test_java.sh'
-          - '!ci/test_notebooks.sh'
-          - '!ci/test_python_common.sh'
-          - '!ci/test_python_cudf.sh'
-          - '!ci/test_python_other.sh'
-          - '!codecov.yml'
-          - '!conda/**'
-          - '!docs/**'
-          - '!img/**'
-          - '!java/**'
-          - '!notebooks/**'
-        not_cudf_polars:
-          - '**'
-          - '!python/cudf_polars/**'
-        neither_cudf_polars_nor_dask_cudf:
-          - '**'
-          - '!python/cudf_polars/**'
-          - '!python/dask_cudf/**'
-        neither_cudf_nor_dask_cudf:
-          - '**'
-          - '!python/cudf/**'
-          - '!python/dask_cudf/**'
-        neither_cpp_nor_cudf_polars_nor_dask_cudf:
-          - '**'
-          - '!cpp/**'
-          - '!python/cudf_polars/**'
-          - '!python/dask_cudf/**'
-  checks:
-    permissions:
-      contents: read
-    needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@release/26.08
-    with:
-      enable_check_generated_files: false
-      ignored_pr_jobs: "telemetry-summarize spark-rapids-jni cuml-compat-tests"
+  # telemetry-setup:
+  #   permissions:
+  #     id-token: write
+  #   continue-on-error: true
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     OTEL_SERVICE_NAME: 'pr-cudf'
+  #   steps:
+  #     - name: Telemetry setup
+  #       if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
+  #       uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
+  # check-nightly-ci:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: read
+  #     id-token: write
+  #   env:
+  #     GH_TOKEN: ${{ github.token }}
+  #   steps:
+  #     - name: Get PR Info
+  #       id: get-pr-info
+  #       uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
+  #     - name: Check if nightly CI is passing
+  #       uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
+  #       with:
+  #         repo: ${{ github.repository }}
+  #         target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+  #         max-days-without-success: 14
+  # changed-files:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     packages: read
+  #     pull-requests: read
+  #   needs: telemetry-setup
+  #   uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@release/26.08
+  #   with:
+  #     files_yaml: |
+  #       build_docs:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!ci/build_wheel*.sh'
+  #         - '!ci/check_style.sh'
+  #         - '!ci/discover_libcudf_tests.sh'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/run_*.sh'
+  #         - '!ci/test_*.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!codecov.yml'
+  #         - '!SECURITY.md'
+  #       test_cpp:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/build_docs.sh'
+  #         - '!ci/build_python*.sh'
+  #         - '!ci/build_wheel*.sh'
+  #         - '!ci/check_style.sh'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_python*.sh'
+  #         - '!ci/test_wheel*.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!docs/**'
+  #         - '!img/**'
+  #         - '!java/**'
+  #         - '!notebooks/**'
+  #         - '!python/**'
+  #       test_cudf_pandas:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_java.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!docs/**'
+  #         - '!img/**'
+  #         - '!java/**'
+  #         - '!notebooks/**'
+  #       test_java:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/build_docs.sh'
+  #         - '!ci/build_wheel*.sh'
+  #         - '!ci/check_style.sh'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_wheel*.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!ci/release/update-version.sh'
+  #         - '!codecov.yml'
+  #         - '!docs/**'
+  #         - '!img/**'
+  #         - '!notebooks/**'
+  #         - '!python/**'
+  #       test_notebooks:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/build_wheel*.sh'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_wheel*.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!codecov.yml'
+  #         - '!java/**'
+  #       test_python_conda:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/build_docs.sh'
+  #         - '!ci/build_wheel*.sh'
+  #         - '!ci/check_style.sh'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_java.sh'
+  #         - '!ci/test_wheel*.sh'
+  #         - '!ci/validate_wheel.sh'
+  #         - '!docs/**'
+  #         - '!img/**'
+  #         - '!java/**'
+  #         - '!notebooks/**'
+  #       test_python_wheels:
+  #         - '**'
+  #         - '!**/REVIEW_GUIDELINES.md'
+  #         - '!.coderabbit.yaml'
+  #         - '!.clang-format'
+  #         - '!.devcontainer/**'
+  #         - '!.github/CODEOWNERS'
+  #         - '!.github/ISSUE_TEMPLATE/**'
+  #         - '!.github/PULL_REQUEST_TEMPLATE.md'
+  #         - '!.github/copy-pr-bot.yaml'
+  #         - '!.github/labeler.yml'
+  #         - '!.github/ops-bot.yaml'
+  #         - '!.github/release.yml'
+  #         - '!.github/workflows/auto-assign.yml'
+  #         - '!.github/workflows/issue-release-scheduled.yml'
+  #         - '!.github/workflows/labeler.yml'
+  #         - '!.github/workflows/pr_issue_status_automation.yml'
+  #         - '!.github/workflows/trigger-breaking-change-alert.yaml'
+  #         - '!.pre-commit-config.yaml'
+  #         - '!CONTRIBUTING.md'
+  #         - '!README.md'
+  #         - '!SECURITY.md'
+  #         - '!ci/build_cpp.sh'
+  #         - '!ci/build_docs.sh'
+  #         - '!ci/build_python_noarch.sh'
+  #         - '!ci/build_python.sh'
+  #         - '!ci/check-style.sh'
+  #         - '!ci/cudf_pandas_scripts/**'
+  #         - '!ci/release/update-version.sh'
+  #         - '!ci/test_cpp.sh'
+  #         - '!ci/test_cpp_common.sh'
+  #         - '!ci/test_cpp_memcheck.sh'
+  #         - '!ci/test_java.sh'
+  #         - '!ci/test_notebooks.sh'
+  #         - '!ci/test_python_common.sh'
+  #         - '!ci/test_python_cudf.sh'
+  #         - '!ci/test_python_other.sh'
+  #         - '!codecov.yml'
+  #         - '!conda/**'
+  #         - '!docs/**'
+  #         - '!img/**'
+  #         - '!java/**'
+  #         - '!notebooks/**'
+  #       not_cudf_polars:
+  #         - '**'
+  #         - '!python/cudf_polars/**'
+  #       neither_cudf_polars_nor_dask_cudf:
+  #         - '**'
+  #         - '!python/cudf_polars/**'
+  #         - '!python/dask_cudf/**'
+  #       neither_cudf_nor_dask_cudf:
+  #         - '**'
+  #         - '!python/cudf/**'
+  #         - '!python/dask_cudf/**'
+  #       neither_cpp_nor_cudf_polars_nor_dask_cudf:
+  #         - '**'
+  #         - '!cpp/**'
+  #         - '!python/cudf_polars/**'
+  #         - '!python/dask_cudf/**'
+  # checks:
+  #   permissions:
+  #     contents: read
+  #   needs: telemetry-setup
+  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@release/26.08
+  #   with:
+  #     enable_check_generated_files: false
+  #     ignored_pr_jobs: "telemetry-summarize spark-rapids-jni cuml-compat-tests"
   conda-cpp-build:
-    needs: checks
+    # needs: checks
     permissions:
       actions: read
       contents: read
@@ -363,569 +363,569 @@ jobs:
       build_type: pull-request
       node_type: cpu16
       script: ci/build_cpp.sh
-  cmake-tests:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    with:
-      build_type: pull-request
-      node_type: cpu16
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_cmake.sh"
-  cpp-linters:
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    needs: checks
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    with:
-      build_type: pull-request
-      script: "ci/cpp_linters.sh"
-  conda-cpp-checks:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@release/26.08
-    with:
-      build_type: pull-request
-      package_name: libcudf
-  conda-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      script: ci/test_cpp.sh
-  conda-python-build:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
-    with:
-      build_type: pull-request
-      script: ci/build_python.sh
-      # Build a conda package for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  conda-python-build-noarch:
-    needs: [conda-cpp-build, conda-python-build]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
-    with:
-      build_type: pull-request
-      script: ci/build_python_noarch.sh
-      pure-conda: cuda_major
-  conda-python-cudf-tests:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      script: "ci/test_python_cudf.sh"
-  conda-python-other-tests:
-    # Tests for dask_cudf, cudf_polars, custreamz, cudf_kafka are separated for CI parallelism
-    needs: [conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      # https://github.com/rapidsai/cudf/pull/22381/changes#r3196736965
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: "ci/test_python_other.sh"
-  conda-java-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_java.sh"
-  # Build and test the cuDF Java JAR for every Maven classifier.
-  java-build-matrix:
-    needs: [checks]
-    permissions:
-      contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.08
-    with:
-      build_type: pull-request
-      matrix_name: conda-cpp-build
-      matrix_filter: 'map(. + {CUDA_MAJOR: (.CUDA_VER | split(".") | .[0])})'
-  java-build:
-    needs: [java-build-matrix, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
-    with:
-      build_type: pull-request
-      arch: ${{ matrix.ARCH }}
-      node_type: cpu16
-      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
-      script: "ci/build_java.sh"
-      file_to_upload: output_jars
-      artifact-name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
-  java-tests:
-    needs: [java-build, java-build-matrix]
-    if: ${{ !cancelled() && needs.java-build.result == 'success' }}
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
-    with:
-      build_type: pull-request
-      arch: ${{ matrix.ARCH }}
-      node_type: "gpu-l4-latest-1"
-      container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
-      script: "ci/test_packaged_java.sh"
-  conda-notebook-tests:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_notebooks.sh"
-  docs-build:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/build_docs.sh"
-  wheel-build-libcudf:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      # build for every combination of arch and CUDA version, but only for the latest Python
-      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
-      build_type: pull-request
-      node_type: cpu16
-      script: "ci/build_wheel_libcudf.sh"
-      package-name: libcudf
-      package-type: cpp
-  wheel-build-libcudf-streaming:
-    needs: [checks, wheel-build-libcudf]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      # build for every combination of arch and CUDA version, but only for the latest Python
-      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
-      build_type: pull-request
-      node_type: cpu16
-      script: "ci/build_wheel_libcudf_streaming.sh"
-      package-name: libcudf_streaming
-      package-type: cpp
-  wheel-build-cudf-streaming:
-    needs: [checks, wheel-build-libcudf-streaming, wheel-build-pylibcudf]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      # Build a wheel for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-      build_type: pull-request
-      node_type: cpu16
-      script: "ci/build_wheel_cudf_streaming.sh"
-      package-name: cudf_streaming
-      package-type: python
-  wheel-tests-cudf-streaming:
-    needs: [wheel-build-cudf-streaming, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cudf_streaming.sh
-  wheel-build-pylibcudf:
-    needs: [checks, wheel-build-libcudf]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      build_type: pull-request
-      node_type: cpu8
-      script: "ci/build_wheel_pylibcudf.sh"
-      package-name: pylibcudf
-      package-type: python
-      # Build a wheel for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  wheel-build-cudf:
-    needs: wheel-build-pylibcudf
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      build_type: pull-request
-      node_type: cpu8
-      script: "ci/build_wheel_cudf.sh"
-      package-name: cudf
-      package-type: python
-      # Build a wheel for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  wheel-tests-cudf:
-    needs: [wheel-build-cudf, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cudf.sh
-  wheel-build-cudf-polars:
-    needs: wheel-build-pylibcudf
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      node_type: cpu8
-      script: "ci/build_wheel_cudf_polars.sh"
-      package-name: cudf_polars
-      package-type: python
-      pure-wheel: true
-  wheel-tests-cudf-polars:
-    needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
-    with:
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: "env POLARS_VERSIONS=endpoints ci/test_wheel_cudf_polars.sh"
-  cudf-polars-polars-tests:
-    needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
-    with:
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      script: "ci/test_cudf_polars_polars_tests.sh"
-  wheel-build-dask-cudf:
-    needs: wheel-build-cudf
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
-    with:
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      node_type: cpu8
-      script: "ci/build_wheel_dask_cudf.sh"
-      package-name: dask_cudf
-      package-type: python
-      pure-wheel: true
-  wheel-tests-dask-cudf:
-    needs: [wheel-build-dask-cudf, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).not_cudf_polars
-    with:
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      script: ci/test_wheel_dask_cudf.sh
-  # build cudf with benchmarks but disable for cudf_streaming since we can't use MPI/UCX in wheel-based builds
-  devcontainer:
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@release/26.08
-    with:
-      arch: '["amd64", "arm64"]'
-      cuda: '["13.3"]'
-      node_type: "cpu8"
-      timeout-minutes: 90
-      env: |
-        SCCACHE_DIST_MAX_RETRIES=inf
-        SCCACHE_SERVER_LOG=sccache=debug
-        SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
-      build_command: |
-        sccache --zero-stats;
-        build-all -j0 --verbose -DBUILD_BENCHMARKS=ON 2>&1 | tee telemetry-artifacts/build.log;
-        sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
-  unit-tests-cudf-pandas:
-    needs: [wheel-build-cudf, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
-    if: (fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels || fromJSON(needs.changed-files.outputs.changed_file_groups).test_cudf_pandas) && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
-    with:
-      # This selects the latest supported Python + CUDA minor versions for each ARCH/CUDA major version combo
-      matrix_filter: group_by([(.ARCH), (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
-      build_type: pull-request
-      script: ci/cudf_pandas_scripts/run_tests.sh
-  third-party-integration-tests-cudf-pandas:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
-      continue-on-error: true
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: |
-        ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
-  cuml-compat-tests:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
-      continue-on-error: true
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_cuml_compat.sh"
-  pandas-tests:
-    # run the Pandas unit tests using PR branch
-    needs: [wheel-build-cudf, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
-      container_image: "rapidsai/citestwheel:26.08-latest"
-      script: ci/cudf_pandas_scripts/pandas-tests/run.sh pr
-  narwhals-tests:
-    needs: [conda-python-build, conda-python-build-noarch, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
-    with:
-      build_type: pull-request
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: ci/test_narwhals.sh
-  spark-rapids-jni:
-    needs: changed-files
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    uses: ./.github/workflows/spark-rapids-jni.yaml
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
-  telemetry-summarize:
-    # This job must use a self-hosted runner to record telemetry traces.
-    runs-on: linux-amd64-cpu4
-    permissions:
-      actions: write
-    needs: pr-builder
-    if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
-    continue-on-error: true
-    steps:
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
-    env:
-      GH_TOKEN: ${{ github.token }}
+  # cmake-tests:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu16
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_cmake.sh"
+  # cpp-linters:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   needs: checks
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/cpp_linters.sh"
+  # conda-cpp-checks:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     package_name: libcudf
+  # conda-cpp-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_cpp.sh
+  # conda-python-build:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python.sh
+  #     # Build a conda package for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # conda-python-build-noarch:
+  #   needs: [conda-cpp-build, conda-python-build]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python_noarch.sh
+  #     pure-conda: cuda_major
+  # conda-python-cudf-tests:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_python_cudf.sh"
+  # conda-python-other-tests:
+  #   # Tests for dask_cudf, cudf_polars, custreamz, cudf_kafka are separated for CI parallelism
+  #   needs: [conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     # https://github.com/rapidsai/cudf/pull/22381/changes#r3196736965
+  #     container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+  #     script: "ci/test_python_other.sh"
+  # conda-java-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_java.sh"
+  # # Build and test the cuDF Java JAR for every Maven classifier.
+  # java-build-matrix:
+  #   needs: [checks]
+  #   permissions:
+  #     contents: read
+  #   uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     matrix_name: conda-cpp-build
+  #     matrix_filter: 'map(. + {CUDA_MAJOR: (.CUDA_VER | split(".") | .[0])})'
+  # java-build:
+  #   needs: [java-build-matrix, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+  #   strategy:
+  #     fail-fast: false
+  #     matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+  #   with:
+  #     build_type: pull-request
+  #     arch: ${{ matrix.ARCH }}
+  #     node_type: cpu16
+  #     container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+  #     script: "ci/build_java.sh"
+  #     file_to_upload: output_jars
+  #     artifact-name: cudf_java_${{ matrix.ARCH }}_cu${{ matrix.CUDA_MAJOR }}
+  # java-tests:
+  #   needs: [java-build, java-build-matrix]
+  #   if: ${{ !cancelled() && needs.java-build.result == 'success' }}
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   strategy:
+  #     fail-fast: false
+  #     matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+  #   with:
+  #     build_type: pull-request
+  #     arch: ${{ matrix.ARCH }}
+  #     node_type: "gpu-l4-latest-1"
+  #     container_image: "rapidsai/ci-wheel:26.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+  #     script: "ci/test_packaged_java.sh"
+  # conda-notebook-tests:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_notebooks.sh"
+  # docs-build:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/build_docs.sh"
+  # wheel-build-libcudf:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     # build for every combination of arch and CUDA version, but only for the latest Python
+  #     matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+  #     build_type: pull-request
+  #     node_type: cpu16
+  #     script: "ci/build_wheel_libcudf.sh"
+  #     package-name: libcudf
+  #     package-type: cpp
+  # wheel-build-libcudf-streaming:
+  #   needs: [checks, wheel-build-libcudf]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     # build for every combination of arch and CUDA version, but only for the latest Python
+  #     matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+  #     build_type: pull-request
+  #     node_type: cpu16
+  #     script: "ci/build_wheel_libcudf_streaming.sh"
+  #     package-name: libcudf_streaming
+  #     package-type: cpp
+  # wheel-build-cudf-streaming:
+  #   needs: [checks, wheel-build-libcudf-streaming, wheel-build-pylibcudf]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     # Build a wheel for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  #     build_type: pull-request
+  #     node_type: cpu16
+  #     script: "ci/build_wheel_cudf_streaming.sh"
+  #     package-name: cudf_streaming
+  #     package-type: python
+  # wheel-tests-cudf-streaming:
+  #   needs: [wheel-build-cudf-streaming, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cudf_streaming.sh
+  # wheel-build-pylibcudf:
+  #   needs: [checks, wheel-build-libcudf]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: "ci/build_wheel_pylibcudf.sh"
+  #     package-name: pylibcudf
+  #     package-type: python
+  #     # Build a wheel for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # wheel-build-cudf:
+  #   needs: wheel-build-pylibcudf
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: "ci/build_wheel_cudf.sh"
+  #     package-name: cudf
+  #     package-type: python
+  #     # Build a wheel for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # wheel-tests-cudf:
+  #   needs: [wheel-build-cudf, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cudf.sh
+  # wheel-build-cudf-polars:
+  #   needs: wheel-build-pylibcudf
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+  #     matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: "ci/build_wheel_cudf_polars.sh"
+  #     package-name: cudf_polars
+  #     package-type: python
+  #     pure-wheel: true
+  # wheel-tests-cudf-polars:
+  #   needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
+  #   with:
+  #     # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+  #     matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+  #     script: "env POLARS_VERSIONS=endpoints ci/test_wheel_cudf_polars.sh"
+  # cudf-polars-polars-tests:
+  #   needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
+  #   with:
+  #     # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+  #     matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     script: "ci/test_cudf_polars_polars_tests.sh"
+  # wheel-build-dask-cudf:
+  #   needs: wheel-build-cudf
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
+  #   with:
+  #     # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+  #     matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: "ci/build_wheel_dask_cudf.sh"
+  #     package-name: dask_cudf
+  #     package-type: python
+  #     pure-wheel: true
+  # wheel-tests-dask-cudf:
+  #   needs: [wheel-build-dask-cudf, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).not_cudf_polars
+  #   with:
+  #     # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+  #     matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     script: ci/test_wheel_dask_cudf.sh
+  # # build cudf with benchmarks but disable for cudf_streaming since we can't use MPI/UCX in wheel-based builds
+  # devcontainer:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   needs: telemetry-setup
+  #   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@release/26.08
+  #   with:
+  #     arch: '["amd64", "arm64"]'
+  #     cuda: '["13.3"]'
+  #     node_type: "cpu8"
+  #     timeout-minutes: 90
+  #     env: |
+  #       SCCACHE_DIST_MAX_RETRIES=inf
+  #       SCCACHE_SERVER_LOG=sccache=debug
+  #       SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
+  #     build_command: |
+  #       sccache --zero-stats;
+  #       build-all -j0 --verbose -DBUILD_BENCHMARKS=ON 2>&1 | tee telemetry-artifacts/build.log;
+  #       sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
+  # unit-tests-cudf-pandas:
+  #   needs: [wheel-build-cudf, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
+  #   if: (fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels || fromJSON(needs.changed-files.outputs.changed_file_groups).test_cudf_pandas) && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
+  #   with:
+  #     # This selects the latest supported Python + CUDA minor versions for each ARCH/CUDA major version combo
+  #     matrix_filter: group_by([(.ARCH), (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+  #     build_type: pull-request
+  #     script: ci/cudf_pandas_scripts/run_tests.sh
+  # third-party-integration-tests-cudf-pandas:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     branch: ${{ inputs.branch }}
+  #     date: ${{ inputs.date }}
+  #     sha: ${{ inputs.sha }}
+  #     node_type: "gpu-l4-latest-1"
+  #     continue-on-error: true
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: |
+  #       ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+  # cuml-compat-tests:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     branch: ${{ inputs.branch }}
+  #     date: ${{ inputs.date }}
+  #     sha: ${{ inputs.sha }}
+  #     node_type: "gpu-l4-latest-1"
+  #     continue-on-error: true
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_cuml_compat.sh"
+  # pandas-tests:
+  #   # run the Pandas unit tests using PR branch
+  #   needs: [wheel-build-cudf, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     branch: ${{ inputs.branch }}
+  #     date: ${{ inputs.date }}
+  #     sha: ${{ inputs.sha }}
+  #     node_type: "gpu-l4-latest-1"
+  #     container_image: "rapidsai/citestwheel:26.08-latest"
+  #     script: ci/cudf_pandas_scripts/pandas-tests/run.sh pr
+  # narwhals-tests:
+  #   needs: [conda-python-build, conda-python-build-noarch, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cpp_nor_cudf_polars_nor_dask_cudf
+  #   with:
+  #     build_type: pull-request
+  #     branch: ${{ inputs.branch }}
+  #     date: ${{ inputs.date }}
+  #     sha: ${{ inputs.sha }}
+  #     node_type: "gpu-l4-latest-1"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: ci/test_narwhals.sh
+  # spark-rapids-jni:
+  #   needs: changed-files
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   uses: ./.github/workflows/spark-rapids-jni.yaml
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+  # telemetry-summarize:
+  #   # This job must use a self-hosted runner to record telemetry traces.
+  #   runs-on: linux-amd64-cpu4
+  #   permissions:
+  #     actions: write
+  #   needs: pr-builder
+  #   if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
+  #   continue-on-error: true
+  #   steps:
+  #     - name: Telemetry summarize
+  #       uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
+  #   env:
+  #     GH_TOKEN: ${{ github.token }}

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -24,6 +24,8 @@ export RAPIDS_ARTIFACTS_DIR
 
 # populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
+
+conda install -c rapidsai librapidsmpf=26.08.01 -y
 
 # --no-build-id allows for caching with `sccache`
 # more info is available at


### PR DESCRIPTION
Explicit check to determine if we can pull `librapidsmpf` 26.08.01 from the conda cache on linux-aarch64
