### PR TITLE
Extend Parquet reader output_dict_columns to fixed-width columns and sized indices

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -297,7 +297,8 @@ ConfigureNVBench(
 # * parquet reader benchmark ----------------------------------------------------------------------
 ConfigureNVBench(
   PARQUET_READER_NVBENCH io/parquet/parquet_reader_input.cpp io/parquet/parquet_reader_encoding.cpp
-  io/parquet/parquet_reader_options.cpp io/parquet/reader_common.cpp
+  io/parquet/parquet_reader_options.cpp io/parquet/parquet_reader_dict_transcode.cpp
+  io/parquet/reader_common.cpp
 )
 
 # ##################################################################################################

--- a/cpp/benchmarks/io/parquet/parquet_reader_dict_transcode.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_dict_transcode.cpp
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/io/cuio_common.hpp>
+#include <benchmarks/io/nvbench_helpers.hpp>
+
+#include <cudf/io/parquet.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+// Size of the data in the benchmark dataframe; chosen to be low enough to allow benchmarks to
+// run on most GPUs, but large enough to allow highest throughput
+constexpr std::size_t data_size = 512 << 20;
+
+// Measures reads of dictionary-encoded low-cardinality columns with and without the direct
+// Parquet-dictionary -> DICTIONARY32 transcode (`output_dict_columns`), over the column types the
+// fast path accepts: flat strings and flat fixed-width INT32/INT64/TIMESTAMP_DAYS columns.
+template <output_dict OutputDict>
+void BM_parquet_read_dict_transcode(nvbench::state& state,
+                                    nvbench::type_list<nvbench::enum_type<OutputDict>>)
+{
+  auto constexpr output_dict_columns = OutputDict == output_dict::YES;
+
+  auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
+  auto const run_length  = static_cast<cudf::size_type>(state.get_int64("run_length"));
+
+  auto const data_types = std::vector<cudf::type_id>{cudf::type_id::INT32,
+                                                     cudf::type_id::INT64,
+                                                     cudf::type_id::TIMESTAMP_DAYS,
+                                                     cudf::type_id::STRING};
+  data_profile const profile =
+    data_profile_builder().cardinality(cardinality).avg_run_length(run_length);
+  auto const tbl  = create_random_table(data_types, table_size_bytes{data_size}, profile);
+  auto const view = tbl->view();
+
+  cuio_source_sink_pair source_sink(io_type::HOST_BUFFER);
+  auto const write_options =
+    cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
+      .dictionary_policy(cudf::io::dictionary_policy::ALWAYS)
+      .build();
+  cudf::io::write_parquet(write_options);
+
+  cudf::io::parquet_reader_options read_options =
+    cudf::io::parquet_reader_options::builder(source_sink.make_source_info())
+      .output_dict_columns(output_dict_columns)
+      .build();
+
+  auto mem_stats_logger = cudf::memory_stats_logger();
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
+  state.exec(
+    nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
+      drop_page_cache_if_enabled(read_options.get_source().filepaths());
+      timer.start();
+      auto const result = cudf::io::read_parquet(read_options);
+      timer.stop();
+      CUDF_EXPECTS(result.tbl->num_rows() == view.num_rows(),
+                   "Benchmark did not read the entire table");
+      CUDF_EXPECTS(result.tbl->num_columns() == view.num_columns(), "Unexpected number of columns");
+    });
+
+  auto const elapsed_time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  state.add_element_count(static_cast<double>(data_size) / elapsed_time, "bytes_per_second");
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+  state.add_buffer_size(source_sink.size(), "encoded_file_size", "encoded_file_size");
+}
+
+NVBENCH_BENCH_TYPES(BM_parquet_read_dict_transcode,
+                    NVBENCH_TYPE_AXES(nvbench::enum_type_list<output_dict::NO, output_dict::YES>))
+  .set_name("parquet_read_dict_transcode")
+  .set_type_axes_names({"output_dict_columns"})
+  .set_min_samples(4)
+  .add_int64_axis("cardinality", {1000})
+  .add_int64_axis("run_length", {4});

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -658,9 +658,11 @@ class parquet_reader_options {
   void enable_prepend_row_index_column(bool val) { _prepend_row_index_column = val; }
 
   /**
-   * @brief Sets to enable/disable trying to output DICTIONARY32 columns for flat string columns.
+   * @brief Sets to enable/disable trying to output DICTIONARY32 columns for eligible flat string
+   * and fixed-width columns (see is_enabled_output_dict_columns for eligibility and fallback
+   * behavior).
    *
-   * @param val Boolean indicating whether to output DICTIONARY32 columns for flat string columns
+   * @param val Boolean indicating whether to output eligible flat columns as DICTIONARY32
    */
   void enable_output_dict_columns(bool val) { _output_dict_columns = val; }
 };
@@ -962,13 +964,17 @@ class parquet_reader_options_builder {
   }
 
   /**
-   * @brief Sets options for enabling/disabling output of DICTIONARY32 columns for flat string
-   * columns.
+   * @brief Sets options for enabling/disabling output of DICTIONARY32 columns for eligible flat
+   * string and fixed-width columns.
    *
-   * @param val Boolean value whether to output flat string columns as DICTIONARY32 encoded columns
+   * @param val Boolean value whether to output eligible flat columns as DICTIONARY32 encoded
+   * columns
    *
-   * @note When enabled, the output columns will be of type DICTIONARY32. When disabled, the output
-   * columns will be of type STRING.
+   * @note When enabled, eligible columns are returned as DICTIONARY32 with a signed integer
+   * indices child sized to the dictionary and a keys child of the logical type; string columns
+   * are always delivered as DICTIONARY32 (post-read encoded when the direct path does not apply),
+   * while fixed-width columns fall back to their plain type
+   * (see parquet_reader_options::is_enabled_output_dict_columns).
    *
    * @return this for chaining
    */

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -343,16 +343,23 @@ class parquet_reader_options {
   }
 
   /**
-   * @brief Returns whether the reader returns flat string columns as DICTIONARY32 encoded columns
+   * @brief Returns whether the reader returns flat string and fixed-width columns as DICTIONARY32
+   * encoded columns
    *
-   * When true, the reader outputs STRING columns as DICTIONARY32 encoded columns. A DICTIONARY32
-   * column consists of an INT32 indices child and a STRING keys child.
+   * When true, the reader outputs eligible flat columns as DICTIONARY32 encoded columns: a signed
+   * integer indices child (INT8/INT16/INT32, sized to the largest row-group dictionary with the
+   * same width rule as cudf::dictionary::encode) plus a keys child of the column's logical type.
+   * Eligible are flat STRING columns and flat fixed-width columns whose physical storage is INT32
+   * or INT64 and whose decode is a plain copy (no decimal, timestamp-unit, or width conversion),
+   * when every data page of the column is dictionary encoded.
    *
    * When AST/JIT filters are set, the direct transcode fast path is disabled.
-   * String columns are materialized, then operated on by the filter. The filtered results are then
-   * encoded as DICTIONARY32 columns.
+   * String columns are materialized, then operated on by the filter, and the filtered results are
+   * encoded as DICTIONARY32 columns. Fixed-width columns participate only in the direct fast path
+   * and are returned as plain columns whenever it does not apply (filters, chunked or bounded
+   * reads, or pages that are not dictionary encoded).
    *
-   * @return `true` if the reader returns flat string columns as DICTIONARY32 encoded columns
+   * @return `true` if the reader returns eligible flat columns as DICTIONARY32 encoded columns
    */
   [[nodiscard]] bool is_enabled_output_dict_columns() const { return _output_dict_columns; }
 

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -86,7 +86,8 @@ __device__ static void scan_block_exclusive_sum(
  * @brief Write a batch of decoded dictionary indices directly as INT32 output values.
  *
  * Used by the Parquet-dict → DICTIONARY32 transcode path: instead of materializing the dictionary
- * keys, the per-row dictionary indices are emitted verbatim as the INT32 indices child of the
+ * keys, the per-row dictionary indices are emitted verbatim as the signed integer indices child
+ * (INT8/INT16/INT32, per the chunk's dict_index_bytes) of the
  * output DICTIONARY32 column.
  *
  * @tparam block_size Number of threads per block
@@ -133,13 +134,23 @@ __device__ void decode_dict_indices_as_int32(
         return thread_pos;
       }();
 
-      auto* dst           = reinterpret_cast<int32_t*>(data_out) + dst_pos;
-      auto const num_keys = static_cast<uint32_t>(s->stream.dict_size / sizeof(string_index_pair));
-      auto const idx      = sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)];
+      auto* dst = reinterpret_cast<int32_t*>(data_out) + dst_pos;
+      // string chunks index a string_index_pair table; fixed-width chunks index the raw
+      // dictionary page, whose entries are the physical value width
+      auto const entry_size = s->setup.col.physical_type == Type::BYTE_ARRAY
+                                ? sizeof(string_index_pair)
+                                : static_cast<size_t>(s->output_cvt.dtype_len_in);
+      auto const num_keys   = static_cast<uint32_t>(s->stream.dict_size / entry_size);
+      auto const idx        = sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)];
       if (idx >= num_keys) {
         s->set_error_code(decode_error::DATA_STREAM_OVERRUN);
       } else {
-        *dst = idx;
+        // the index width follows dictionary::get_indices_type_for_size for the key count
+        switch (s->output_cvt.dtype_len) {
+          case 1: reinterpret_cast<int8_t*>(data_out)[dst_pos] = static_cast<int8_t>(idx); break;
+          case 2: reinterpret_cast<int16_t*>(data_out)[dst_pos] = static_cast<int16_t>(idx); break;
+          default: *dst = idx; break;
+        }
       }
     }
 
