### PR TITLE
Enable Sphinx version switcher for dask-cudf docs

### DIFF
--- a/docs/dask_cudf/source/conf.py
+++ b/docs/dask_cudf/source/conf.py
@@ -65,6 +65,10 @@ html_theme_options = {
     "navbar_align": "right",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/dask-cudf/versions.json",
+        "version_match": version,
+    },
 }
 include_pandas_compat = True
 


### PR DESCRIPTION
Let's enable the version switcher for the `dask-cudf` Sphinx docs.

This is already enabled for the main `cudf` docs.