### PR TITLE
Fix streaming builds with RAPIDS MPF stream pools

### DIFF
--- a/cpp/libcudf_streaming/benchmarks/bench_shuffle.cpp
+++ b/cpp/libcudf_streaming/benchmarks/bench_shuffle.cpp
@@ -507,13 +507,12 @@ int main(int argc, char** argv)
                     std::runtime_error);
   auto pinned_pool_properties =
     args.pinned_mem_disable ? rapidsmpf::PinnedMemoryDisabled : rapidsmpf::PinnedPoolProperties{};
-  auto br = rapidsmpf::BufferResource::create(
-    rmm_mr,
-    std::move(pinned_pool_properties),
-    std::move(memory_limits),
-    std::chrono::milliseconds{1},
-    std::make_shared<rmm::cuda_stream_pool>(16, rmm::cuda_stream::flags::non_blocking),
-    stats);
+  auto br = rapidsmpf::BufferResource::create(rmm_mr,
+                                              std::move(pinned_pool_properties),
+                                              std::move(memory_limits),
+                                              std::chrono::milliseconds{1},
+                                              std::make_shared<rapidsmpf::StreamPool>(16),
+                                              stats);
   // `BufferResource` wraps the device resource in an internal tracking
   // `RmmResourceAdaptor` (exposed via `device_mr_adaptor()`). Install the
   // tracking adaptor as the current device resource so libcudf temporary

--- a/cpp/libcudf_streaming/benchmarks/streaming/bench_streaming_shuffle.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/bench_streaming_shuffle.cpp
@@ -336,13 +336,12 @@ int main(int argc, char** argv)
                     std::runtime_error);
   auto pinned_pool_properties =
     args.pinned_mem_disable ? rapidsmpf::PinnedMemoryDisabled : rapidsmpf::PinnedPoolProperties{};
-  auto br = rapidsmpf::BufferResource::create(
-    rmm_mr,
-    std::move(pinned_pool_properties),
-    std::move(memory_limits),
-    std::nullopt,
-    std::make_shared<rmm::cuda_stream_pool>(16, rmm::cuda_stream::flags::non_blocking),
-    stats);
+  auto br = rapidsmpf::BufferResource::create(rmm_mr,
+                                              std::move(pinned_pool_properties),
+                                              std::move(memory_limits),
+                                              std::nullopt,
+                                              std::make_shared<rapidsmpf::StreamPool>(16),
+                                              stats);
   // `BufferResource` wraps the device resource in an internal tracking
   // `RmmResourceAdaptor` (exposed via `device_mr_adaptor()`). Install it as
   // the current device resource so libcudf temp allocations are also tracked.

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.cpp
@@ -201,8 +201,7 @@ std::pair<std::shared_ptr<streaming::Context>, std::shared_ptr<Communicator>> cr
                                    std::move(pinned_pool_properties),
                                    std::move(memory_limits),
                                    arguments.periodic_spill,
-                                   std::make_shared<rmm::cuda_stream_pool>(
-                                     arguments.num_streams, rmm::cuda_stream::flags::non_blocking),
+                                   std::make_shared<rapidsmpf::StreamPool>(arguments.num_streams),
                                    statistics);
   auto environment                     = config::get_environment_variables();
   environment["NUM_STREAMING_THREADS"] = std::to_string(arguments.num_streaming_threads);

--- a/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
@@ -36,9 +36,8 @@ class StreamingTableChunk : public BaseStreamingFixture,
     rapidsmpf::config::Options options(rapidsmpf::config::get_environment_variables());
 
     std::unordered_map<rapidsmpf::MemoryType, std::int64_t> memory_limits{};
-    auto stream_pool =
-      std::make_shared<rmm::cuda_stream_pool>(16, rmm::cuda_stream::flags::non_blocking);
-    stream = cudf::get_default_stream();
+    auto stream_pool = std::make_shared<rapidsmpf::StreamPool>(16);
+    stream           = cudf::get_default_stream();
     // Enable pinned host memory only when supported; otherwise the non-pinned
     // params still run and the PINNED_HOST cases skip in the test bodies.
     auto pinned_pool_properties = rapidsmpf::is_pinned_memory_resources_supported()


### PR DESCRIPTION
## Summary
- replace legacy rmm::cuda_stream_pool instances passed to rapidsmpf::BufferResource::create
- use rapidsmpf::StreamPool, matching the current RAPIDS MPF API
- fix libcudf-streaming benchmark and table-chunk test compilation

## Validation
- pre-commit hooks passed
- local devcontainer libcudf/libcudf-streaming build is in progress