### PR TITLE
wheels: declare 'cuda-pathfinder' dependency for libcudf

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -303,6 +303,7 @@ files:
       - depends_on_libnvcomp
       - depends_on_librmm
       - depends_on_rapids_logger
+      - run_libcudf
   py_build_pylibcudf:
     output: pyproject
     matrix:
@@ -1071,6 +1072,11 @@ dependencies:
           # Cap below 3.0.4 (rather than just excluding it) until a fixed
           # release is confirmed upstream, then raise the bound.
           - &pandas pandas>=3.0.0,<3.0.4a0
+  run_libcudf:
+    common:
+      - output_types: [requirements, pyproject]
+        packages:
+          - cuda-pathfinder
   run_pylibcudf:
     common:
       - output_types: [conda, requirements, constraints, pyproject]

--- a/python/libcudf/pyproject.toml
+++ b/python/libcudf/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA",
 ]
 dependencies = [
+    "cuda-pathfinder",
     "cuda-toolkit[nvrtc]==13.*",
     "libkvikio==26.10.*,>=0.0.0a0",
     "librmm==26.10.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Follow-up to #23414

Contributes to https://github.com/rapidsai/build-planning/issues/307

`libcudf` wheels use `cuda-pathfinder`:

https://github.com/NVIDIA/cudf/blob/ea199db1d76a99bcad27bfd39c838fa1ff99cf82/python/libcudf/libcudf/load.py#L40-L43

But don't explicitly declare a dependency on it. This fixes that.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
