### PR TITLE
Fix fast-count optimization with hybrid scan

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/select.py
+++ b/python/cudf_polars/cudf_polars/streaming/select.py
@@ -434,13 +434,16 @@ def _(
         # Special Case: Fast count.
         # We can't use prefetched file metadata here, because we're in lowering,
         # not execution, so we don't have an IRExecutionContext with the prefetched
-        # file metadata yet.
+        # file metadata yet. Hybrid scan requires prefetched file metadata,
+        # so disable that as well.
         count = Scan._get_parquet_row_count_from_metadata(
             scan_child.paths,
             scan_child.skip_rows,
             scan_child.n_rows,
             dataclasses.replace(
-                scan_child.parquet_options, prefetch_file_metadata=False
+                scan_child.parquet_options,
+                prefetch_file_metadata=False,
+                use_hybrid_scan=False,
             ),
             None,
         )

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -217,13 +217,21 @@ def test_resolve_max_concurrent_io_tasks_partial_override() -> None:
     )
 
 
+@pytest.mark.parametrize("use_hybrid_scan", [True, False])
 def test_prefetch_file_metadata_select_fast_count(
     df: pl.DataFrame,
     streaming_engine_factory: Callable[..., StreamingEngine],
     tmp_path: Path,
+    *,
+    use_hybrid_scan: bool,
 ) -> None:
     streaming_engine = streaming_engine_factory(
-        StreamingOptions(parquet_options={"prefetch_file_metadata": True}),
+        StreamingOptions(
+            parquet_options={
+                "prefetch_file_metadata": True,
+                "use_hybrid_scan": use_hybrid_scan,
+            }
+        ),
     )
     source = tmp_path / "data.parquet"
     df.write_parquet(source)


### PR DESCRIPTION
## Description

Noted in
https://github.com/NVIDIA/cudf/pull/23677#pullrequestreview-5045828678, our fast count optimization for
`pl.scan_parquet(...).select(pl.len())` currently errors when hybrid scan is enabled.

This fix (temporarily) disables it for the node where we have to disable metadata prefetching.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

cc @Matt711 