@@ -1306,7 +1317,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   if constexpr (has_strings_t || has_lists_t || is_dict_int32_t) {
     if (process_nulls) {
       uint32_t const dtype_len = [&]() -> uint32_t {
-        if constexpr (is_dict_int32_t) { return sizeof(int32_t); }
+        if constexpr (is_dict_int32_t) { return s->setup.col.dict_index_bytes; }
         if constexpr (has_strings_t) { return sizeof(cudf::size_type); }
         return s->output_cvt.dtype_len;
       }();

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -83,7 +83,7 @@ __device__ static void scan_block_exclusive_sum(
 }
 
 /**
- * @brief Write a batch of decoded dictionary indices directly as INT32 output values.
+ * @brief Write a batch of decoded dictionary indices directly as signed integer output values.
  *
  * Used by the Parquet-dict → DICTIONARY32 transcode path: instead of materializing the dictionary
  * keys, the per-row dictionary indices are emitted verbatim as the signed integer indices child
@@ -134,7 +134,6 @@ __device__ void decode_dict_indices_as_int32(
         return thread_pos;
       }();
 
-      auto* dst = reinterpret_cast<int32_t*>(data_out) + dst_pos;
       // string chunks index a string_index_pair table; fixed-width chunks index the raw
       // dictionary page, whose entries are the physical value width
       auto const entry_size = s->setup.col.physical_type == Type::BYTE_ARRAY
@@ -149,7 +148,7 @@ __device__ void decode_dict_indices_as_int32(
         switch (s->output_cvt.dtype_len) {
           case 1: reinterpret_cast<int8_t*>(data_out)[dst_pos] = static_cast<int8_t>(idx); break;
           case 2: reinterpret_cast<int16_t*>(data_out)[dst_pos] = static_cast<int16_t>(idx); break;
-          default: *dst = idx; break;
+          default: reinterpret_cast<int32_t*>(data_out)[dst_pos] = idx; break;
         }
       }
     }

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -1257,6 +1257,12 @@ inline __device__ bool setup_local_page_info(auto* const s,
         } else if (data_type == Type::INT96) {
           s->output_cvt.dtype_len = 8;  // Convert to 64-bit timestamp
         }
+        // Parquet-dict -> DICTIONARY32 transcode: the output holds dictionary indices, so both
+        // the per-page output offset and the value width follow the index width, not the
+        // logical type width. (String pages coincidentally match via the string special case.)
+        if (s->setup.page.kernel_mask == decode_kernel_mask::DICT_INT32) {
+          s->output_cvt.dtype_len = s->setup.col.dict_index_bytes;
+        }
       }
 
       // during the decoding step we need to offset the global output buffers
@@ -1301,7 +1307,10 @@ inline __device__ bool setup_local_page_info(auto* const s,
                   idx < max_depth - 1 ? sizeof(cudf::size_type) : s->output_cvt.dtype_len;
                 // if this is a string column, then dtype_len is a lie. data will be offsets rather
                 // than (ptr,len) tuples.
-                if (is_string_col(s->setup.col)) { len = sizeof(cudf::size_type); }
+                if (is_string_col(s->setup.col) &&
+                    s->setup.page.kernel_mask != decode_kernel_mask::DICT_INT32) {
+                  len = sizeof(cudf::size_type);
+                }
                 nesting_info->data_out += (output_offset * len);
               }
               if (nesting_info->string_out != nullptr) {

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -257,7 +257,8 @@ enum class decode_kernel_mask {
   STRING_STREAM_SPLIT_NESTED =
     (1 << 24),  // Run decode kernel for nested BYTE_STREAM_SPLIT string data
   STRING_STREAM_SPLIT_LIST = (1 << 25),  // Run decode kernel for list BYTE_STREAM_SPLIT string data
-  DICT_INT32               = (1 << 26),  // Run decode kernel for dict string → INT32 indices
+  DICT_INT32               = (1 << 26),  // Emit dictionary indices (string or fixed-width chunks)
+                                         // as a signed integer column; name predates sized indices
 };
 
 constexpr uint32_t STRINGS_MASK_NON_DELTA = BitOr(decode_kernel_mask::STRING,
@@ -510,9 +511,10 @@ struct ColumnChunkDesc {
 
   float list_bytes_per_row_est{};  // for LIST columns, an estimate on number of bytes per row
 
-  bool is_strings_to_cat{};    // convert strings to hashes
-  bool is_large_string_col{};  // `true` if string data uses 64-bit offsets
-  int32_t src_file_idx{};      // source file index
+  bool is_strings_to_cat{};     // convert strings to hashes
+  uint8_t dict_index_bytes{4};  // width of the emitted dictionary index for DICT_INT32 (1/2/4)
+  bool is_large_string_col{};   // `true` if string data uses 64-bit offsets
+  int32_t src_file_idx{};       // source file index
 };
 
 /**

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -768,7 +768,8 @@ table_with_metadata reader_impl::read_chunk_internal(read_mode mode)
   }
 
   // For any columns that were selected for direct parquet-dict → DICTIONARY32 transcode in
-  // `prepare_dict_transcode`, the entries in `out_columns` are currently INT32 indices columns.
+  // `prepare_dict_transcode`, the entries in `out_columns` are currently signed integer indices
+  // columns (INT8/INT16/INT32, sized to the dictionary).
   // Assemble them into DICTIONARY32 columns here by attaching per-chunk keys; concatenate
   // remaps indices to the unified keys child.
   assemble_dict_transcoded_columns(out_columns);

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -602,6 +602,9 @@ class reader_impl {
   // Per-input-column flag indicating whether that column was selected for direct
   // Parquet-dict → DICTIONARY32 transcode.
   std::vector<bool> _dict_transcode_eligible;
+  // Per input column: the logical output type of a column selected for direct transcode
+  // (the DICTIONARY32 keys type); EMPTY when the column is not transcoded.
+  std::vector<data_type> _dict_transcode_key_types;
 };
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -8,6 +8,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/concatenate.hpp>
+#include <cudf/detail/unary.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
@@ -18,7 +20,10 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
@@ -29,6 +34,7 @@
 #include <algorithm>
 #include <functional>
 #include <numeric>
+#include <type_traits>
 #include <vector>
 
 namespace cudf::io::parquet::detail {
@@ -51,15 +57,38 @@ namespace {
 }
 
 /**
+ * @brief Whether a column chunk is a flat fixed-width chunk whose decode is a plain copy of the
+ * physical values (no decimal, timestamp-unit, or width conversion), so its dictionary page holds
+ * the output values verbatim.
+ *
+ * @param chunk The column chunk descriptor to classify
+ * @param out_type The current output buffer type of the chunk's column
+ * @return True if the chunk's dictionary page entries are `out_type` values as stored
+ */
+[[nodiscard]] bool is_fixed_width_dict_chunk(ColumnChunkDesc const& chunk, data_type out_type)
+{
+  if (chunk.physical_type != Type::INT32 and chunk.physical_type != Type::INT64) { return false; }
+  if (chunk.logical_type.has_value() and chunk.logical_type->type == LogicalType::DECIMAL) {
+    return false;
+  }
+  // a non-zero clock rate means the decode rescales timestamp values
+  if (chunk.ts_clock_rate != 0) { return false; }
+  if (not cudf::is_fixed_width(out_type)) { return false; }
+  auto const physical_size = chunk.physical_type == Type::INT32 ? std::size_t{4} : std::size_t{8};
+  return cudf::size_of(out_type) == physical_size;
+}
+
+/**
  * @brief Per-input-column eligibility flags for Parquet-dict → DICTIONARY32 transcode.
  *
  * Each column must satisfy all of these conditions to be eligible for direct transcode.
  */
 struct column_eligibility {
-  bool has_string_buffer = false;  ///< Output buffer is currently typed as STRING
-  bool has_any_chunk     = false;  ///< At least one chunk was seen for this column
-  bool all_chunks_string = true;   ///< Every chunk is a flat BYTE_ARRAY string chunk with a dict
-  bool all_pages_dict    = true;   ///< Every data page uses a dictionary encoding
+  data_type key_type{type_id::EMPTY};    ///< Logical output type; the DICTIONARY32 keys type
+  bool has_transcodable_buffer = false;  ///< Output buffer is a flat STRING or fixed-width column
+  bool has_any_chunk           = false;  ///< At least one chunk was seen for this column
+  bool all_chunks_eligible = true;  ///< Every chunk is a flat dictionary chunk of the buffer type
+  bool all_pages_dict      = true;  ///< Every data page uses a dictionary encoding
 
   /**
    * @brief Whether the column satisfies every transcode-eligibility condition.
@@ -68,7 +97,7 @@ struct column_eligibility {
    */
   [[nodiscard]] bool is_eligible() const
   {
-    return has_string_buffer and has_any_chunk and all_chunks_string and all_pages_dict;
+    return has_transcodable_buffer and has_any_chunk and all_chunks_eligible and all_pages_dict;
   }
 };
 
@@ -80,10 +109,13 @@ struct column_eligibility {
  */
 void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
 {
-  e.has_any_chunk = true;
+  e.has_any_chunk                 = true;
+  bool const chunk_matches_buffer = e.key_type.id() == type_id::STRING
+                                      ? is_byte_array_string_chunk(chunk)
+                                      : is_fixed_width_dict_chunk(chunk, e.key_type);
   if (chunk.max_nesting_depth != 1 or chunk.max_level[level_type::REPETITION] != 0 or
-      not is_byte_array_string_chunk(chunk) or chunk.num_dict_pages < 1) {
-    e.all_chunks_string = false;
+      not chunk_matches_buffer or chunk.num_dict_pages < 1) {
+    e.all_chunks_eligible = false;
   }
 }
 
@@ -109,12 +141,17 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
   auto const num_input_cols = input_columns.size();
   std::vector<column_eligibility> elig(num_input_cols);
 
-  // Mark columns whose output buffer is a flat string column.
+  // Mark columns whose output buffer is a flat string or fixed-width column, and record the
+  // buffer's logical type: it becomes the DICTIONARY32 keys type.
   std::transform(
     input_columns.begin(), input_columns.end(), elig.begin(), [&](input_column_info const& col) {
       column_eligibility e{};
-      e.has_string_buffer =
-        col.nesting_depth() == 1 and output_buffers[col.nesting[0]].type.id() == type_id::STRING;
+      if (col.nesting_depth() != 1) { return e; }
+      auto const out_type = output_buffers[col.nesting[0]].type;
+      e.has_transcodable_buffer =
+        out_type.id() == type_id::STRING or
+        (cudf::is_fixed_width(out_type) and out_type.id() != type_id::BOOL8);
+      if (e.has_transcodable_buffer) { e.key_type = out_type; }
       return e;
     });
 
@@ -183,18 +220,20 @@ struct stacked_key_gather_fn {
  * that index to point at the correct entry in the compact, unique keys column. Done in place, in
  * one pass over the rows, in lieu of `cudf::dictionary::detail::concatenate`.
  *
- * @param indices INT32 index buffer (one entry per row), mutated in place
+ * @tparam Index Signed integer index type
+ * @param indices Signed integer index buffer (one entry per row), mutated in place
  * @param row_offsets Per-chunk row boundaries `[offsets[k], offsets[k+1])`, size num_chunks+1
  * @param key_counts_prefix Per-chunk key-prefix offsets into the stacked key space, size
  * num_chunks+1
  * @param stacked_to_unique Map from stacked-key position to compact unique-key index
  * @param stream CUDA stream used for the kernel launch
  */
-void remap_dict_indices_by_chunk(cudf::device_span<int32_t> indices,
+template <typename Index>
+void remap_dict_indices_by_chunk(cudf::device_span<Index> indices,
                                  cudf::device_span<size_type const> row_offsets,
                                  cudf::device_span<size_type const> key_counts_prefix,
                                  cudf::device_span<int32_t const> stacked_to_unique,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   thrust::for_each(
     rmm::exec_policy_nosync(stream, get_current_device_resource_ref()),
@@ -210,8 +249,42 @@ void remap_dict_indices_by_chunk(cudf::device_span<int32_t> indices,
         return;
       }
       auto const stacked_pos = key_counts_prefix[k] + indices[row];
-      indices[row]           = stacked_to_unique[stacked_pos];
+      indices[row]           = static_cast<Index>(stacked_to_unique[stacked_pos]);
     });
+}
+
+/**
+ * @brief Build a keys column of `key_type` from a chunk's dictionary entries.
+ *
+ * String chunks use the reader's `str_dict_index` (pointer/length pairs). Fixed-width chunks copy
+ * the PLAIN-encoded dictionary page, whose entries are the output values verbatim (guaranteed by
+ * `is_fixed_width_dict_chunk`).
+ *
+ * @param chunk The column chunk whose dictionary becomes the keys
+ * @param dict_page_data Device pointer to the chunk's (decompressed) dictionary page payload
+ * @param key_type The logical output type of the column
+ * @param entry_count Number of dictionary entries (keys) for this chunk
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's memory
+ * @return A `key_type` column holding this chunk's dictionary keys
+ */
+[[nodiscard]] std::unique_ptr<column> make_keys_column(ColumnChunkDesc const& chunk,
+                                                       uint8_t const* dict_page_data,
+                                                       data_type key_type,
+                                                       size_type entry_count,
+                                                       cuda::stream_ref stream,
+                                                       rmm::device_async_resource_ref mr)
+{
+  if (key_type.id() == type_id::STRING) {
+    return make_keys_column_from_index_pairs(chunk.str_dict_index, entry_count, stream, mr);
+  }
+  if (entry_count <= 0) { return cudf::make_empty_column(key_type); }
+  auto const keys_bytes = static_cast<std::size_t>(entry_count) * cudf::size_of(key_type);
+  return std::make_unique<column>(key_type,
+                                  entry_count,
+                                  rmm::device_buffer{dict_page_data, keys_bytes, stream, mr},
+                                  rmm::device_buffer{},
+                                  0);
 }
 
 }  // namespace
@@ -221,6 +294,7 @@ void reader_impl::prepare_dict_transcode(read_mode mode)
   CUDF_FUNC_RANGE();
 
   _dict_transcode_eligible.assign(_input_columns.size(), false);
+  _dict_transcode_key_types.assign(_input_columns.size(), data_type{type_id::EMPTY});
 
   if (not _options.output_dict_columns) { return; }
 
@@ -247,6 +321,10 @@ void reader_impl::prepare_dict_transcode(read_mode mode)
     elig.begin(), elig.end(), _dict_transcode_eligible.begin(), [](column_eligibility const& e) {
       return e.is_eligible();
     });
+  std::transform(
+    elig.begin(), elig.end(), _dict_transcode_key_types.begin(), [](column_eligibility const& e) {
+      return e.is_eligible() ? e.key_type : data_type{type_id::EMPTY};
+    });
 
   auto const num_eligible =
     std::count(_dict_transcode_eligible.begin(), _dict_transcode_eligible.end(), true);
@@ -254,12 +332,29 @@ void reader_impl::prepare_dict_transcode(read_mode mode)
 
   auto const num_input_cols = _input_columns.size();
 
-  // Change the output buffer type for eligible columns from STRING → INT32.
+  // Per-column index type from the largest chunk dictionary, following the same width rule as
+  // `dictionary::encode` (`get_indices_type_for_size`), so that concatenating batches keeps the
+  // width unless the merged keys overflow it.
+  std::vector<data_type> index_types(num_input_cols, data_type{type_id::INT32});
+  {
+    std::vector<size_type> max_keys(num_input_cols, 0);
+    for (auto const& page : pass.pages) {
+      if ((page.flags & PAGEINFO_FLAGS_DICTIONARY) == 0) { continue; }
+      auto const col_idx = pass.chunks[page.chunk_idx].src_col_index;
+      max_keys[col_idx]  = std::max(max_keys[col_idx], size_type{page.num_input_values});
+    }
+    std::transform(max_keys.begin(), max_keys.end(), index_types.begin(), [](size_type keys) {
+      return cudf::dictionary::detail::get_indices_type_for_size(keys);
+    });
+  }
+
+  // Change the output buffer type for eligible columns to the index type: the decode writes the
+  // dictionary indices instead of the logical values.
   std::for_each(
     cuda::counting_iterator<size_t>{0}, cuda::counting_iterator{num_input_cols}, [&](size_t i) {
       if (not _dict_transcode_eligible[i]) { return; }
       auto& out_buf = _output_buffers[_input_columns[i].nesting[0]];
-      out_buf.type  = data_type{type_id::INT32};
+      out_buf.type  = index_types[i];
     });
 
   // Rewrite per-page `kernel_mask` for eligible columns on the host subpass pages from
@@ -270,9 +365,12 @@ void reader_impl::prepare_dict_transcode(read_mode mode)
     auto const chunk_idx = page.chunk_idx;
     auto const col_idx   = pass.chunks[chunk_idx].src_col_index;
     if (not _dict_transcode_eligible[col_idx]) { return; }
-    if (page.kernel_mask == decode_kernel_mask::STRING_DICT) {
+    if (page.kernel_mask == decode_kernel_mask::STRING_DICT or
+        page.kernel_mask == decode_kernel_mask::FIXED_WIDTH_DICT) {
       page.kernel_mask = decode_kernel_mask::DICT_INT32;
-      any_rewritten    = true;
+      pass.chunks[chunk_idx].dict_index_bytes =
+        static_cast<uint8_t>(cudf::size_of(index_types[col_idx]));
+      any_rewritten = true;
     }
   });
 
@@ -283,9 +381,10 @@ void reader_impl::prepare_dict_transcode(read_mode mode)
     return;
   }
 
