### PR TITLE
Fix parquet prefetch test wrapper signature

### DIFF
--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -167,9 +167,13 @@ def test_prefetch_skips_paths_cached_by_stats_collection(
     fetched_paths: list[str] = []
     real_prefetch = io_module._prefetch_parquet_footers_for_paths
 
-    def recording_prefetch(paths_arg: list[str]) -> list:
+    def recording_prefetch(
+        paths_arg: list[str], *, parse_hybrid_metadata: bool = False
+    ) -> list:
         fetched_paths.extend(paths_arg)
-        return real_prefetch(paths_arg)
+        return real_prefetch(
+            paths_arg, parse_hybrid_metadata=parse_hybrid_metadata
+        )
 
     monkeypatch.setattr(
         io_module, "_prefetch_parquet_footers_for_paths", recording_prefetch

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -171,9 +171,7 @@ def test_prefetch_skips_paths_cached_by_stats_collection(
         paths_arg: list[str], *, parse_hybrid_metadata: bool = False
     ) -> list:
         fetched_paths.extend(paths_arg)
-        return real_prefetch(
-            paths_arg, parse_hybrid_metadata=parse_hybrid_metadata
-        )
+        return real_prefetch(paths_arg, parse_hybrid_metadata=parse_hybrid_metadata)
 
     monkeypatch.setattr(
         io_module, "_prefetch_parquet_footers_for_paths", recording_prefetch


### PR DESCRIPTION
## Description

Fix `test_prefetch_skips_paths_cached_by_stats_collection` so its monkeypatched prefetch wrapper accepts and forwards the keyword-only `parse_hybrid_metadata` argument.

This is an integration regression between #23677 and #23855: #23855 was tested before #23677 expanded the helper signature, then merged afterwards. The resulting combination made unrelated PRs fail in `ci/test_python_other.sh` with `TypeError: ...recording_prefetch() got an unexpected keyword argument 'parse_hybrid_metadata'`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.