### PR TITLE
Fix racecheck in segmented_offset_bitmask_binop kernel

### DIFF
--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -19,7 +19,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
 #include <cub/block/block_reduce.cuh>
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/atomic>
@@ -160,18 +159,10 @@ CUDF_KERNEL void segmented_offset_bitmask_binop(Binop op,
                                                 size_type const* const segment_offsets,
                                                 size_type* const null_counts)
 {
-  namespace cg = cooperative_groups;
-
-  // Treat the whole block as a single tile
-  __shared__ cg::block_tile_memory<block_size> tile_memory;
-  auto const block = cg::this_thread_block(tile_memory);
-  auto const tile  = cg::tiled_partition<block_size>(block);
-
   // Blocks are assigned to segments in consecutive groups of `blocks_per_segment`
-  auto const block_rank       = static_cast<size_type>(block.group_index().x);
+  auto const block_rank       = static_cast<size_type>(blockIdx.x);
   auto const segment_id       = block_rank / blocks_per_segment;
   auto const block_in_segment = block_rank % blocks_per_segment;
-  // Uniform across the block, so the collective below is still reached by all of the tile's threads
   if (segment_id >= num_segments) { return; }
 
   auto const segment_start = segment_offsets[segment_id];
@@ -188,7 +179,7 @@ CUDF_KERNEL void segmented_offset_bitmask_binop(Binop op,
 
   // Process the mask such that each thread of the segment's blocks handles different words
   for (auto destination_word_index =
-         block_in_segment * block_size + static_cast<size_type>(tile.thread_rank());
+         block_in_segment * block_size + static_cast<size_type>(threadIdx.x);
        destination_word_index < destination_size;
        destination_word_index += blocks_per_segment * block_size) {
     bitmask_type destination_word = identity;
@@ -221,13 +212,15 @@ CUDF_KERNEL void segmented_offset_bitmask_binop(Binop op,
     destination[destination_word_index] = destination_word;
   }
 
-  // Reduce the null counts across the block, then across the blocks of the segment
-  auto const block_null_count = cg::reduce(tile, thread_null_count, cg::plus<size_type>());
-  if (block_null_count > 0) {
-    cg::invoke_one(tile, [&] {
-      cuda::atomic_ref<size_type, cuda::thread_scope_device>{null_counts[segment_id]}.fetch_add(
-        block_null_count, cuda::std::memory_order_relaxed);
-    });
+  // Reduce the null counts across the block, then accumulate across the blocks of the segment.
+  // Use cub::BlockReduce (instead of cg::reduce + block_tile_memory) to avoid shared-memory races
+  // that compute-sanitizer detects in CG's multi-warp reduction tree.
+  using BlockReduce = cub::BlockReduce<size_type, block_size>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  auto const block_null_count = BlockReduce(temp_storage).Sum(thread_null_count);
+  if (threadIdx.x == 0 && block_null_count > 0) {
+    cuda::atomic_ref<size_type, cuda::thread_scope_device>{null_counts[segment_id]}.fetch_add(
+      block_null_count, cuda::std::memory_order_relaxed);
   }
 }
 


### PR DESCRIPTION
## Description
Fixes a racecheck in the `segmented_offset_bitmask_binop` libcudf kernel. This was found in the weekly compute-sanitizer run: https://github.com/NVIDIA/cudf/actions/runs/33247027974/job/99086397670#step:5:3039

```
[ RUN      ] MergeBitmaskTest.TestSegmentedBitmaskAndSingleSegment
========= Error: Race reported between Write access at decltype((param#3(param#2, param#2))) cooperative_groups::__v1::details::tile_reduce_dispatch<(unsigned int)5>::reduce<(unsigned int)256, cooperative_groups::__v1::thread_block, int &, cooperative_groups::__v1::plus<int>>(const cooperative_groups::__v1::thread_block_tile<T1, T2> &, T3 &&, T4 &&)::[lambda(const cooperative_groups::__v1::details::internal_thread_block_tile<(unsigned int)32, cooperative_groups::__v1::__static_size_multi_warp_tile_base<(unsigned int)256>> &, int *) (instance 1)]::operator ()(const cooperative_groups::__v1::details::internal_thread_block_tile<(unsigned int)32, cooperative_groups::__v1::__static_size_multi_warp_tile_base<(unsigned int)256>> &, int *) const+0xeb0 in reduce.h:283
=========     and Read access at decltype((param#3(param#2, param#2))) cooperative_groups::__v1::details::coalesced_reduce<int &, cooperative_groups::__v1::plus<int>, (unsigned int)8, cooperative_groups::__v1::details::internal_thread_block_tile<(unsigned int)32, cooperative_groups::__v1::__static_size_multi_warp_tile_base<(unsigned int)256>>>(const cooperative_groups::__v1::__single_warp_thread_block_tile<T3, T4> &, T1 &&, T2 &&)+0x10d0 in coalesced_reduce.h:66 [28 hazards]
=========

```

The race `compute-sanitizer` detects is a real shared-memory hazard: within `cg::reduce's` hierarchical reduction tree  (e.g., 8 warps → 4 → 2 → 1), one level writes partial sums to shared memory and the next level reads them. The  CG library uses `__syncthreads()` internally to order these, but `compute-sanitizer` racecheck operates at a warp granularity — it sees one warp writing shared memory and another warp reading that same location, and flags  it as a race because the `__syncthreads` barrier is between those two events but racecheck's memory access tracking can fire before the barrier is resolved in its model.

The solution employed here replaces the CG calls with equivalent CUB `BlockReduce` calls instead which seems to make `compute-sanitizer` happy. The benchmarks showed no performance regressions with the modified code.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
