### PR TITLE
Fix racecheck in parquet reader delta byte array kernels

### DIFF
--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -314,6 +314,11 @@ struct delta_binary_decoder {
       rolling_index<delta_rolling_buf_size>(current_value_idx + warp_size * pass + lane_id);
     value[value_idx] = delta;
 
+    // lanes can reach this point at different times (the bit-unpacking loop above has a
+    // lane-dependent trip count), so make sure every lane's read of last_value above has
+    // happened before lane 31 overwrites it below.
+    warp.sync();
+
     // save value from last lane in warp. this will become the 'first value' added to the
     // deltas calculated in the next pass (or invocation).
     if (lane_id == warp_size - 1) { last_value = delta; }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -117,10 +117,15 @@ struct delta_byte_array_decoder {
 
     // now fill in blockers until done
     for (uint32_t i = 1; i < warp_size && i + start_idx < end_idx; i++) {
-      if (prefix_len != 0 && prefix_lens[blocker] == 0 && lane_out != nullptr) {
+      // record whether this lane's blocker is complete before any lane writes below
+      // prevents race condition accessing prefix_lens
+      bool const completed = prefix_len != 0 && prefix_lens[blocker] == 0 && lane_out != nullptr;
+      __syncwarp();
+      if (completed) {
         memcpy(lane_out, offsets[blocker], prefix_len);
         prefix_lens[lane_id] = prefix_len = 0;
       }
+      __syncwarp();
 
       // check for finished
       if (__all_sync(0xffff'ffff, prefix_len == 0)) { return; }
@@ -214,8 +219,13 @@ struct delta_byte_array_decoder {
     // the next batch overwrites the temp scratch from its start, so if the last decoded string
     // lives there, preserve it in the reserved seed slot ahead of the scratch
     if (end_idx <= start_val && last_string != prefix_seed) {
+      // snapshot before lane 0 overwrites last_string below; without this sync, other lanes'
+      // (unused but still issued) reads of last_string can race with lane 0's write of it.
+      uint8_t const* const last_string_snapshot = last_string;
+      uint32_t const last_string_len_snapshot   = last_string_len;
+      __syncwarp();
       if (lane_id == 0) {
-        memcpy(prefix_seed, last_string, last_string_len);
+        memcpy(prefix_seed, last_string_snapshot, last_string_len_snapshot);
         last_string = prefix_seed;
       }
       __syncwarp();
@@ -279,8 +289,13 @@ struct delta_byte_array_decoder {
     // the next batch overwrites the temp scratch from its start, so if the last decoded string
     // lives there, preserve it in the reserved seed slot ahead of the scratch
     if (end_idx <= start_val && last_string != prefix_seed) {
+      // snapshot before lane 0 overwrites last_string below; without this sync, other lanes'
+      // (unused but still issued) reads of last_string can race with lane 0's write of it.
+      uint8_t const* const last_string_snapshot = last_string;
+      uint32_t const last_string_len_snapshot   = last_string_len;
+      __syncwarp();
       if (lane_id == 0) {
-        memcpy(prefix_seed, last_string, last_string_len);
+        memcpy(prefix_seed, last_string_snapshot, last_string_len_snapshot);
         last_string = prefix_seed;
       }
       __syncwarp();


### PR DESCRIPTION
## Description
Fixes some racecheck warnings reported by compute-sanitizer in the weekly CI runs: https://github.com/NVIDIA/cudf/actions/runs/33247027974/job/99086397880#step:5:3314
```
[ RUN      ] ParquetReaderTest.DeltaByteArrayLargeMiniBlockSkipRows
========= Warning: Race reported between Read access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)+0x19710 in page_delta_decode.cu:222
=========     and Write access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)+0x198b0 in page_delta_decode.cu:225 [8 hazards]
=========
========= Warning: Race reported between Read access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)+0x19710 in page_delta_decode.cu:222
=========     and Write access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)+0x198b0 in page_delta_decode.cu:225 [16 hazards]
=========
[       OK ] ParquetReaderTest.DeltaByteArrayLargeMiniBlockSkipRows (2385 ms)
```
Adds appropriate sync-warp to prevent the race condition.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
