### PR TITLE
Apply memory backpressure to the shuffle

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -128,6 +128,10 @@ class ShuffleManager:
             br = self._manager.context.br()
             # Three allocations of the chunk's packed size: the key table, the
             # reorder, then the pack.
+            #
+            # Charging the key table a whole chunk is an approximation, not a
+            # bound. A key expression that expands its input evaluates to more
+            # than the chunk's packed size and under-reserves.
             chunk_nbytes = py_split_and_pack_cost(chunk.table_view(), chunk.stream, br)
             reservation = await reserve_memory(
                 self._manager.context,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -15,16 +15,21 @@ from cudf_streaming.channel_metadata import (
 )
 from cudf_streaming.partition_utils import (
     partition_and_pack as py_partition_and_pack,
+    partition_and_pack_cost as py_partition_and_pack_cost,
     split_and_pack as py_split_and_pack,
+    split_and_pack_cost as py_split_and_pack_cost,
     unpack_and_concat as py_unpack_and_concat,
+    unpack_and_concat_cost as py_unpack_and_concat_cost,
 )
 from cudf_streaming.table_chunk import TableChunk
 from rapidsmpf.communicator.single import new_communicator as single_comm
 from rapidsmpf.config import Options, get_environment_variables
+from rapidsmpf.memory.memory_reservation import opaque_memory_usage
 from rapidsmpf.shuffler import PartitionAssignment
 from rapidsmpf.streaming.coll.shuffler import ShufflerAsync
 from rapidsmpf.streaming.core.actor import define_actor
 from rapidsmpf.streaming.core.context import Context
+from rapidsmpf.streaming.core.memory_reserve_or_wait import reserve_memory
 from rapidsmpf.streaming.core.message import Message
 
 from cudf_polars.containers import DataFrame
@@ -44,7 +49,7 @@ from cudf_polars.streaming.shuffle import Shuffle
 from cudf_polars.utils.cuda_stream import stream_ordered_after
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import AsyncGenerator
 
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.memory.packed_data import PackedData
@@ -93,49 +98,87 @@ class ShuffleManager:
         def __init__(self, manager: ShuffleManager):
             self._manager = manager
 
-        def insert_hash(
+        async def insert_hash(
             self, chunk: TableChunk, columns_to_hash: tuple[int, ...]
         ) -> None:
             """Partition chunk by hash and insert into the shuffler."""
+            br = self._manager.context.br()
+            reservation = await reserve_memory(
+                self._manager.context,
+                py_partition_and_pack_cost(chunk.table_view(), chunk.stream, br),
+                # The chunk's data moves into shuffler-owned packed buffers,
+                # nothing lasting is added.
+                net_memory_delta=0,
+            )
             self._manager.shuffler.insert(
                 py_partition_and_pack(
                     table=chunk.table_view(),
                     columns_to_hash=columns_to_hash,
                     num_partitions=self._manager.num_partitions,
                     stream=chunk.stream,
-                    br=self._manager.context.br(),
+                    br=br,
+                    reservation=reservation,
                 )
             )
 
-        def insert_hash_keys(self, chunk: TableChunk, key_table: plc.Table) -> None:
+        async def insert_hash_keys(
+            self, chunk: TableChunk, key_table: plc.Table
+        ) -> None:
             """Partition chunk by hash of a row-aligned key table and insert."""
-            partitioned_table, offsets = plc.partitioning.hash_partition(
-                chunk.table_view(),
-                key_table,
-                self._manager.num_partitions,
-                stream=chunk.stream,
+            br = self._manager.context.br()
+            # `partition_and_pack_cost` covers a reorder plus a pack, which is what
+            # the hash partitioning below and the split-and-pack after it need.
+            reservation = await reserve_memory(
+                self._manager.context,
+                py_partition_and_pack_cost(chunk.table_view(), chunk.stream, br),
+                # The chunk's data moves into shuffler-owned packed buffers,
+                # nothing lasting is added.
+                net_memory_delta=0,
             )
+            reorder_nbytes = py_split_and_pack_cost(
+                chunk.table_view(), chunk.stream, br
+            )
+            with opaque_memory_usage(reservation.split(reorder_nbytes)):
+                partitioned_table, offsets = plc.partitioning.hash_partition(
+                    chunk.table_view(),
+                    key_table,
+                    self._manager.num_partitions,
+                    stream=chunk.stream,
+                    mr=br.device_mr,
+                )
             self._manager.shuffler.insert(
                 py_split_and_pack(
                     table=partitioned_table,
                     splits=list(offsets[1:-1]),
                     stream=chunk.stream,
-                    br=self._manager.context.br(),
+                    br=br,
+                    reservation=reservation,
                 )
             )
 
-        def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
+        async def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
             """Split chunk at the given indices and insert into the shuffler."""
+            br = self._manager.context.br()
+            reservation = await reserve_memory(
+                self._manager.context,
+                py_split_and_pack_cost(chunk.table_view(), chunk.stream, br),
+                # The chunk's data moves into shuffler-owned packed buffers,
+                # nothing lasting is added.
+                net_memory_delta=0,
+            )
             self._manager.shuffler.insert(
                 py_split_and_pack(
                     table=chunk.table_view(),
                     splits=splits,
                     stream=chunk.stream,
-                    br=self._manager.context.br(),
+                    br=br,
+                    reservation=reservation,
                 )
             )
 
-        def insert_index(self, chunk: TableChunk, partition_map: TableChunk) -> None:
+        async def insert_index(
+            self, chunk: TableChunk, partition_map: TableChunk
+        ) -> None:
             """
             Partition chunk by a separate single-column partition-map and insert.
 
@@ -149,23 +192,38 @@ class ShuffleManager:
                 target partition ID for each row. Must be row-aligned with
                 ``chunk``.
             """
+            br = self._manager.context.br()
+            # As in `insert_hash_keys`, this covers the reorder plus the pack.
+            reservation = await reserve_memory(
+                self._manager.context,
+                py_partition_and_pack_cost(chunk.table_view(), chunk.stream, br),
+                # The chunk's data moves into shuffler-owned packed buffers,
+                # nothing lasting is added.
+                net_memory_delta=0,
+            )
+            reorder_nbytes = py_split_and_pack_cost(
+                chunk.table_view(), chunk.stream, br
+            )
             with stream_ordered_after(
-                self._manager.context.br().stream_pool.get_stream,
+                br.stream_pool.get_stream,
                 upstreams=(chunk.stream, partition_map.stream),
             ) as stream:
                 partition_map_col = partition_map.table_view().columns()[0]
-                reordered, offsets = plc.partitioning.partition(
-                    chunk.table_view(),
-                    partition_map_col,
-                    self._manager.num_partitions,
-                    stream=stream,
-                )
+                with opaque_memory_usage(reservation.split(reorder_nbytes)):
+                    reordered, offsets = plc.partitioning.partition(
+                        chunk.table_view(),
+                        partition_map_col,
+                        self._manager.num_partitions,
+                        stream=stream,
+                        mr=br.device_mr,
+                    )
                 self._manager.shuffler.insert(
                     py_split_and_pack(
                         table=reordered,
                         splits=list(offsets[1:-1]),
                         stream=stream,
-                        br=self._manager.context.br(),
+                        br=br,
+                        reservation=reservation,
                     )
                 )
 
@@ -206,7 +264,7 @@ class ShuffleManager:
         """Get the local partition IDs for this rank."""
         return self.shuffler.local_partitions()
 
-    def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
+    async def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
         """
         Extract a chunk from the ShuffleManager.
 
@@ -221,10 +279,19 @@ class ShuffleManager:
         -------
         The extracted table.
         """
+        partitions = self.shuffler.extract(partition_id)
+        reservation = await reserve_memory(
+            self.context,
+            py_unpack_and_concat_cost(partitions),
+            # Representation change: the packed input is consumed as the
+            # unpacked table is produced, at roughly the same size.
+            net_memory_delta=0,
+        )
         return py_unpack_and_concat(
-            partitions=self.shuffler.extract(partition_id),
+            partitions=partitions,
             stream=stream,
             br=self.context.br(),
+            reservation=reservation,
         )
 
     def extract_pieces(self, partition_id: int) -> list[PackedData]:
@@ -270,11 +337,21 @@ class LocalRepartitioner:
             shuffle.collective_id,
         )
 
-    def _iter_chunks(self, stream: Stream) -> Generator[plc.Table, None, None]:
+    async def _iter_chunks(self, stream: Stream) -> AsyncGenerator[plc.Table, None]:
         for partition_id in self._global_shuffle.local_partitions():
             for piece in self._global_shuffle.extract_pieces(partition_id):
                 # TODO: batch pieces up to target_partition_size before unpacking
-                table = py_unpack_and_concat([piece], stream=stream, br=self._br)
+                pieces = [piece]
+                reservation = await reserve_memory(
+                    self._global_shuffle.context,
+                    py_unpack_and_concat_cost(pieces),
+                    # Representation change: the packed input is consumed as the
+                    # unpacked table is produced, at roughly the same size.
+                    net_memory_delta=0,
+                )
+                table = py_unpack_and_concat(
+                    pieces, stream=stream, br=self._br, reservation=reservation
+                )
                 if table.num_rows() > 0:
                     yield table
 
@@ -292,8 +369,8 @@ class LocalRepartitioner:
             CUDA stream for the unpack operation.
         """
         async with self._local_shuffle.inserting() as inserter:
-            for table in self._iter_chunks(stream):
-                inserter.insert_hash(
+            async for table in self._iter_chunks(stream):
+                await inserter.insert_hash(
                     TableChunk.from_pylibcudf_table(
                         table, stream, exclusive_view=True, br=self._br
                     ),
@@ -322,7 +399,7 @@ class LocalRepartitioner:
             payload before inserting. If ``False``, it is kept in the output.
         """
         async with self._local_shuffle.inserting() as inserter:
-            for table in self._iter_chunks(stream):
+            async for table in self._iter_chunks(stream):
                 cols = table.columns()
                 payload = plc.Table(
                     [
@@ -332,7 +409,7 @@ class LocalRepartitioner:
                     ]
                 )
                 partition_map = plc.Table([cols[partition_col]])
-                inserter.insert_index(
+                await inserter.insert_index(
                     TableChunk.from_pylibcudf_table(
                         payload, stream, exclusive_view=True, br=self._br
                     ),
@@ -345,7 +422,7 @@ class LocalRepartitioner:
         """Return the local partition IDs."""
         return self._local_shuffle.local_partitions()
 
-    def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
+    async def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
         """
         Extract the table for *partition_id* from the local shuffle.
 
@@ -356,7 +433,7 @@ class LocalRepartitioner:
         stream
             CUDA stream for the unpack operation.
         """
-        return self._local_shuffle.extract_chunk(partition_id, stream)
+        return await self._local_shuffle.extract_chunk(partition_id, stream)
 
 
 def _key_column_indices(
@@ -465,11 +542,11 @@ async def _global_shuffle(
                     msg, br=context.br()
                 ).make_available_and_spill(context.br(), allow_overbooking=True)
                 if columns_to_hash is None:
-                    inserter.insert_hash_keys(
+                    await inserter.insert_hash_keys(
                         chunk, _evaluate_key_table(chunk, keys_to_hash, input_schema)
                     )
                 else:
-                    inserter.insert_hash(
+                    await inserter.insert_hash(
                         chunk,
                         columns_to_hash,
                     )
@@ -481,7 +558,7 @@ async def _global_shuffle(
             Message(
                 partition_id,
                 TableChunk.from_pylibcudf_table(
-                    table=shuffle.extract_chunk(partition_id, stream),
+                    table=await shuffle.extract_chunk(partition_id, stream),
                     stream=stream,
                     exclusive_view=True,
                     br=context.br(),

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -122,23 +122,23 @@ class ShuffleManager:
             )
 
         async def insert_hash_keys(
-            self, chunk: TableChunk, key_table: plc.Table
+            self, chunk: TableChunk, keys: tuple[NamedExpr, ...], schema: Schema
         ) -> None:
-            """Partition chunk by hash of a row-aligned key table and insert."""
+            """Partition chunk by hash of ``keys`` evaluated over it, and insert."""
             br = self._manager.context.br()
-            # `partition_and_pack_cost` covers a reorder plus a pack, which is what
-            # the hash partitioning below and the split-and-pack after it need.
+            # Three allocations of the chunk's packed size: the key table, the
+            # reorder, then the pack.
+            chunk_nbytes = py_split_and_pack_cost(chunk.table_view(), chunk.stream, br)
             reservation = await reserve_memory(
                 self._manager.context,
-                py_partition_and_pack_cost(chunk.table_view(), chunk.stream, br),
+                3 * chunk_nbytes,
                 # The chunk's data moves into shuffler-owned packed buffers,
                 # nothing lasting is added.
                 net_memory_delta=0,
             )
-            reorder_nbytes = py_split_and_pack_cost(
-                chunk.table_view(), chunk.stream, br
-            )
-            with opaque_memory_usage(reservation.split(reorder_nbytes)):
+            with opaque_memory_usage(reservation.split(chunk_nbytes)):
+                key_table = _evaluate_key_table(chunk, keys, schema)
+            with opaque_memory_usage(reservation.split(chunk_nbytes)):
                 partitioned_table, offsets = plc.partitioning.hash_partition(
                     chunk.table_view(),
                     key_table,
@@ -542,9 +542,7 @@ async def _global_shuffle(
                     msg, br=context.br()
                 ).make_available_and_spill(context.br(), allow_overbooking=True)
                 if columns_to_hash is None:
-                    await inserter.insert_hash_keys(
-                        chunk, _evaluate_key_table(chunk, keys_to_hash, input_schema)
-                    )
+                    await inserter.insert_hash_keys(chunk, keys_to_hash, input_schema)
                 else:
                     await inserter.insert_hash(
                         chunk,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/sort.py
@@ -605,7 +605,7 @@ async def _insert_chunks_into_shuffle(
                 stream=stream,
                 chunk_relative=True,
             )
-            inserter.insert_split(available_chunk, splits)
+            await inserter.insert_split(available_chunk, splits)
 
     post_sort_ir = ir
     if ir.stable:
@@ -641,7 +641,7 @@ async def _extract_partitions_and_send(
     ncols_out = len(output_schema)
     for partition_id in shuffle.local_partitions():
         stream = ir_context.get_cuda_stream()
-        table = shuffle.extract_chunk(partition_id, stream)
+        table = await shuffle.extract_chunk(partition_id, stream)
         if table.num_rows() > 0:
             table = post_sort_ir.do_evaluate(
                 *post_sort_ir._non_child_args,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/groupby.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/groupby.py
@@ -409,7 +409,7 @@ async def _shuffle_reduce(
         collective_id,
     )
     async with shuffle.inserting() as inserter:
-        inserter.insert_hash(
+        await inserter.insert_hash(
             _enforce_schema(
                 aggregated,
                 decomposed.reduction_ir.schema,
@@ -427,7 +427,7 @@ async def _shuffle_reduce(
                 ch_in,
                 target_partition_size,
             )
-            inserter.insert_hash(
+            await inserter.insert_hash(
                 _enforce_schema(
                     aggregated, decomposed.reduction_ir.schema, context.br()
                 ),
@@ -440,7 +440,7 @@ async def _shuffle_reduce(
     for partition_id in shuffle.local_partitions():
         stream = ir_context.get_cuda_stream()
         partition_chunk = TableChunk.from_pylibcudf_table(
-            shuffle.extract_chunk(partition_id, stream),
+            await shuffle.extract_chunk(partition_id, stream),
             stream,
             exclusive_view=True,
             br=context.br(),

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -327,31 +327,29 @@ def _evaluate_window_with_stamps(
     return result.with_columns(stamp_cols, stream=stream)
 
 
-def _partition_by_origin_rank(
+def _split_off_origin_rank(
     result: DataFrame,
-    num_ranks: int,
     br: Any,
-) -> tuple[TableChunk | None, list[int]]:
+) -> tuple[TableChunk, TableChunk] | None:
     """
-    Rearrange rows so partition i contains rows whose origin rank is i.
+    Split the origin-rank stamp off the evaluated result.
 
-    Returns a chunk with the rank stamp dropped and the per-rank split
-    indices for direct insertion into the return shuffle.
+    Returns the payload and the single-column rank map that routes each row
+    back to its origin, or ``None`` when there is nothing to route. The
+    rearrangement itself is left to ``insert_index``, which reserves for it.
     """
     if result.table.num_rows() == 0:
-        return None, []
+        return None
 
     stream = result.stream
     columns = result.table.columns()
-    rank_column = columns[-1]
-    payload = plc.Table(columns[:-1])
-
-    rearranged, offsets = plc.partitioning.partition(
-        payload, rank_column, num_ranks, stream=stream
-    )
     return (
-        TableChunk.from_pylibcudf_table(rearranged, stream, exclusive_view=True, br=br),
-        list(offsets[1:-1]),
+        TableChunk.from_pylibcudf_table(
+            plc.Table(columns[:-1]), stream, exclusive_view=True, br=br
+        ),
+        TableChunk.from_pylibcudf_table(
+            plc.Table([columns[-1]]), stream, exclusive_view=True, br=br
+        ),
     )
 
 
@@ -517,7 +515,7 @@ async def _distribute_by_group(
                     ir_context.get_cuda_stream(),
                     context.br(),
                 )
-                inserter.insert_hash(stamped, key_indices)
+                await inserter.insert_hash(stamped, key_indices)
             chunk_index += 1
     return sequence_numbers
 
@@ -528,7 +526,6 @@ async def _evaluate_and_route_to_origin(
     ir_context: IRExecutionContext,
     forward_shuffle: ShuffleManager,
     return_shuffle: ShuffleManager,
-    num_ranks: int,
     stamps: OriginStamps,
     *,
     sort_by_input_order: bool,
@@ -537,7 +534,7 @@ async def _evaluate_and_route_to_origin(
     async with return_shuffle.inserting() as inserter:
         for partition_id in forward_shuffle.local_partitions():
             stream = ir_context.get_cuda_stream()
-            extracted = forward_shuffle.extract_chunk(partition_id, stream)
+            extracted = await forward_shuffle.extract_chunk(partition_id, stream)
             if extracted.num_rows() == 0:
                 continue
             partition = TableChunk.from_pylibcudf_table(
@@ -551,11 +548,11 @@ async def _evaluate_and_route_to_origin(
                 stamps,
                 sort_by_input_order=sort_by_input_order,
             )
-            routed, splits = await ir_context.to_thread(
-                _partition_by_origin_rank, evaluated, num_ranks, context.br()
+            routed = await ir_context.to_thread(
+                _split_off_origin_rank, evaluated, context.br()
             )
             if routed is not None:
-                inserter.insert_split(routed, splits)
+                await inserter.insert_index(*routed)
 
 
 async def _reassemble_input_chunks(
@@ -588,7 +585,7 @@ async def _reassemble_input_chunks(
         # Distinct stream per chunk so downstream work on different
         # chunks can overlap on the GPU.
         stream = ir_context.get_cuda_stream()
-        tbl = local.extract_chunk(chunk_index, stream)
+        tbl = await local.extract_chunk(chunk_index, stream)
         if tbl.num_rows() == 0:
             chunk = empty_table_chunk(ir, context, stream)
         else:
@@ -683,7 +680,6 @@ async def _shuffle_and_reassemble(
         ir_context,
         forward_shuffle,
         return_shuffle,
-        comm.nranks,
         stamps,
         sort_by_input_order=sort_by_input_order,
     )

--- a/python/cudf_polars/tests/streaming/test_shuffler.py
+++ b/python/cudf_polars/tests/streaming/test_shuffler.py
@@ -144,70 +144,32 @@ def test_join_asymmetric_non_col_keys_rapidsmpf(
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 
-def test_is_already_partitioned():
-    # Unit test for _is_already_partitioned helper
-    chunks = 4
-    columns = (0, 1)
-    modulus = 8
-    nranks = 1
+def _partitioning(columns=(0, 1), modulus=8, local="inherit"):
+    """The partitioning `test_is_already_partitioned` queries for, unless overridden."""
+    return Partitioning(inter_rank=HashScheme(columns, modulus), local=local)
 
-    # Exact match: should return True
-    metadata_match = ChannelMetadata(
-        chunks,
-        partitioning=Partitioning(
-            inter_rank=HashScheme(columns, modulus),
-            local="inherit",
-        ),
-    )
-    assert _is_already_partitioned(metadata_match, columns, modulus, nranks) is True
 
-    # Different columns: should return False
-    metadata_diff_cols = ChannelMetadata(
-        chunks,
-        partitioning=Partitioning(
-            inter_rank=HashScheme((0,), modulus),
-            local="inherit",
+@pytest.mark.parametrize(
+    "partitioning,expected",
+    [
+        pytest.param(_partitioning(), True, id="exact-match"),
+        pytest.param(_partitioning(columns=(0,)), False, id="different-columns"),
+        pytest.param(_partitioning(modulus=16), False, id="different-modulus"),
+        pytest.param(_partitioning(local=None), False, id="local-none"),
+        pytest.param(
+            _partitioning(local=HashScheme((0,), 4)), False, id="local-not-inherit"
         ),
-    )
+        pytest.param(None, False, id="no-partitioning"),
+    ],
+)
+def test_is_already_partitioned(partitioning, expected):
+    metadata = ChannelMetadata(4, partitioning=partitioning)
     assert (
-        _is_already_partitioned(metadata_diff_cols, columns, modulus, nranks) is False
+        _is_already_partitioned(
+            metadata, columns_to_hash=(0, 1), num_partitions=8, nranks=1
+        )
+        is expected
     )
-
-    # Different local partitioning: should return False
-    metadata_diff_local = ChannelMetadata(
-        chunks,
-        partitioning=Partitioning(
-            inter_rank=HashScheme(columns, modulus),
-            local=None,
-        ),
-    )
-    assert (
-        _is_already_partitioned(metadata_diff_local, columns, modulus, nranks) is False
-    )
-
-    # Different modulus: should return False
-    metadata_diff_mod = ChannelMetadata(
-        chunks,
-        partitioning=Partitioning(
-            inter_rank=HashScheme(columns, 16),
-            local="inherit",
-        ),
-    )
-    assert _is_already_partitioned(metadata_diff_mod, columns, modulus, nranks) is False
-
-    # No partitioning: should return False
-    metadata_none = ChannelMetadata(chunks)
-    assert _is_already_partitioned(metadata_none, columns, modulus, nranks) is False
-
-    # Local not "inherit": should return False
-    metadata_local = ChannelMetadata(
-        chunks,
-        partitioning=Partitioning(
-            inter_rank=HashScheme(columns, modulus),
-            local=HashScheme((0,), 4),
-        ),
-    )
-    assert _is_already_partitioned(metadata_local, columns, modulus, nranks) is False
 
 
 @pytest.mark.spmd
@@ -230,7 +192,7 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
                 context, comm, num_partitions=comm.nranks, collective_id=op_id
             )
             async with shuffle.inserting() as inserter:
-                inserter.insert_hash(
+                await inserter.insert_hash(
                     TableChunk.from_pylibcudf_table(
                         cudf_df.table, stream, exclusive_view=True, br=context.br()
                     ),
@@ -241,7 +203,7 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
             await local.repartition_by_hash(columns_to_hash=(0,), stream=stream)
 
             for pid in local.local_partitions():
-                tbl = local.extract_chunk(pid, stream)
+                tbl = await local.extract_chunk(pid, stream)
                 results.append(
                     (
                         pid,
@@ -298,7 +260,7 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
                 context, comm, num_partitions=comm.nranks, collective_id=op_id
             )
             async with shuffle.inserting() as inserter:
-                inserter.insert_index(
+                await inserter.insert_index(
                     TableChunk.from_pylibcudf_table(
                         payload_df.table, stream, exclusive_view=True, br=context.br()
                     ),
@@ -311,7 +273,7 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
             await local.repartition_by_index(partition_col=0, stream=stream)
 
             for pid in local.local_partitions():
-                tbl = local.extract_chunk(pid, stream)
+                tbl = await local.extract_chunk(pid, stream)
                 results.append(
                     (
                         pid,


### PR DESCRIPTION
The shuffle now takes its device memory from `reserve_memory()` on both sides, the four `ShuffleManager.Inserter` methods going in and `extract_chunk` coming out, so a request that cannot be satisfied queues alongside the other actors' and is served by priority. Before this both let the C++ side reserve and spill internally. cudf-polars already reserves this way for scans in `actor_graph/io.py`.

### Breaking change

The insert methods and `extract_chunk` are coroutines now, and `LocalRepartitioner._iter_chunks` is an async generator. That updates twenty-one call sites across `groupby.py`, `over.py`, `sort.py`, `shuffle.py` and the shuffler tests.

### Notes

Reserving inside the insert methods rather than at the call sites keeps the accounting in one place. That matters for `insert_hash_keys` and `insert_index`, whose Python-side reorder allocates a full table copy that nothing reserved before. They reserve `partition_and_pack_cost()`, which covers a reorder plus a pack, consume the reorder's share once it lands, and hand the remainder to `split_and_pack()`.

The cost functions call `cudf::packed_size()`, which syncs the stream, and they run on the actor event loop. `insert_hash` and `insert_split` add one sync per chunk, `insert_hash_keys` and `insert_index` two, since they size the reorder separately from the pack. Passing a `packed_bytes` hint through the Cython layer would remove the second one, and `partition_and_pack` already takes that hint in C++.

`_iter_chunks` reserves per piece, so the `TODO` there about batching pieces up to `target_partition_size` would cut the reservation traffic as well as the unpack overhead.
