### PR TITLE
Avoid blocking memory reservations in actor coroutines

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/allgather.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cudf_streaming.partition_utils import unpack_and_concat
+from cudf_streaming.partition_utils import unpack_and_concat, unpack_and_concat_cost
+from cudf_streaming.table_chunk import make_table_chunks_available_or_wait
 from rapidsmpf.streaming.coll.allgather import AllGather
+from rapidsmpf.streaming.core.memory_reserve_or_wait import reserve_memory
 
 if TYPE_CHECKING:
     import pylibcudf as plc
@@ -49,7 +51,7 @@ class AllGatherManager:
         def __init__(self, manager: AllGatherManager):
             self._manager = manager
 
-        def insert(self, sequence_number: int, chunk: TableChunk) -> None:
+        async def insert(self, sequence_number: int, chunk: TableChunk) -> None:
             """
             Insert a chunk into the AllGather.
 
@@ -61,8 +63,13 @@ class AllGatherManager:
                 The table chunk to insert. Need not be GPU-resident; if spilled,
                 it will be made available internally.
             """
-            chunk = chunk.make_available_and_spill(
-                self._manager.context.br(), allow_overbooking=True
+            # The chunk's data moves into AllGather-owned packed buffers,
+            # nothing lasting is added.
+            chunk, _ = await make_table_chunks_available_or_wait(
+                self._manager.context,
+                chunk,
+                reserve_extra=0,
+                net_memory_delta=0,
             )
             self._manager.allgather.insert(
                 sequence_number,
@@ -105,9 +112,20 @@ class AllGatherManager:
         -------
         The concatenated AllGather result.
         """
+        partitions = await self.allgather.extract_all(self.context, ordered=ordered)
+        # The cost covers the concatenated output plus moving any
+        # host-resident partitions to device. The packed inputs stay live
+        # until the concat finishes and are released after, so the net
+        # change is about zero.
+        reservation = await reserve_memory(
+            self.context,
+            unpack_and_concat_cost(partitions),
+            net_memory_delta=0,
+        )
         return await ir_context.to_thread(
             unpack_and_concat,
-            partitions=await self.allgather.extract_all(self.context, ordered=ordered),
+            partitions=partitions,
             stream=stream,
             br=self.context.br(),
+            reservation=reservation,
         )

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/ordering.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/ordering.py
@@ -14,10 +14,16 @@ from cudf_streaming.channel_metadata import Ordering
 from cudf_streaming.partition_utils import (
     packed_data_from_cudf_packed_columns,
     unpack_and_concat,
+    unpack_and_concat_cost,
 )
-from cudf_streaming.table_chunk import TableChunk
+from cudf_streaming.table_chunk import (
+    TableChunk,
+    make_table_chunks_available_or_wait,
+)
 from pylibcudf.contiguous_split import pack
+from rapidsmpf.memory.memory_reservation import opaque_memory_usage
 from rapidsmpf.streaming.coll.sparse_alltoall import SparseAlltoall
+from rapidsmpf.streaming.core.memory_reserve_or_wait import reserve_memory
 from rapidsmpf.streaming.core.message import Message
 
 from cudf_polars.containers import DataFrame, DataType
@@ -305,14 +311,25 @@ def _remote_pids_from_source(
     ]
 
 
-def _unpack_remote_partition(
+async def _unpack_remote_partition(
+    context: Context,
     packed: PackedData,
     stream: Stream,
-    br: BufferResource,
 ) -> TableChunk:
     """Unpack one remote output-partition payload."""
+    br = context.br()
+    partitions = [packed]
+    # The cost covers the concatenated output plus moving any
+    # host-resident partitions to device. The packed inputs stay live
+    # until the concat finishes and are released after, so the net
+    # change is about zero.
+    reservation = await reserve_memory(
+        context,
+        unpack_and_concat_cost(partitions),
+        net_memory_delta=0,
+    )
     return TableChunk.from_pylibcudf_table(
-        unpack_and_concat([packed], stream=stream, br=br),
+        unpack_and_concat(partitions, stream=stream, br=br, reservation=reservation),
         stream,
         exclusive_view=True,
         br=br,
@@ -324,7 +341,12 @@ def _copy_to_owned_chunk(
     stream: Stream,
     br: BufferResource,
 ) -> TableChunk:
-    """Copy a table view into a uniquely-owned chunk."""
+    """
+    Copy a table view into a uniquely-owned chunk.
+
+    Makes no memory reservation of its own. The caller must reserve the
+    copy's device memory, see ``_OutputPartitionBuffer.collect_output_partition``.
+    """
     table = table.copy(stream=stream, mr=br.device_mr)
     return TableChunk.from_pylibcudf_table(
         table,
@@ -370,15 +392,26 @@ class _OutputPartitionBuffer:
             if msg is None:
                 self.input_done = True
                 break
-            chunk = TableChunk.from_message(
-                msg, br=self.context.br()
-            ).make_available_and_spill(self.context.br(), allow_overbooking=True)
-            if chunk.table_view().num_rows() == 0:
+            chunk = TableChunk.from_message(msg, br=self.context.br())
+            if chunk.shape[0] == 0:
+                # Nothing to split, so skip the unspill and its reservation.
                 continue
-            with stream_ordered_after(
-                self.context.br().stream_pool.get_stream,
-                upstreams=(chunk.stream, self.boundary_chunk.stream),
-            ) as stream:
+            # The pieces copied out below hold the same rows as the chunk, so
+            # they need room for roughly a second copy of it and leave the
+            # total unchanged.
+            chunk, extra = await make_table_chunks_available_or_wait(
+                self.context,
+                chunk,
+                reserve_extra=chunk.data_alloc_size(),
+                net_memory_delta=0,
+            )
+            with (
+                opaque_memory_usage(extra),
+                stream_ordered_after(
+                    self.context.br().stream_pool.get_stream,
+                    upstreams=(chunk.stream, self.boundary_chunk.stream),
+                ) as stream,
+            ):
                 table = chunk.table_view()
                 splits = _split_points(
                     table,
@@ -582,7 +615,7 @@ async def _adjust_ordering_impl(
                 exchange.extract(source_rank),
                 strict=True,
             ):
-                chunk = _unpack_remote_partition(packed, stream, context.br())
+                chunk = await _unpack_remote_partition(context, packed, stream)
                 if chunk.table_view().num_rows() > 0:
                     _store_chunk(context, remote_pieces, pid, chunk)
             pieces_by_source[source_rank] = remote_pieces

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -21,7 +21,10 @@ from cudf_streaming.partition_utils import (
     unpack_and_concat as py_unpack_and_concat,
     unpack_and_concat_cost as py_unpack_and_concat_cost,
 )
-from cudf_streaming.table_chunk import TableChunk
+from cudf_streaming.table_chunk import (
+    TableChunk,
+    make_table_chunks_available_or_wait,
+)
 from rapidsmpf.communicator.single import new_communicator as single_comm
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.memory_reservation import opaque_memory_usage
@@ -542,9 +545,12 @@ async def _global_shuffle(
     async with shuffle.inserting() as inserter:
         while (msg := await ch_in.recv(context)) is not None:
             if not skip_insert:
-                chunk = TableChunk.from_message(
-                    msg, br=context.br()
-                ).make_available_and_spill(context.br(), allow_overbooking=True)
+                chunk, _ = await make_table_chunks_available_or_wait(
+                    context,
+                    TableChunk.from_message(msg, br=context.br()),
+                    reserve_extra=0,
+                    net_memory_delta=0,
+                )
                 if columns_to_hash is None:
                     await inserter.insert_hash_keys(chunk, keys_to_hash, input_schema)
                 else:

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/sort.py
@@ -250,7 +250,7 @@ async def extract_orderscheme_partitioning(
         )
         allgather = AllGatherManager(context, comm, collective_id)
         with allgather.inserting() as inserter:
-            inserter.insert(comm.rank, local_chunk)
+            await inserter.insert(comm.rank, local_chunk)
         endpoint_table = await allgather.extract_concatenated(
             stream, ordered=True, ir_context=ir_context
         )
@@ -334,7 +334,7 @@ async def _simple_top_or_bottom_k(
     if comm.nranks > 1 and not metadata_in.duplicated:
         allgather = AllGatherManager(context, comm, collective_ids.pop())
         with allgather.inserting() as inserter:
-            inserter.insert(comm.rank, chunk)
+            await inserter.insert(comm.rank, chunk)
 
         stream = ir_context.get_cuda_stream()
         chunk = await evaluate_chunk(
@@ -415,7 +415,7 @@ async def _compute_sort_boundaries(
         )
         allgather = AllGatherManager(context, comm, allgather_id)
         with allgather.inserting() as inserter:
-            inserter.insert(comm.rank, chunk)
+            await inserter.insert(comm.rank, chunk)
         concat_table = await allgather.extract_concatenated(
             stream, ordered=True, ir_context=ir_context
         )
@@ -583,9 +583,14 @@ async def _insert_chunks_into_shuffle(
             if skip_insert:
                 continue
             seq_num = msg.sequence_number
-            available_chunk = TableChunk.from_message(
-                msg, br=context.br()
-            ).make_available_and_spill(context.br(), allow_overbooking=True)
+            # The chunk's data moves into shuffler-owned packed buffers,
+            # nothing lasting is added.
+            available_chunk, _ = await make_table_chunks_available_or_wait(
+                context,
+                TableChunk.from_message(msg, br=context.br()),
+                reserve_extra=0,
+                net_memory_delta=0,
+            )
             tbl = available_chunk.table_view()
             sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
 

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
@@ -15,7 +15,10 @@ import polars as pl
 
 import pylibcudf as plc
 from cudf_streaming.channel_metadata import ChannelMetadata
-from cudf_streaming.table_chunk import TableChunk
+from cudf_streaming.table_chunk import (
+    TableChunk,
+    make_table_chunks_available_or_wait,
+)
 from rapidsmpf.memory.memory_reservation import opaque_memory_usage
 from rapidsmpf.streaming.core.memory_reserve_or_wait import reserve_memory
 from rapidsmpf.streaming.core.message import Message
@@ -782,9 +785,15 @@ async def sink_node(
                 _prepare_sink_directory(ir.sink.path)
                 i = 0
                 while (msg := await ch_in.recv(context)) is not None:
-                    chunk = TableChunk.from_message(
-                        msg, br=context.br()
-                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                    chunk = TableChunk.from_message(msg, br=context.br())
+                    # Terminal: the chunk is dropped after the write, so its
+                    # whole footprint leaves the system.
+                    chunk, _ = await make_table_chunks_available_or_wait(
+                        context,
+                        chunk,
+                        reserve_extra=0,
+                        net_memory_delta=-chunk.data_alloc_size(),
+                    )
                     df = chunk_to_frame(chunk, child_ir)
                     part_path = f"{path_root}.{str(i).zfill(count_width)}.{suffix}"
                     await ir_context.to_thread(
@@ -802,9 +811,15 @@ async def sink_node(
                 # Write chunks to a single file
                 writer_state = None
                 while (msg := await ch_in.recv(context)) is not None:
-                    chunk = TableChunk.from_message(
-                        msg, br=context.br()
-                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                    chunk = TableChunk.from_message(msg, br=context.br())
+                    # Terminal: the chunk is dropped after the write, so its
+                    # whole footprint leaves the system.
+                    chunk, _ = await make_table_chunks_available_or_wait(
+                        context,
+                        chunk,
+                        reserve_extra=0,
+                        net_memory_delta=-chunk.data_alloc_size(),
+                    )
                     # Multiple chunks - use chunked writer
                     df = chunk_to_frame(chunk, child_ir)
                     writer_state = await ir_context.to_thread(

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/join.py
@@ -21,6 +21,7 @@ from cudf_streaming.table_chunk import (
 from rapidsmpf.memory.memory_reservation import opaque_memory_usage
 from rapidsmpf.streaming.core.actor import define_actor
 from rapidsmpf.streaming.core.memory_reserve_or_wait import (
+    missing_net_memory_delta,
     reserve_memory,
 )
 
@@ -231,7 +232,7 @@ async def _collect_small_side_for_broadcast(
         allgather = AllGatherManager(context, comm, collective_id)
         with allgather.inserting() as inserter:
             for s_id in range(len(chunks)):
-                inserter.insert(s_id, chunks.pop(0))
+                await inserter.insert(s_id, chunks.pop(0))
         stream = ir_context.get_cuda_stream()
         gathered = await allgather.extract_concatenated(stream, ir_context=ir_context)
         # When every rank inserted zero chunks, the AllGather has no schema
@@ -408,6 +409,14 @@ async def _broadcast_join(
     )
 
     while (msg := await large_ch.recv(context)) is not None:
+        # Unknown: the large chunk is freed but the join output replaces
+        # it, and its size depends on selectivity we cannot estimate here.
+        large_chunk, _ = await make_table_chunks_available_or_wait(
+            context,
+            TableChunk.from_message(msg, br=context.br()),
+            reserve_extra=0,
+            net_memory_delta=missing_net_memory_delta,
+        )
         await _broadcast_join_large_chunk(
             context,
             ir,
@@ -415,9 +424,7 @@ async def _broadcast_join(
             ch_out,
             small_dfs,
             small_child,
-            TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
-                context.br(), allow_overbooking=True
-            ),
+            large_chunk,
             large_child,
             msg.sequence_number,
             small_size,
@@ -574,12 +581,17 @@ async def _join_chunks(
             f"Left: {left_msg.sequence_number}, Right: {right_msg.sequence_number}"
         )
 
-        left_chunk = TableChunk.from_message(
-            left_msg, br=context.br()
-        ).make_available_and_spill(context.br(), allow_overbooking=True)
-        right_chunk = TableChunk.from_message(
-            right_msg, br=context.br()
-        ).make_available_and_spill(context.br(), allow_overbooking=True)
+        # Unknown: both chunks are freed but the join output replaces them,
+        # and its size depends on selectivity we cannot estimate here.
+        (left_chunk, right_chunk), _ = await make_table_chunks_available_or_wait(
+            context,
+            [
+                TableChunk.from_message(left_msg, br=context.br()),
+                TableChunk.from_message(right_msg, br=context.br()),
+            ],
+            reserve_extra=0,
+            net_memory_delta=missing_net_memory_delta,
+        )
 
         input_bytes = sum(
             col.device_buffer_size()

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/nodes.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/nodes.py
@@ -291,9 +291,14 @@ async def fanout_node_bounded(
         )
 
         while (msg := await ch_in.recv(context)) is not None:
-            table_chunk = TableChunk.from_message(
-                msg, br=context.br()
-            ).make_available_and_spill(context.br(), allow_overbooking=True)
+            # Pass-through: every output wraps the same device buffer
+            # (exclusive_view=False), so nothing is duplicated.
+            table_chunk, _ = await make_table_chunks_available_or_wait(
+                context,
+                TableChunk.from_message(msg, br=context.br()),
+                reserve_extra=0,
+                net_memory_delta=0,
+            )
             seq_num = msg.sequence_number
             del msg
             for ch_out in chs_out:
@@ -462,30 +467,33 @@ async def fanout_node_unbounded(
                             # We need (num_outputs - 1) copies since last one reuses original
                             num_copies = num_outputs - 1
                             total_copy_cost = msg.copy_cost() * num_copies
-                            available_device_mem = context.br().memory_available(
-                                MemoryType.DEVICE
-                            )
 
-                            # Decide target memory:
-                            # Use device ONLY if message is in device AND we have sufficient headroom.
-                            if (
-                                device_size > 0
-                                and available_device_mem >= total_copy_cost
-                            ):
-                                # Use reserve_device_memory_and_spill to automatically trigger spilling
-                                # if needed to make room for the copy
-                                memory_reservation = (
-                                    context.br().reserve_device_memory_and_spill(
-                                        total_copy_cost,
-                                        allow_overbooking=True,
-                                    )
-                                )
-                            else:
-                                # Use host memory for buffering - much safer
-                                # Downstream consumers will make_available() when they need device memory
+                            # Decide target memory. Keep the copies on device when
+                            # the message is already there and device has room,
+                            # otherwise buffer on host. Downstream consumers call
+                            # make_available() when they need device memory.
+                            # `reserve_or_fail` takes the first type that fits
+                            # without spilling, so it neither blocks the event loop
+                            # nor races a separate memory_available() check.
+                            mem_types = (
+                                [
+                                    MemoryType.DEVICE,
+                                    MemoryType.PINNED_HOST,
+                                    MemoryType.HOST,
+                                ]
+                                if device_size > 0
+                                else [MemoryType.PINNED_HOST, MemoryType.HOST]
+                            )
+                            try:
                                 memory_reservation = context.br().reserve_or_fail(
+                                    total_copy_cost, mem_types
+                                )
+                            except RuntimeError:
+                                # Nothing fit. Overbook on host rather than fail the query.
+                                memory_reservation, _ = context.br().reserve(
+                                    MemoryType.HOST,
                                     total_copy_cost,
-                                    [MemoryType.PINNED_HOST, MemoryType.HOST],
+                                    allow_overbooking=True,
                                 )
 
                             # Copy message for each output buffer

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -252,6 +252,10 @@ def _origin_stamps_for(ir: Over) -> OriginStamps:
     return OriginStamps(next(names), next(names), next(names))
 
 
+# _append_origin_stamps appends three int32 columns.
+_ORIGIN_STAMP_BYTES_PER_ROW = 3 * 4
+
+
 def _append_origin_stamps(
     chunk: TableChunk,
     chunk_index: int,
@@ -496,9 +500,19 @@ async def _distribute_by_group(
     chunk_index = 0
     async with forward_shuffle.inserting() as inserter:
         while (msg := await ch_in.recv(context)) is not None:
-            chunk = TableChunk.from_message(
-                msg, br=context.br()
-            ).make_available_and_spill(context.br(), allow_overbooking=True)
+            chunk = TableChunk.from_message(msg, br=context.br())
+            stamp_bytes = (
+                0 if skip_insert else _ORIGIN_STAMP_BYTES_PER_ROW * chunk.shape[0]
+            )
+            # The chunk's data moves into shuffler-owned packed buffers, so the
+            # stamp columns _append_origin_stamps allocates below are both the
+            # extra we need and the only lasting addition.
+            chunk, extra = await make_table_chunks_available_or_wait(
+                context,
+                chunk,
+                reserve_extra=stamp_bytes,
+                net_memory_delta=stamp_bytes,
+            )
             sequence_numbers.append(msg.sequence_number)
             if not skip_insert:
                 # TODO: For duplicated input only rank 0 inserts here, and
@@ -507,14 +521,15 @@ async def _distribute_by_group(
                 # 1..nranks-1 sit idle on emit. Slice the duplicated input
                 # across ranks (e.g. stripe by row index) and stamp each
                 # slice with its target origin rank to distribute emit work.
-                stamped = await ir_context.to_thread(
-                    _append_origin_stamps,
-                    chunk,
-                    chunk_index,
-                    comm.rank,
-                    ir_context.get_cuda_stream(),
-                    context.br(),
-                )
+                with opaque_memory_usage(extra):
+                    stamped = await ir_context.to_thread(
+                        _append_origin_stamps,
+                        chunk,
+                        chunk_index,
+                        comm.rank,
+                        ir_context.get_cuda_stream(),
+                        context.br(),
+                    )
                 await inserter.insert_hash(stamped, key_indices)
             chunk_index += 1
     return sequence_numbers

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
@@ -148,7 +148,7 @@ async def concatenate_node(
             allgather = AllGatherManager(context, comm, collective_id)
             with allgather.inserting() as inserter:
                 while (msg := await ch_in.recv(context)) is not None:
-                    inserter.insert(
+                    await inserter.insert(
                         seq_num, TableChunk.from_message(msg, br=context.br())
                     )
                     seq_num += 1

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/union.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/union.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from cudf_streaming.channel_metadata import ChannelMetadata
-from cudf_streaming.table_chunk import TableChunk
+from cudf_streaming.table_chunk import (
+    TableChunk,
+    make_table_chunks_available_or_wait,
+)
 from rapidsmpf.streaming.core.message import Message
 
 from cudf_polars.dsl.ir import Union
@@ -94,9 +97,14 @@ async def union_node(
                     stream = ir_context.get_cuda_stream()
                     out_chunk = empty_table_chunk(ir, context, stream)
                 else:
-                    out_chunk = TableChunk.from_message(
-                        msg, br=context.br()
-                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                    # Relay: the unspilled chunk is forwarded as-is, nothing
+                    # is duplicated or freed.
+                    out_chunk, _ = await make_table_chunks_available_or_wait(
+                        context,
+                        TableChunk.from_message(msg, br=context.br()),
+                        reserve_extra=0,
+                        net_memory_delta=0,
+                    )
                 await ch_out.send(
                     context,
                     Message(

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/utils.py
@@ -852,7 +852,7 @@ async def allgather_and_reduce(
     """
     allgather = AllGatherManager(context, comm, collective_id)
     with allgather.inserting() as inserter:
-        inserter.insert(0, local_chunk)
+        await inserter.insert(0, local_chunk)
     stream = ir_context.get_cuda_stream()
     concat_chunk = TableChunk.from_pylibcudf_table(
         await allgather.extract_concatenated(stream, ir_context=ir_context),

--- a/python/cudf_polars/tests/streaming/test_allgather.py
+++ b/python/cudf_polars/tests/streaming/test_allgather.py
@@ -40,7 +40,7 @@ async def _test_allgather(engine) -> None:
     allgather = AllGatherManager(context, comm, 0)
     with allgather.inserting() as inserter:
         for i, table in enumerate(tables):
-            inserter.insert(
+            await inserter.insert(
                 i,
                 TableChunk.from_pylibcudf_table(
                     table, stream, exclusive_view=True, br=context.br()


### PR DESCRIPTION
Every actor on a rank shares one event loop, so an actor that reserves device memory synchronously stalls all the others while it spills. This moves every such reservation that runs inside an actor coroutine off the blocking path. They take their memory from `reserve_memory()` now, so a request that cannot be satisfied queues alongside the other actors' and is served by priority instead of spilling on the spot. That gives these sites memory backpressure as well as an unblocked loop, since an actor waiting on a reservation lets the ones that can release memory run first.

### Unspilling table chunks

`TableChunk.make_available_and_spill()` spills synchronously. Twelve call sites move to the awaitable `make_table_chunks_available_or_wait()`, which suspends until a reservation is granted so the other actors can run and release memory meanwhile.


`AllGatherManager.Inserter.insert` and `_unpack_remote_partition` become coroutines, updating eight call sites across `join.py`, `repartition.py`, `sort.py`, `utils.py`, `ordering.py` and the AllGather tests. `_unpack_remote_partition` also takes the context rather than a buffer resource. Neither is public API.

### Behavior change

The unspill calls previously passed `allow_overbooking=True`. They now fall through to the `allow_overbooking_by_default` configuration option, matching every existing `make_table_chunks_available_or_wait()` call site. That option ships as `true`, so under the default the only difference is that these sites wait for memory before overbooking rather than overbooking immediately. With the option set to `false` they can raise where previously they could not.

