### PR TITLE
Fix Literal broadcasting in pl.struct

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
@@ -1351,18 +1351,22 @@ class UnaryFunction(Expr):
                 dtype=self.dtype,
             )
         elif self.name == "as_struct":
-            children = [
-                child.evaluate(df, context=context).obj for child in self.children
-            ]
+            children = [child.evaluate(df, context=context) for child in self.children]
+            non_unit_sizes = [c.size for c in children if c.size != 1]
+            broadcasted = broadcast(
+                *children,
+                target_length=max(non_unit_sizes) if non_unit_sizes else None,
+                stream=df.stream,
+            )
             return Column(
                 plc.Column(
                     data_type=self.dtype.plc_type,
-                    size=children[0].size(),
+                    size=broadcasted[0].size,
                     data=None,
                     mask=None,
                     null_count=0,
                     offset=0,
-                    children=children,
+                    children=[c.obj for c in broadcasted],
                 ),
                 dtype=self.dtype,
             )

--- a/python/cudf_polars/tests/expressions/test_struct.py
+++ b/python/cudf_polars/tests/expressions/test_struct.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -120,4 +120,15 @@ def test_nested_struct(engine: pl.GPUEngine):
 def test_value_counts_with_nulls(engine: pl.GPUEngine, ldf):
     ldf_with_nulls = ldf.select(c=pl.Series(["x", None, "y", "x", None, "x"]))
     q = ldf_with_nulls.select(pl.col("c").value_counts(sort=True))
+    assert_gpu_result_equal(q, engine=engine)
+
+
+@pytest.mark.parametrize("literal", [pl.lit(value=False), pl.lit(7)])
+def test_struct_literal_field_is_broadcast(
+    engine: pl.GPUEngine, literal: pl.Expr
+) -> None:
+    df = pl.LazyFrame(
+        {"a": [1, 2, 3], "b": ["dogs", "cats", None], "c": ["play", "swim", "walk"]}
+    )
+    q = df.select(pl.struct("a", x="c", y=literal).alias("struct").struct.field("y"))
     assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cudf/actions/runs/33362692439/job/99397029474#step:14:4240 is a failing narwhals test in an expression involving `pl.struct` with a literal. We need to ensure that the literal is broadcast to the correct size, otherwise the output dataframe has an incorrect number of rows.