-  // Push the rewritten `kernel_mask`s back to device so subsequent decode kernels dispatch
-  // correctly.
+  // Push the rewritten `kernel_mask`s and chunk index widths back to device so subsequent decode
+  // kernels dispatch and write correctly.
   subpass.pages.host_to_device_async(_stream);
+  pass.chunks.host_to_device_async(_stream);
   subpass.kernel_mask = std::transform_reduce(
     subpass.pages.host_begin(),
     subpass.pages.host_end(),
@@ -315,12 +414,14 @@ void reader_impl::assemble_dict_transcoded_columns(
   // Pre-pass 1: Map each chunk to its dictionary page's key count.
   // Chunks without a dictionary page keep a count of 0.
   std::vector<size_type> chunk_dict_key_counts(pass.chunks.size(), 0);
+  std::vector<uint8_t const*> chunk_dict_payloads(pass.chunks.size(), nullptr);
   for (auto const& page : pass.pages) {
     if ((page.flags & PAGEINFO_FLAGS_DICTIONARY) == 0) { continue; }
     auto const chunk_idx = page.chunk_idx;
     if (chunk_idx < 0 or static_cast<size_t>(chunk_idx) >= pass.chunks.size()) { continue; }
     if (pass.chunks[chunk_idx].dict_page == nullptr) { continue; }
     chunk_dict_key_counts[chunk_idx] = static_cast<size_type>(page.num_input_values);
+    chunk_dict_payloads[chunk_idx] = page.page_data;
   }
 
   // Pre-pass 2: Bucket chunk indices by their source input-column ordinal. Because
@@ -358,17 +459,23 @@ void reader_impl::assemble_dict_transcoded_columns(
       // column, so `nesting[0]` is the correct, and only, output-buffer index to use.
       auto const out_idx = static_cast<size_t>(_input_columns[i].nesting[0]);
 
-      // Per-chunk key counts, looked up from the pre-pass 1 map.
+      auto const key_type = _dict_transcode_key_types[i];
+      CUDF_EXPECTS(key_type.id() != type_id::EMPTY,
+                   "Missing keys type for a dict-transcoded column");
+
+      // Per-chunk key counts and payloads from pre-pass 1.
       std::vector<size_type> chunk_key_counts(chunk_indices.size());
-      std::transform(chunk_indices.begin(),
-                     chunk_indices.end(),
-                     chunk_key_counts.begin(),
-                     [&](size_t chunk_idx) { return chunk_dict_key_counts[chunk_idx]; });
+      std::vector<uint8_t const*> chunk_dict_data(chunk_indices.size());
+      for (size_t k = 0; k < chunk_indices.size(); ++k) {
+        chunk_key_counts[k] = chunk_dict_key_counts[chunk_indices[k]];
+        chunk_dict_data[k] = chunk_dict_payloads[chunk_indices[k]];
+      }
 
       auto& indices_col = out_columns[out_idx];
-      CUDF_EXPECTS(indices_col != nullptr and indices_col->type().id() == type_id::INT32,
-                   "Expected INT32 indices column for dict-transcoded flat string column");
-      // Claim ownership of the indices column; the `out_idx` entry in `out_columns` is now empty.
+      CUDF_EXPECTS(indices_col != nullptr and (indices_col->type().id() == type_id::INT8 or
+                                               indices_col->type().id() == type_id::INT16 or
+                                               indices_col->type().id() == type_id::INT32),
+                   "Expected a signed integer indices column for a dict-transcoded flat column");
       auto indices_owner = std::move(indices_col);
 
       // Single row group fast path: the Parquet dictionary page's entries become the keys as-is,
@@ -378,8 +485,8 @@ void reader_impl::assemble_dict_transcoded_columns(
       // `indices_owner` intact for the path below.
       auto const emit_single_row_group_column = [&]() -> bool {
         auto const& chunk = pass.chunks[chunk_indices[0]];
-        auto keys         = make_keys_column_from_index_pairs(
-          chunk.str_dict_index, chunk_key_counts[0], _stream, _mr);
+        auto keys =
+          make_keys_column(chunk, chunk_dict_data[0], key_type, chunk_key_counts[0], _stream, _mr);
         auto const num_distinct_keys = cudf::detail::distinct_count(
           keys->view(), null_policy::INCLUDE, nan_policy::NAN_IS_VALID, _stream);
         if (num_distinct_keys != keys->size()) { return true; }  // fall back: dedup below
@@ -433,7 +540,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       // The per-chunk key ranges are contiguous in `pass.str_dict_index` iff this is the only
       // eligible string column: chunks are laid out row-group-major, so a second string column
       // interleaves its chunks between this one's.
-      auto const contiguous = std::all_of(
+      auto const contiguous = key_type.id() == type_id::STRING and std::all_of(
         cuda::counting_iterator<size_t>{0},
         cuda::counting_iterator{chunk_indices.size() - 1},
         [&](size_t k) { return key_offset_of(k + 1) == key_offset_of(k) + chunk_key_counts[k]; });
@@ -459,7 +566,16 @@ void reader_impl::assemble_dict_transcoded_columns(
       // stacked position from the correct place in `pass.str_dict_index` via a counting-transform
       // iterator.
       std::unique_ptr<column> stacked_keys_owner;
-      if (contiguous) {
+      if (key_type.id() != type_id::STRING) {
+        // Stack fixed-width dictionary payloads directly; only keys are copied, not row indices.
+        std::vector<column_view> key_views;
+        key_views.reserve(chunk_indices.size());
+        for (size_t k = 0; k < chunk_indices.size(); ++k) {
+          key_views.emplace_back(key_type, chunk_key_counts[k], chunk_dict_data[k]);
+        }
+        stacked_keys_owner = cudf::detail::concatenate(
+          key_views, _stream, get_current_device_resource_ref());
+      } else if (contiguous) {
         stacked_keys_owner =
           make_keys_column_from_index_pairs(pass.chunks[chunk_indices[0]].str_dict_index,
                                             total_keys,
@@ -500,14 +616,27 @@ void reader_impl::assemble_dict_transcoded_columns(
       // Remap every row's index onto the compact key space in place. Null rows carry a zero index
       // (fill_pruned_offsets); the shift keeps them in range and the null mask (carried by
       // `indices_owner`) still nullifies them in `decode`.
-      remap_dict_indices_by_chunk(
-        cudf::device_span<int32_t>{indices_owner->mutable_view().data<int32_t>(),
-                                   static_cast<std::size_t>(num_row_vals)},
-        cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
-        cudf::device_span<size_type const>{d_key_counts_prefix.data(), d_key_counts_prefix.size()},
-        cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
-                                         static_cast<std::size_t>(stacked_to_unique->size())},
-        _stream);
+      // The union of row-group keys may require wider indices than any individual dictionary.
+      auto const required_type =
+        cudf::dictionary::detail::get_indices_type_for_size(unique_keys->size());
+      if (cudf::size_of(required_type) > cudf::size_of(indices_owner->type())) {
+        indices_owner = cudf::detail::cast(indices_owner->view(), required_type, _stream, _mr);
+      }
+      cudf::type_dispatcher(indices_owner->type(), [&]<typename Index>() {
+        if constexpr (std::is_same_v<Index, int8_t> or std::is_same_v<Index, int16_t> or
+                      std::is_same_v<Index, int32_t>) {
+          remap_dict_indices_by_chunk(
+            cudf::device_span<Index>{indices_owner->mutable_view().data<Index>(),
+                                    static_cast<std::size_t>(num_row_vals)},
+            cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
+            cudf::device_span<size_type const>{d_key_counts_prefix.data(), d_key_counts_prefix.size()},
+            cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
+                                           static_cast<std::size_t>(stacked_to_unique->size())},
+            _stream);
+        } else {
+          CUDF_FAIL("Expected signed INT8, INT16 or INT32 dictionary indices");
+        }
+      });
 
       _stream.sync();
 

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -7,11 +7,11 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/concatenate.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/unary.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
+#include <cudf/detail/utilities/cuda_memcpy.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/dictionary/detail/encode.hpp>
@@ -572,14 +572,23 @@ void reader_impl::assemble_dict_transcoded_columns(
       // iterator.
       std::unique_ptr<column> stacked_keys_owner;
       if (key_type.id() != type_id::STRING) {
-        // Stack fixed-width dictionary payloads directly; only keys are copied, not row indices.
-        std::vector<column_view> key_views;
-        key_views.reserve(chunk_indices.size());
+        // Dictionary payloads follow variable-length page headers and need not be aligned
+        // for key_type. Copy bytes into an aligned allocation before exposing typed keys.
+        auto const key_width = cudf::size_of(key_type);
+        rmm::device_buffer stacked_data{static_cast<std::size_t>(total_keys) * key_width,
+                                        _stream,
+                                        get_current_device_resource_ref()};
+        auto* const dst = static_cast<uint8_t*>(stacked_data.data());
         for (size_t k = 0; k < chunk_indices.size(); ++k) {
-          key_views.emplace_back(key_type, chunk_key_counts[k], chunk_dict_data[k], nullptr, 0);
+          if (chunk_key_counts[k] == 0) { continue; }
+          CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+            dst + static_cast<std::size_t>(key_counts_prefix[k]) * key_width,
+            chunk_dict_data[k],
+            static_cast<std::size_t>(chunk_key_counts[k]) * key_width,
+            _stream));
         }
-        stacked_keys_owner =
-          cudf::detail::concatenate(key_views, _stream, get_current_device_resource_ref());
+        stacked_keys_owner = std::make_unique<column>(
+          key_type, total_keys, std::move(stacked_data), rmm::device_buffer{}, 0);
       } else if (contiguous) {
         stacked_keys_owner =
           make_keys_column_from_index_pairs(pass.chunks[chunk_indices[0]].str_dict_index,

--- a/cpp/src/io/parquet/reader_impl_dict_transcode.cu
+++ b/cpp/src/io/parquet/reader_impl_dict_transcode.cu
@@ -7,10 +7,10 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/concatenate.hpp>
-#include <cudf/detail/unary.hpp>
+#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/unary.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -123,14 +123,17 @@ void update_from_chunk(column_eligibility& e, ColumnChunkDesc const& chunk)
  * @brief Compute per-input-column eligibility for Parquet-dict → DICTIONARY32 transcode.
  *
  * A column is eligible iff
- *  - the corresponding output buffer is currently typed as STRING (i.e. a flat string column),
- *  - every chunk of that column is a BYTE_ARRAY string chunk with a dictionary page,
+ *  - the corresponding output buffer is a flat STRING column, or a flat fixed-width column whose
+ *    decode is a plain copy of INT32/INT64 physical values (no decimal, timestamp-unit, or width
+ *    conversion) -- the buffer's logical type becomes the DICTIONARY32 keys type,
+ *  - every chunk of that column is a matching chunk of that type with a dictionary page,
  *  - every data page of every chunk of that column uses DICTIONARY encoding,
  *  - the chunk has a flat (non-list, non-nested) schema.
  *
  * @param pass The pass intermediate data holding host-side chunks and pages
  * @param input_columns The reader's input column descriptors
- * @param output_buffers The output column buffers (used to detect flat STRING columns)
+ * @param output_buffers The output column buffers (used to detect eligible flat columns and
+ * their logical key types)
  * @return A vector of per-input-column eligibility records, indexed by input column
  */
 [[nodiscard]] std::vector<column_eligibility> compute_dict_transcode_eligibility(
@@ -421,7 +424,7 @@ void reader_impl::assemble_dict_transcoded_columns(
     if (chunk_idx < 0 or static_cast<size_t>(chunk_idx) >= pass.chunks.size()) { continue; }
     if (pass.chunks[chunk_idx].dict_page == nullptr) { continue; }
     chunk_dict_key_counts[chunk_idx] = static_cast<size_type>(page.num_input_values);
-    chunk_dict_payloads[chunk_idx] = page.page_data;
+    chunk_dict_payloads[chunk_idx]   = page.page_data;
   }
 
   // Pre-pass 2: Bucket chunk indices by their source input-column ordinal. Because
@@ -468,7 +471,7 @@ void reader_impl::assemble_dict_transcoded_columns(
       std::vector<uint8_t const*> chunk_dict_data(chunk_indices.size());
       for (size_t k = 0; k < chunk_indices.size(); ++k) {
         chunk_key_counts[k] = chunk_dict_key_counts[chunk_indices[k]];
-        chunk_dict_data[k] = chunk_dict_payloads[chunk_indices[k]];
+        chunk_dict_data[k]  = chunk_dict_payloads[chunk_indices[k]];
       }
 
       auto& indices_col = out_columns[out_idx];
@@ -540,10 +543,12 @@ void reader_impl::assemble_dict_transcoded_columns(
       // The per-chunk key ranges are contiguous in `pass.str_dict_index` iff this is the only
       // eligible string column: chunks are laid out row-group-major, so a second string column
       // interleaves its chunks between this one's.
-      auto const contiguous = key_type.id() == type_id::STRING and std::all_of(
-        cuda::counting_iterator<size_t>{0},
-        cuda::counting_iterator{chunk_indices.size() - 1},
-        [&](size_t k) { return key_offset_of(k + 1) == key_offset_of(k) + chunk_key_counts[k]; });
+      auto const contiguous =
+        key_type.id() == type_id::STRING and
+        std::all_of(
+          cuda::counting_iterator<size_t>{0},
+          cuda::counting_iterator{chunk_indices.size() - 1},
+          [&](size_t k) { return key_offset_of(k + 1) == key_offset_of(k) + chunk_key_counts[k]; });
 
       // Device copies of the per-chunk row/key boundaries, reused by the strided key gather below
       // and by `remap_dict_indices_by_chunk`.
@@ -571,10 +576,10 @@ void reader_impl::assemble_dict_transcoded_columns(
         std::vector<column_view> key_views;
         key_views.reserve(chunk_indices.size());
         for (size_t k = 0; k < chunk_indices.size(); ++k) {
-          key_views.emplace_back(key_type, chunk_key_counts[k], chunk_dict_data[k]);
+          key_views.emplace_back(key_type, chunk_key_counts[k], chunk_dict_data[k], nullptr, 0);
         }
-        stacked_keys_owner = cudf::detail::concatenate(
-          key_views, _stream, get_current_device_resource_ref());
+        stacked_keys_owner =
+          cudf::detail::concatenate(key_views, _stream, get_current_device_resource_ref());
       } else if (contiguous) {
         stacked_keys_owner =
           make_keys_column_from_index_pairs(pass.chunks[chunk_indices[0]].str_dict_index,
@@ -627,11 +632,12 @@ void reader_impl::assemble_dict_transcoded_columns(
                       std::is_same_v<Index, int32_t>) {
           remap_dict_indices_by_chunk(
             cudf::device_span<Index>{indices_owner->mutable_view().data<Index>(),
-                                    static_cast<std::size_t>(num_row_vals)},
+                                     static_cast<std::size_t>(num_row_vals)},
             cudf::device_span<size_type const>{d_row_offsets.data(), d_row_offsets.size()},
-            cudf::device_span<size_type const>{d_key_counts_prefix.data(), d_key_counts_prefix.size()},
+            cudf::device_span<size_type const>{d_key_counts_prefix.data(),
+                                               d_key_counts_prefix.size()},
             cudf::device_span<int32_t const>{stacked_to_unique->view().data<int32_t>(),
-                                           static_cast<std::size_t>(stacked_to_unique->size())},
+                                             static_cast<std::size_t>(stacked_to_unique->size())},
             _stream);
         } else {
           CUDF_FAIL("Expected signed INT8, INT16 or INT32 dictionary indices");

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -499,7 +499,8 @@ TEST_F(ParquetReaderDictTest, MultiColumnMixedEligibility)
     << "List<string> must remain LIST when output_dict_columns is on (transcode is flat-only)";
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(list_col->view(), read_list);
 
-  // Non-string column: unchanged INT32.
+  // All-unique INT32 column: the writer does not dictionary-encode it (data pages are PLAIN),
+  // so it is ineligible for transcode and stays a plain INT32 column.
   auto const read_key = read_table->view().column(2);
   ASSERT_EQ(read_key.type().id(), cudf::type_id::INT32);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(key_col, read_key);
@@ -598,4 +599,135 @@ TEST_F(ParquetReaderDictTest, NullRowGroupDictTranscode)
 
   auto const decoded = cudf::dictionary::decode(dict_view);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(input_col, decoded->view());
+}
+
+namespace {
+
+/// A low-cardinality nullable INT32 column.
+cudf::test::fixed_width_column_wrapper<int32_t> make_low_cardinality_ints()
+{
+  std::mt19937 engine(seed ^ 0xF17ED0UL);
+  std::uniform_int_distribution<int> value_dist(0, cardinality - 1);
+  std::bernoulli_distribution null_dist(null_probability);
+  std::vector<int32_t> values(num_rows);
+  std::vector<bool> valids(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    values[i] = 1'000'000 + value_dist(engine);
+    valids[i] = not null_dist(engine);
+  }
+  return cudf::test::fixed_width_column_wrapper<int32_t>(
+    values.begin(), values.end(), valids.begin());
+}
+
+/// A low-cardinality INT64 column.
+cudf::test::fixed_width_column_wrapper<int64_t> make_low_cardinality_int64s()
+{
+  std::mt19937 engine(seed ^ 0x64B175UL);
+  std::uniform_int_distribution<int> value_dist(0, cardinality - 1);
+  std::vector<int64_t> values(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    values[i] = 3'000'000'000LL + value_dist(engine);
+  }
+  return cudf::test::fixed_width_column_wrapper<int64_t>(values.begin(), values.end());
+}
+
+/// A low-cardinality date (TIMESTAMP_DAYS, physical INT32) column.
+cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, int32_t> make_low_cardinality_dates()
+{
+  std::mt19937 engine(seed ^ 0xDA7E5UL);
+  std::uniform_int_distribution<int> value_dist(0, cardinality - 1);
+  std::vector<int32_t> values(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    values[i] = 8000 + value_dist(engine);
+  }
+  return cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, int32_t>(values.begin(),
+                                                                            values.end());
+}
+
+}  // namespace
+
+// Flat fixed-width columns (INT32 with nulls, INT64, DATE) written with dictionary encoding must
+// transcode to DICTIONARY32 columns whose keys carry the logical type, across several row groups,
+// and decode back to exactly the input.
+TEST_F(ParquetReaderDictTest, FlatFixedWidthDictTranscode)
+{
+  auto const int32_col = make_low_cardinality_ints();
+  auto const int64_col = make_low_cardinality_int64s();
+  auto const date_col  = make_low_cardinality_dates();
+  auto const input     = cudf::table_view{{int32_col, int64_col, date_col}};
+
+  auto const filepath = temp_env->get_temp_filepath("FlatFixedWidthDictTranscode.parquet");
+  write_parquet(input, filepath);
+
+  auto const read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                           .output_dict_columns(true)
+                           .build();
+  auto const read_table = cudf::io::read_parquet(read_opts).tbl;
+
+  std::array<cudf::type_id, 3> const key_types{
+    cudf::type_id::INT32, cudf::type_id::INT64, cudf::type_id::TIMESTAMP_DAYS};
+  for (cudf::size_type i = 0; i < read_table->num_columns(); ++i) {
+    auto const read_col = read_table->view().column(i);
+    ASSERT_EQ(read_col.type().id(), cudf::type_id::DICTIONARY32) << "column " << i;
+    cudf::dictionary_column_view const dict{read_col};
+    EXPECT_EQ(dict.keys().type().id(), key_types[i]) << "column " << i;
+    // `cardinality` distinct keys fit INT16 indices (get_indices_type_for_size)
+    EXPECT_EQ(dict.indices().type().id(), cudf::type_id::INT16) << "column " << i;
+    auto const decoded = cudf::dictionary::decode(dict);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input.column(i), decoded->view());
+  }
+}
+
+// Fixed-width columns stay plain by default (option off).
+TEST_F(ParquetReaderDictTest, FlatFixedWidthNoTranscodeByDefault)
+{
+  auto const int32_col = make_low_cardinality_ints();
+  auto const input     = cudf::table_view{{int32_col}};
+  auto const filepath  = temp_env->get_temp_filepath("FlatFixedWidthNoTranscode.parquet");
+  write_parquet(input, filepath);
+
+  auto const read_table =
+    cudf::io::read_parquet(
+      cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath}).build())
+      .tbl;
+  auto const read_col = read_table->view().column(0);
+  ASSERT_EQ(read_col.type().id(), cudf::type_id::INT32);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int32_col, read_col);
+}
+
+// Under an AST filter the direct fast path is off: string columns are still delivered as
+// DICTIONARY32 via the post-hoc encode, while fixed-width columns fall back to plain.
+TEST_F(ParquetReaderDictTest, FixedWidthFilterFallsBackToPlain)
+{
+  auto const int32_col  = make_low_cardinality_ints();
+  auto const string_col = make_low_cardinality_strings();
+  auto const input      = cudf::table_view{{int32_col, string_col}};
+  auto const filepath   = temp_env->get_temp_filepath("FixedWidthFilterFallback.parquet");
+  write_parquet(input, filepath);
+
+  auto const ref     = cudf::ast::column_reference(0);
+  auto literal_value = cudf::numeric_scalar<int32_t>(1'000'000 + cardinality / 2);
+  auto const literal = cudf::ast::literal(literal_value);
+  auto const expr    = cudf::ast::operation(cudf::ast::ast_operator::LESS, ref, literal);
+
+  auto const read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                           .filter(expr)
+                           .output_dict_columns(true)
+                           .build();
+  auto const read_table = cudf::io::read_parquet(read_opts).tbl;
+
+  auto const read_int = read_table->view().column(0);
+  ASSERT_EQ(read_int.type().id(), cudf::type_id::INT32);
+  auto const read_str = read_table->view().column(1);
+  ASSERT_EQ(read_str.type().id(), cudf::type_id::DICTIONARY32);
+
+  // Cross-check the surviving rows against a plain filtered read.
+  auto const plain_table = cudf::io::read_parquet(cudf::io::parquet_reader_options::builder(
+                                                    cudf::io::source_info{filepath})
+                                                    .filter(expr)
+                                                    .build())
+                             .tbl;
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(plain_table->view().column(0), read_int);
+  auto const decoded_str = cudf::dictionary::decode(cudf::dictionary_column_view(read_str));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(plain_table->view().column(1), decoded_str->view());
 }

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -731,3 +731,165 @@ TEST_F(ParquetReaderDictTest, FixedWidthFilterFallsBackToPlain)
   auto const decoded_str = cudf::dictionary::decode(cudf::dictionary_column_view(read_str));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(plain_table->view().column(1), decoded_str->view());
 }
+
+namespace {
+
+/// A nullable INT32 column with `distinct` distinct values over `rows` rows.
+cudf::test::fixed_width_column_wrapper<int32_t> make_int_column_with_cardinality(
+  cudf::size_type rows, cudf::size_type distinct, unsigned int local_seed)
+{
+  std::mt19937 engine(local_seed);
+  std::uniform_int_distribution<int> value_dist(0, distinct - 1);
+  std::vector<int32_t> values(rows);
+  for (cudf::size_type i = 0; i < rows; ++i) {
+    values[i] = 5'000'000 + value_dist(engine);
+  }
+  return cudf::test::fixed_width_column_wrapper<int32_t>(values.begin(), values.end());
+}
+
+}  // namespace
+
+// The emitted index width follows the largest row-group dictionary: <= 127 keys use INT8 and
+// > 32767 keys use INT32 (the INT16 middle case is covered by FlatFixedWidthDictTranscode).
+TEST_F(ParquetReaderDictTest, FixedWidthIndexWidths)
+{
+  // INT8: 100 distinct keys across the default row groups.
+  {
+    auto const col      = make_int_column_with_cardinality(num_rows, 100, seed ^ 0x1D8);
+    auto const filepath = temp_env->get_temp_filepath("FixedWidthIndexWidthInt8.parquet");
+    write_parquet(cudf::table_view{{col}}, filepath);
+    auto const read_table = read_parquet_as_dict(filepath).tbl;
+    auto const read_col   = read_table->view().column(0);
+    ASSERT_EQ(read_col.type().id(), cudf::type_id::DICTIONARY32);
+    cudf::dictionary_column_view const dict{read_col};
+    EXPECT_EQ(dict.indices().type().id(), cudf::type_id::INT8);
+    auto const decoded = cudf::dictionary::decode(dict);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, decoded->view());
+  }
+  // INT32: a single row group whose dictionary exceeds 32767 keys.
+  {
+    constexpr cudf::size_type wide_rows     = 136'000;
+    constexpr cudf::size_type wide_distinct = 34'000;
+    // deterministic: each value appears four times in adjacent runs, so the dictionary holds
+    // `wide_distinct` keys and dictionary encoding beats PLAIN in size (the writer skips the
+    // dictionary, even with policy ALWAYS, when it would not be smaller)
+    std::vector<int32_t> wide_values(wide_rows);
+    for (cudf::size_type i = 0; i < wide_rows; ++i) {
+      wide_values[i] = 5'000'000 + (i / 4) % wide_distinct;
+    }
+    cudf::test::fixed_width_column_wrapper<int32_t> const col(wide_values.begin(),
+                                                              wide_values.end());
+    auto const filepath = temp_env->get_temp_filepath("FixedWidthIndexWidthInt32.parquet");
+    auto const options  = cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath},
+                                                                   cudf::table_view{{col}})
+                           .dictionary_policy(cudf::io::dictionary_policy::ALWAYS)
+                           .row_group_size_rows(wide_rows)
+                           .build();
+    cudf::io::write_parquet(options);
+    auto const read_table = read_parquet_as_dict(filepath).tbl;
+    auto const read_col   = read_table->view().column(0);
+    ASSERT_EQ(read_col.type().id(), cudf::type_id::DICTIONARY32);
+    cudf::dictionary_column_view const dict{read_col};
+    EXPECT_EQ(dict.indices().type().id(), cudf::type_id::INT32);
+    EXPECT_GT(dict.keys_size(), 32767);
+    auto const decoded = cudf::dictionary::decode(dict);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, decoded->view());
+  }
+}
+
+// Bounded reads (skip_rows / num_rows) disable the direct fast path; fixed-width columns fall
+// back to their plain type and match a plain bounded read.
+TEST_F(ParquetReaderDictTest, FixedWidthBoundedReadFallsBackToPlain)
+{
+  auto const col      = make_low_cardinality_ints();
+  auto const filepath = temp_env->get_temp_filepath("FixedWidthBoundedRead.parquet");
+  write_parquet(cudf::table_view{{col}}, filepath);
+
+  auto const bounded = [&](bool output_dict) {
+    return cudf::io::read_parquet(
+             cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+               .skip_rows(row_group_size / 2)
+               .num_rows(row_group_size)
+               .output_dict_columns(output_dict)
+               .build())
+      .tbl;
+  };
+  auto const read_table = bounded(true);
+  auto const read_col   = read_table->view().column(0);
+  ASSERT_EQ(read_col.type().id(), cudf::type_id::INT32);
+  auto const plain_table = bounded(false);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(plain_table->view().column(0), read_col);
+}
+
+// Chunked reads disable the direct fast path; fixed-width columns come back plain in every
+// output chunk and reassemble to the input.
+TEST_F(ParquetReaderDictTest, FixedWidthChunkedReadFallsBackToPlain)
+{
+  auto const col      = make_low_cardinality_ints();
+  auto const filepath = temp_env->get_temp_filepath("FixedWidthChunkedRead.parquet");
+  write_parquet(cudf::table_view{{col}}, filepath);
+
+  auto const read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                           .output_dict_columns(true)
+                           .build();
+  auto reader = cudf::io::chunked_parquet_reader(/*chunk_read_limit=*/8 * 1024, read_opts);
+
+  std::vector<std::unique_ptr<cudf::table>> chunks;
+  std::vector<cudf::column_view> views;
+  cudf::size_type total_rows = 0;
+  int num_chunks             = 0;
+  while (reader.has_next()) {
+    auto chunk          = reader.read_chunk();
+    auto const read_col = chunk.tbl->view().column(0);
+    if (read_col.size() == 0) { continue; }
+    ASSERT_EQ(read_col.type().id(), cudf::type_id::INT32);
+    total_rows += read_col.size();
+    ++num_chunks;
+    chunks.push_back(std::move(chunk.tbl));
+    views.push_back(chunks.back()->view().column(0));
+  }
+  ASSERT_EQ(total_rows, num_rows);
+  EXPECT_GT(num_chunks, 1) << "byte limit should split the read into multiple chunks";
+  auto const combined = cudf::concatenate(views);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, combined->view());
+}
+
+// Row-group dictionaries fit INT8 separately, but their union needs INT16. Exercise both
+// fixed-width keys and the optimized string-key gather while preserving null rows.
+TEST_F(ParquetReaderDictTest, DictTranscodeWidensMergedIndices)
+{
+  std::vector<int32_t> values(num_rows);
+  std::vector<std::string> strings(num_rows);
+  std::vector<bool> valid(num_rows);
+  for (cudf::size_type row = 0; row < num_rows; ++row) {
+    values[row]  = (row / row_group_size) * 100 + row % 100;
+    strings[row] = make_value_string(values[row]);
+    valid[row]   = row % 17 != 0;
+  }
+  auto ints =
+    cudf::test::fixed_width_column_wrapper<int32_t>(values.begin(), values.end(), valid.begin());
+  auto strs = cudf::test::strings_column_wrapper(strings.begin(), strings.end(), valid.begin());
+  auto const input    = cudf::table_view{{ints, strs}};
+  auto const filepath = temp_env->get_temp_filepath("DictTranscodeWidensMergedIndices.parquet");
+  write_parquet(input, filepath);
+
+  // Reading just one row group proves the per-chunk indices use INT8.
+  auto const single = cudf::io::read_parquet(
+                        cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                          .row_groups({{0}})
+                          .output_dict_columns(true)
+                          .build())
+                        .tbl;
+  auto const merged = read_parquet_as_dict(filepath).tbl;
+  for (cudf::size_type col = 0; col < input.num_columns(); ++col) {
+    ASSERT_EQ(single->view().column(col).type().id(), cudf::type_id::DICTIONARY32);
+    EXPECT_EQ(cudf::dictionary_column_view(single->view().column(col)).indices().type().id(),
+              cudf::type_id::INT8);
+    ASSERT_EQ(merged->view().column(col).type().id(), cudf::type_id::DICTIONARY32);
+    auto const dict = cudf::dictionary_column_view(merged->view().column(col));
+    EXPECT_EQ(dict.indices().type().id(), cudf::type_id::INT16);
+    EXPECT_EQ(dict.keys().size(), 500);
+    auto const decoded = cudf::dictionary::decode(dict);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input.column(col), decoded->view());
+  }
+}

--- a/cpp/tests/io/parquet_reader_dict_test.cpp
+++ b/cpp/tests/io/parquet_reader_dict_test.cpp
@@ -26,6 +26,8 @@
 
 #include <rmm/device_buffer.hpp>
 
+#include <src/io/parquet/compact_protocol_reader.hpp>
+
 #include <algorithm>
 #include <array>
 #include <memory>
@@ -889,6 +891,56 @@ TEST_F(ParquetReaderDictTest, DictTranscodeWidensMergedIndices)
     auto const dict = cudf::dictionary_column_view(merged->view().column(col));
     EXPECT_EQ(dict.indices().type().id(), cudf::type_id::INT16);
     EXPECT_EQ(dict.keys().size(), 500);
+    auto const decoded = cudf::dictionary::decode(dict);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input.column(col), decoded->view());
+  }
+}
+
+// Uncompressed dictionary payloads follow variable-length page headers. A typed column view
+// over these bytes can cause misaligned INT32/INT64 loads when row-group keys are stacked.
+TEST_F(ParquetReaderDictTest, UnalignedFixedWidthDictionaryPayloads)
+{
+  auto const ints  = make_low_cardinality_ints();
+  auto const longs = make_low_cardinality_int64s();
+  auto const dates = make_low_cardinality_dates();
+  auto const input = cudf::table_view{{ints, longs, dates}};
+  auto const filepath =
+    temp_env->get_temp_filepath("UnalignedFixedWidthDictionaryPayloads.parquet");
+  write_parquet(input, filepath);
+
+  auto const source = cudf::io::datasource::create(filepath);
+  cudf::io::parquet::FileMetaData metadata;
+  read_footer(source, &metadata);
+  ASSERT_GT(metadata.row_groups.size(), 1);
+  // The reader packs the requested chunk ranges into one aligned buffer. Check the
+  // payload offsets in that buffer, including the variable-sized preceding chunks.
+  std::array<bool, 3> has_unaligned_payload{};
+  std::size_t chunk_offset = 0;
+  for (auto const& row_group : metadata.row_groups) {
+    for (std::size_t col = 0; col < row_group.columns.size(); ++col) {
+      auto const& md = row_group.columns[col].meta_data;
+      ASSERT_GT(md.dictionary_page_offset, 0);
+      auto const bytes = source->host_read(md.dictionary_page_offset, md.total_compressed_size);
+      cudf::io::parquet::detail::CompactProtocolReader reader(bytes->data(), bytes->size());
+      cudf::io::parquet::PageHeader header;
+      reader.read(&header);
+      ASSERT_EQ(header.type, cudf::io::parquet::PageType::DICTIONARY_PAGE);
+      auto const width = md.type == cudf::io::parquet::Type::INT64 ? 8 : 4;
+      has_unaligned_payload[col] =
+        has_unaligned_payload[col] or (chunk_offset + reader.bytecount()) % width != 0;
+      chunk_offset += md.total_compressed_size;
+    }
+  }
+  for (auto const unaligned : has_unaligned_payload) {
+    ASSERT_TRUE(unaligned);
+  }
+
+  auto const result = read_parquet_as_dict(filepath).tbl;
+  ASSERT_EQ(result->num_columns(), input.num_columns());
+  for (cudf::size_type col = 0; col < input.num_columns(); ++col) {
+    ASSERT_EQ(result->view().column(col).type().id(), cudf::type_id::DICTIONARY32);
+    auto const dict = cudf::dictionary_column_view(result->view().column(col));
+    EXPECT_EQ(dict.keys().type(), input.column(col).type());
     auto const decoded = cudf::dictionary::decode(dict);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(input.column(col), decoded->view());
   }


### PR DESCRIPTION
> **Update (2026-09-08):** Rebased onto `main` and fixed unaligned fixed-width dictionary reads. The current revision has been built and tested locally; results are updated below.

## Summary

Extends `parquet_reader_options::output_dict_columns` to return eligible flat
fixed-width Parquet dictionary columns directly as `DICTIONARY32`.
Direct-transcoded string and fixed-width columns use the narrowest signed index
type that can address the largest row-group dictionary, widening when necessary
to address the merged key set.

## Behavior

The fixed-width direct path applies only when:

- physical storage is `INT32` or `INT64`;
- every selected data page is dictionary encoded; and
- decoding requires no decimal, timestamp-unit, or width conversion.

Keys retain the logical cuDF type. With filters, bounded reads, or
chunked/multi-pass reads, fixed-width columns remain plain. Strings keep the
existing post-read dictionary-encoding fallback, which uses `INT32` indices.

## Integration

Rebased onto `main` at `c27d94e64863faddc7d05bacc75891cb820c0ddd`.
#23889 is merged; its two temporary dependency commits have been removed.
The assembly path preserves #23710's batched key deduplication and index remapping,
extending it to fixed-width keys and widening indices when the merged key set requires it.

## Validation

Current revision (`51eb666972`, NVIDIA GB10, CUDA 13.3, RMM 26.10):

- Built libcudf and `PARQUET_TEST` from source in an isolated build directory.
- Full `PARQUET_TEST`: **556 passed, 1 skipped, 0 failed**; 4 additional tests are disabled.
- `compute-sanitizer --tool memcheck --error-exitcode 99` on `ParquetReaderDictTest.*`:
  **21 passed, 0 errors**, including the new unaligned-payload regression.
- Before the fix, the new regression reproduced a misaligned 4-byte read in
  `fused_concatenate_kernel<int>` (sanitizer exit code 99).
- Changed-file pre-commit checks passed (mypy skipped for this C++-only change).

The fixed-width stacking path now copies dictionary payloads as bytes into one aligned
buffer before exposing typed keys. The regression verifies unaligned payload offsets and
round-trip values for INT32, INT64, and date columns across multiple row groups.

Before rebase:

- All `PARQUET_TEST` tests passed locally, covering fixed-width `INT32`, `INT64`,
  and `TIMESTAMP_DAYS`, nulls, five row groups, `INT16` indices, default-off
  behavior, and filter fallback.
- On TPC-H SF100 data, `DICTIONARY32` output for date, `INT64`, and string
  columns across eight row groups decoded equal to a plain read.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] Documentation updated to describe fixed-width output and sized direct-path indices.
