### PR TITLE
Allow prebuilt `filesystem` object in cuIO readers and writers

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -7827,6 +7827,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         max_page_size_bytes=None,
         max_page_size_rows=None,
         storage_options=None,
+        filesystem=None,
         return_metadata=False,
         use_dictionary=True,
         header_version="1.0",
@@ -7857,6 +7858,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             max_page_size_bytes=max_page_size_bytes,
             max_page_size_rows=max_page_size_rows,
             storage_options=storage_options,
+            filesystem=filesystem,
             return_metadata=return_metadata,
             use_dictionary=use_dictionary,
             header_version=header_version,
@@ -7890,6 +7892,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         lineterminator=None,
         chunksize=None,
         storage_options=None,
+        filesystem=None,
     ):
         """{docstring}"""
         from cudf.io import csv
@@ -7909,6 +7912,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             encoding=encoding,
             compression=compression,
             storage_options=storage_options,
+            filesystem=filesystem,
             quoting=quoting,
         )
 
@@ -7923,6 +7927,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         row_index_stride=None,
         cols_as_map_type=None,
         storage_options=None,
+        filesystem=None,
         index=None,
     ):
         """{docstring}"""
@@ -7938,6 +7943,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             row_index_stride=row_index_stride,
             cols_as_map_type=cols_as_map_type,
             storage_options=storage_options,
+            filesystem=filesystem,
             index=index,
         )
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -7827,7 +7827,6 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         max_page_size_bytes=None,
         max_page_size_rows=None,
         storage_options=None,
-        filesystem=None,
         return_metadata=False,
         use_dictionary=True,
         header_version="1.0",
@@ -7836,6 +7835,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         column_type_length=None,
         output_as_binary=None,
         *args,
+        filesystem=None,
         **kwargs,
     ):
         """{docstring}"""
@@ -7927,8 +7927,8 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         row_index_stride=None,
         cols_as_map_type=None,
         storage_options=None,
-        filesystem=None,
         index=None,
+        filesystem=None,
     ):
         """{docstring}"""
         from cudf.io import orc

--- a/python/cudf/cudf/io/avro.py
+++ b/python/cudf/cudf/io/avro.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pylibcudf as plc

--- a/python/cudf/cudf/io/avro.py
+++ b/python/cudf/cudf/io/avro.py
@@ -14,12 +14,14 @@ def read_avro(
     skiprows=None,
     num_rows=None,
     storage_options=None,
+    filesystem=None,
 ):
     """{docstring}"""
 
     filepath_or_buffer = ioutils.get_reader_filepath_or_buffer(
         path_or_data=filepath_or_buffer,
         storage_options=storage_options,
+        filesystem=filesystem,
     )
     filepath_or_buffer = ioutils._select_single_source(
         filepath_or_buffer, "read_avro"

--- a/python/cudf/cudf/io/csv.py
+++ b/python/cudf/cudf/io/csv.py
@@ -123,8 +123,8 @@ def read_csv(
     comment: str | None = None,
     byte_range: list[int] | tuple[int, int] | None = None,
     storage_options=None,
-    filesystem=None,
     bytes_per_thread: int | None = None,
+    filesystem=None,
 ) -> DataFrame:
     """{docstring}"""
 

--- a/python/cudf/cudf/io/csv.py
+++ b/python/cudf/cudf/io/csv.py
@@ -123,6 +123,7 @@ def read_csv(
     comment: str | None = None,
     byte_range: list[int] | tuple[int, int] | None = None,
     storage_options=None,
+    filesystem=None,
     bytes_per_thread: int | None = None,
 ) -> DataFrame:
     """{docstring}"""
@@ -148,6 +149,7 @@ def read_csv(
         path_or_data=filepath_or_buffer,
         iotypes=(BytesIO, StringIO),
         storage_options=storage_options,
+        filesystem=filesystem,
         bytes_per_thread=bytes_per_thread,
     )
     filepath_or_buffer = ioutils._select_single_source(
@@ -406,6 +408,7 @@ def to_csv(
     lineterminator: str = "\n",
     chunksize: int | None = None,
     storage_options=None,
+    filesystem=None,
 ):
     """{docstring}"""
 
@@ -449,7 +452,10 @@ def to_csv(
         return_as_string = True
 
     path_or_buf = ioutils.get_writer_filepath_or_buffer(
-        path_or_data=path_or_buf, mode="w", storage_options=storage_options
+        path_or_data=path_or_buf,
+        mode="w",
+        storage_options=storage_options,
+        filesystem=filesystem,
     )
 
     if columns is not None:

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -119,11 +119,11 @@ def read_json(
     byte_range: None | list[int] = None,
     keep_quotes: bool = False,
     storage_options=None,
-    filesystem=None,
     mixed_types_as_string: bool = False,
     prune_columns: bool = False,
     on_bad_lines: Literal["error", "recover"] = "error",
     *args,
+    filesystem=None,
     **kwargs,
 ) -> DataFrame:
     """{docstring}"""
@@ -371,8 +371,8 @@ def to_json(
     engine: Literal["auto", "pandas", "cudf"] = "auto",
     orient=None,
     storage_options=None,
-    filesystem=None,
     *args,
+    filesystem=None,
     **kwargs,
 ):
     """{docstring}"""

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -119,6 +119,7 @@ def read_json(
     byte_range: None | list[int] = None,
     keep_quotes: bool = False,
     storage_options=None,
+    filesystem=None,
     mixed_types_as_string: bool = False,
     prune_columns: bool = False,
     on_bad_lines: Literal["error", "recover"] = "error",
@@ -155,6 +156,7 @@ def read_json(
             path_or_buf,
             iotypes=(BytesIO, StringIO),
             storage_options=storage_options,
+            filesystem=filesystem,
             warn_meta=("json", "read_json"),
             expand_dir_pattern="*.json",
         )
@@ -244,6 +246,7 @@ def read_json(
             path_or_data=path_or_buf,
             iotypes=(BytesIO, StringIO),
             storage_options=storage_options,
+            filesystem=filesystem,
         )
         filepath_or_buffer = ioutils._select_single_source(
             filepath_or_buffer, "read_json (via pandas)"
@@ -368,6 +371,7 @@ def to_json(
     engine: Literal["auto", "pandas", "cudf"] = "auto",
     orient=None,
     storage_options=None,
+    filesystem=None,
     *args,
     **kwargs,
 ):
@@ -391,6 +395,7 @@ def to_json(
                 path_or_data=path_or_buf,
                 mode="w",
                 storage_options=storage_options,
+                filesystem=filesystem,
             )
             return_as_string = False
 
@@ -419,6 +424,11 @@ def to_json(
             path_or_buf.seek(0)
             return path_or_buf.read()
     elif engine == "pandas":
+        if filesystem is not None:
+            raise NotImplementedError(
+                "filesystem is not supported with engine='pandas'. "
+                "Use storage_options instead, or engine='cudf'."
+            )
         warnings.warn("Using CPU via Pandas to write JSON dataset")
         if isinstance(cudf_val, DataFrame):
             pd_data = {

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -164,6 +164,7 @@ def read_orc(
     use_index: bool = True,
     timestamp_type=None,
     storage_options=None,
+    filesystem=None,
     bytes_per_thread=None,
 ):
     """{docstring}"""
@@ -202,6 +203,7 @@ def read_orc(
     filepaths_or_buffers = ioutils.get_reader_filepath_or_buffer(
         path_or_data=filepath_or_buffer,
         storage_options=storage_options,
+        filesystem=filesystem,
         bytes_per_thread=bytes_per_thread,
         expand_dir_pattern="*.orc",
     )
@@ -372,6 +374,7 @@ def to_orc(
     row_index_stride: int | None = None,
     cols_as_map_type=None,
     storage_options=None,
+    filesystem=None,
     index: bool | None = None,
 ):
     """{docstring}"""
@@ -393,7 +396,10 @@ def to_orc(
         raise TypeError("cols_as_map_type must be a list of column names.")
 
     path_or_buf = ioutils.get_writer_filepath_or_buffer(
-        path_or_data=fname, mode="wb", storage_options=storage_options
+        path_or_data=fname,
+        mode="wb",
+        storage_options=storage_options,
+        filesystem=filesystem,
     )
     if ioutils.is_fsspec_open_file(path_or_buf):
         with path_or_buf as file_obj:

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -164,8 +164,8 @@ def read_orc(
     use_index: bool = True,
     timestamp_type=None,
     storage_options=None,
-    filesystem=None,
     bytes_per_thread=None,
+    filesystem=None,
 ):
     """{docstring}"""
     if skiprows is not None:
@@ -374,8 +374,8 @@ def to_orc(
     row_index_stride: int | None = None,
     cols_as_map_type=None,
     storage_options=None,
-    filesystem=None,
     index: bool | None = None,
+    filesystem=None,
 ):
     """{docstring}"""
 

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -2128,9 +2128,8 @@ class ParquetDatasetWriter:
             ioutils._validate_filesystem(filesystem, storage_options)
         self.filesystem = filesystem
 
-        # libcudf's chunked-writer sinks only understand local paths, so
-        # remote output is staged in a temporary directory and uploaded on
-        # `close()`.
+        # libcudf's chunked sinks only take local paths, so remote output is
+        # staged in a temp dir and uploaded in `close()`.
         is_remote = (
             filesystem is not None
             and not ioutils._is_local_filesystem(filesystem)
@@ -2183,8 +2182,7 @@ class ParquetDatasetWriter:
             preserve_index=self.common_args["index"],
         )
         if self.fs_meta.get("is_remote", False):
-            # `self.path` is a local staging directory here; the upload to the
-            # remote store happens in `close()`.
+            # `self.path` is the local staging dir (see `__init__`)
             fs = ioutils._ensure_filesystem(None, self.path, None)
         else:
             fs = ioutils._ensure_filesystem(

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -727,12 +727,16 @@ def _parse_metadata(meta) -> tuple[bool, Any, None | np.dtype]:
 @_performance_tracking
 def read_parquet_metadata(
     filepath_or_buffer,
+    storage_options=None,
+    filesystem=None,
 ) -> tuple[int, int, Sequence[Hashable], int, Sequence[dict[str, int]]]:
     """{docstring}"""
 
     # List of filepaths or buffers
     filepaths_or_buffers = ioutils.get_reader_filepath_or_buffer(
         path_or_data=filepath_or_buffer,
+        storage_options=storage_options,
+        filesystem=filesystem,
         bytes_per_thread=None,
     )
 

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -727,19 +727,13 @@ def _parse_metadata(meta) -> tuple[bool, Any, None | np.dtype]:
 @_performance_tracking
 def read_parquet_metadata(
     filepath_or_buffer,
-    storage_options=None,
-    filesystem=None,
 ) -> tuple[int, int, Sequence[Hashable], int, Sequence[dict[str, int]]]:
     """{docstring}"""
 
     # List of filepaths or buffers
     filepaths_or_buffers = ioutils.get_reader_filepath_or_buffer(
         path_or_data=filepath_or_buffer,
-        storage_options=storage_options,
-        filesystem=filesystem,
         bytes_per_thread=None,
-        # Only the footer is needed, so avoid pulling whole remote files
-        prefetch_options={"method": "parquet-footer"},
     )
 
     parquet_metadata = plc.io.parquet_metadata.read_parquet_metadata(

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -264,6 +264,7 @@ def _write_parquet(
     max_dictionary_size: int | None = None,
     partitions_info=None,
     storage_options=None,
+    filesystem=None,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
     use_dictionary: bool = True,
@@ -303,7 +304,10 @@ def _write_parquet(
 
     paths_or_bufs = [
         ioutils.get_writer_filepath_or_buffer(
-            path_or_data=path, mode="wb", storage_options=storage_options
+            path_or_data=path,
+            mode="wb",
+            storage_options=storage_options,
+            filesystem=filesystem,
         )
         for path in paths
     ]
@@ -365,6 +369,7 @@ def write_to_dataset(
     max_page_size_bytes: int | None = None,
     max_page_size_rows: int | None = None,
     storage_options=None,
+    filesystem=None,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
     use_dictionary: bool = True,
@@ -484,6 +489,9 @@ def write_to_dataset(
         be written uncompressed.
     """
 
+    if filesystem is not None:
+        ioutils._validate_filesystem(filesystem, storage_options)
+        fs = fs if fs is not None else filesystem
     fs = ioutils._ensure_filesystem(fs, root_path, storage_options)
     fs.mkdirs(root_path, exist_ok=True)
 
@@ -511,6 +519,7 @@ def write_to_dataset(
             index=preserve_index,
             partition_offsets=part_offsets,
             storage_options=storage_options,
+            filesystem=filesystem,
             metadata_file_path=metadata_file_path,
             statistics=statistics,
             int96_timestamps=int96_timestamps,
@@ -540,6 +549,7 @@ def write_to_dataset(
             compression=compression,
             index=preserve_index,
             storage_options=storage_options,
+            filesystem=filesystem,
             metadata_file_path=metadata_file_path,
             statistics=statistics,
             int96_timestamps=int96_timestamps,
@@ -786,7 +796,7 @@ def _process_dataset(
 
     # Deal with case that the user passed in a directory name
     file_list = paths
-    if len(paths) == 1 and ioutils.is_directory(paths[0]):
+    if len(paths) == 1 and ioutils.is_directory(paths[0], filesystem=fs):
         paths = ioutils.stringify_pathlike(paths[0])
     elif (
         filters is None
@@ -1534,6 +1544,7 @@ def to_parquet(
     max_page_size_rows: int | None = None,
     max_dictionary_size: int | None = None,
     storage_options=None,
+    filesystem=None,
     return_metadata: bool = False,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
@@ -1604,6 +1615,7 @@ def to_parquet(
                 max_page_size_rows=max_page_size_rows,
                 return_metadata=return_metadata,
                 storage_options=storage_options,
+                filesystem=filesystem,
                 force_nullable_schema=force_nullable_schema,
                 header_version=header_version,
                 use_dictionary=use_dictionary,
@@ -1635,6 +1647,7 @@ def to_parquet(
             max_dictionary_size=max_dictionary_size,
             partitions_info=partition_info,
             storage_options=storage_options,
+            filesystem=filesystem,
             force_nullable_schema=force_nullable_schema,
             header_version=header_version,
             use_dictionary=use_dictionary,
@@ -1670,6 +1683,9 @@ def to_parquet(
             )
         # Type ignore: mypy complains about potential duplicate arguments from *args
         # but our API design allows passing additional args/kwargs to pyarrow
+        if filesystem is not None:
+            ioutils._validate_filesystem(filesystem, storage_options)
+            kwargs["filesystem"] = filesystem
         return pq.write_to_dataset(  # type: ignore[misc]
             pa_table,
             root_path=path,
@@ -2106,6 +2122,7 @@ class ParquetDatasetWriter:
         max_file_size=None,
         file_name_prefix=None,
         storage_options=None,
+        filesystem=None,
     ) -> None:
         if isinstance(path, str) and path.startswith("s3://"):
             self.fs_meta = {"is_s3": True, "actual_path": path}
@@ -2131,6 +2148,9 @@ class ParquetDatasetWriter:
         # in self._chunked_writers for reverse lookup
         self.path_cw_map: dict[str, int] = {}
         self.storage_options = storage_options
+        if filesystem is not None:
+            ioutils._validate_filesystem(filesystem, storage_options)
+        self.filesystem = filesystem
         self.filename = file_name_prefix
         self.max_file_size = max_file_size
         if max_file_size is not None:
@@ -2153,7 +2173,14 @@ class ParquetDatasetWriter:
             partition_cols=self.partition_cols,
             preserve_index=self.common_args["index"],
         )
-        fs = ioutils._ensure_filesystem(None, self.path, None)
+        if self.fs_meta.get("is_s3", False):
+            # `self.path` is a local temporary directory here; the upload to S3
+            # happens in `close()` using the configured filesystem.
+            fs = ioutils._ensure_filesystem(None, self.path, None)
+        else:
+            fs = ioutils._ensure_filesystem(
+                self.filesystem, self.path, self.storage_options
+            )
         fs.mkdirs(self.path, exist_ok=True)
 
         full_paths = []
@@ -2293,7 +2320,9 @@ class ParquetDatasetWriter:
             local_path = self.path
             s3_path = self.fs_meta["actual_path"]
             s3_file, _ = ioutils._get_filesystem_and_paths(
-                s3_path, storage_options=self.storage_options
+                s3_path,
+                storage_options=self.storage_options,
+                filesystem=self.filesystem,
             )
             s3_file.put(local_path, s3_path, recursive=True)
             shutil.rmtree(self.path)

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -738,6 +738,8 @@ def read_parquet_metadata(
         storage_options=storage_options,
         filesystem=filesystem,
         bytes_per_thread=None,
+        # Only the footer is needed, so avoid pulling whole remote files
+        prefetch_options={"method": "parquet-footer"},
     )
 
     parquet_metadata = plc.io.parquet_metadata.read_parquet_metadata(

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -264,7 +264,6 @@ def _write_parquet(
     max_dictionary_size: int | None = None,
     partitions_info=None,
     storage_options=None,
-    filesystem=None,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
     use_dictionary: bool = True,
@@ -286,6 +285,7 @@ def _write_parquet(
     output_as_binary: set[Hashable] | None = None,
     write_arrow_schema: bool = True,
     page_level_compression: bool = False,
+    filesystem=None,
 ) -> np.ndarray | None:
     if is_list_like(paths) and len(paths) > 1:
         if partitions_info is None:
@@ -369,7 +369,6 @@ def write_to_dataset(
     max_page_size_bytes: int | None = None,
     max_page_size_rows: int | None = None,
     storage_options=None,
-    filesystem=None,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
     use_dictionary: bool = True,
@@ -391,6 +390,7 @@ def write_to_dataset(
     output_as_binary: set[Hashable] | None = None,
     store_schema=False,
     page_level_compression: bool = False,
+    filesystem=None,
 ):
     """Wraps `to_parquet` to write partitioned Parquet datasets.
     For each combination of partition group and value,
@@ -1544,7 +1544,6 @@ def to_parquet(
     max_page_size_rows: int | None = None,
     max_dictionary_size: int | None = None,
     storage_options=None,
-    filesystem=None,
     return_metadata: bool = False,
     force_nullable_schema: bool = False,
     header_version: Literal["1.0", "2.0"] = "1.0",
@@ -1568,6 +1567,7 @@ def to_parquet(
     store_schema=False,
     page_level_compression: bool = False,
     *args,
+    filesystem=None,
     **kwargs,
 ):
     """{docstring}"""
@@ -2124,8 +2124,20 @@ class ParquetDatasetWriter:
         storage_options=None,
         filesystem=None,
     ) -> None:
-        if isinstance(path, str) and path.startswith("s3://"):
-            self.fs_meta = {"is_s3": True, "actual_path": path}
+        if filesystem is not None:
+            ioutils._validate_filesystem(filesystem, storage_options)
+        self.filesystem = filesystem
+
+        # libcudf's chunked-writer sinks only understand local paths, so
+        # remote output is staged in a temporary directory and uploaded on
+        # `close()`.
+        is_remote = (
+            filesystem is not None
+            and not ioutils._is_local_filesystem(filesystem)
+        ) or (isinstance(path, str) and path.startswith("s3://"))
+
+        if is_remote:
+            self.fs_meta = {"is_remote": True, "actual_path": path}
             self.dir_: tempfile.TemporaryDirectory | None = (
                 tempfile.TemporaryDirectory()
             )
@@ -2148,9 +2160,6 @@ class ParquetDatasetWriter:
         # in self._chunked_writers for reverse lookup
         self.path_cw_map: dict[str, int] = {}
         self.storage_options = storage_options
-        if filesystem is not None:
-            ioutils._validate_filesystem(filesystem, storage_options)
-        self.filesystem = filesystem
         self.filename = file_name_prefix
         self.max_file_size = max_file_size
         if max_file_size is not None:
@@ -2173,9 +2182,9 @@ class ParquetDatasetWriter:
             partition_cols=self.partition_cols,
             preserve_index=self.common_args["index"],
         )
-        if self.fs_meta.get("is_s3", False):
-            # `self.path` is a local temporary directory here; the upload to S3
-            # happens in `close()` using the configured filesystem.
+        if self.fs_meta.get("is_remote", False):
+            # `self.path` is a local staging directory here; the upload to the
+            # remote store happens in `close()`.
             fs = ioutils._ensure_filesystem(None, self.path, None)
         else:
             fs = ioutils._ensure_filesystem(
@@ -2316,15 +2325,13 @@ class ParquetDatasetWriter:
             for cw, _, meta_path in self._chunked_writers
         ]
 
-        if self.fs_meta.get("is_s3", False):
+        if self.fs_meta.get("is_remote", False):
             local_path = self.path
-            s3_path = self.fs_meta["actual_path"]
-            s3_file, _ = ioutils._get_filesystem_and_paths(
-                s3_path,
-                storage_options=self.storage_options,
-                filesystem=self.filesystem,
+            remote_path = self.fs_meta["actual_path"]
+            fs = ioutils._ensure_filesystem(
+                self.filesystem, remote_path, self.storage_options
             )
-            s3_file.put(local_path, s3_path, recursive=True)
+            fs.put(local_path, remote_path, recursive=True)
             shutil.rmtree(self.path)
 
         if self.dir_ is not None:

--- a/python/cudf/cudf/io/text.py
+++ b/python/cudf/cudf/io/text.py
@@ -20,6 +20,7 @@ def read_text(
     compression=None,
     compression_offsets=None,
     storage_options=None,
+    filesystem=None,
 ) -> Series:
     """{docstring}"""
 
@@ -30,6 +31,7 @@ def read_text(
         path_or_data=filepath_or_buffer,
         iotypes=(BytesIO, StringIO),
         storage_options=storage_options,
+        filesystem=filesystem,
     )
     filepath_or_buffer = ioutils._select_single_source(
         filepath_or_buffer, "read_text"

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -329,14 +329,29 @@ def test_cudf_json_writer_sinks(sink, tmp_path):
             assert f.read() == '[{"a":1,"b":4},{"a":2,"b":5},{"a":3,"b":6}]'
 
 
-def test_cudf_json_writer_fsspec(tmp_path):
-    path = f"memory://{tmp_path.name}/test_df.json"
+@pytest.mark.parametrize("pass_filesystem", [False, True])
+def test_cudf_json_writer_fsspec(tmp_path, pass_filesystem):
     df = cudf.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    expected = '[{"a":1,"b":4},{"a":2,"b":5},{"a":3,"b":6}]'
 
-    df.to_json(path, engine="cudf")
+    if pass_filesystem:
+        # No protocol in the path: the filesystem object alone must resolve it.
+        path = f"/{tmp_path.name}/test_df_fs.json"
+        kwargs = {"filesystem": fsspec.filesystem("memory")}
+    else:
+        path = f"memory://{tmp_path.name}/test_df.json"
+        kwargs = {}
 
-    with fsspec.open(path, mode="rt") as file_obj:
-        assert file_obj.read() == '[{"a":1,"b":4},{"a":2,"b":5},{"a":3,"b":6}]'
+    df.to_json(path, engine="cudf", **kwargs)
+
+    with fsspec.open(f"memory://{path.split('://')[-1]}", mode="rt") as f:
+        assert f.read() == expected
+
+    # Round-trip through the reader with the same filesystem object
+    got = cudf.read_json(
+        path, engine="cudf", orient="records", lines=False, **kwargs
+    )
+    assert_eq(df, got)
 
 
 @pytest.fixture(params=["filepath", "pathobj", "bytes_io", "string_io", "url"])

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -3,7 +3,6 @@
 
 import copy
 import gzip
-import inspect
 import os
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -353,69 +352,6 @@ def test_cudf_json_writer_fsspec(tmp_path, pass_filesystem):
         path, engine="cudf", orient="records", lines=False, **kwargs
     )
     assert_eq(df, got)
-
-
-@pytest.mark.parametrize(
-    "func",
-    [
-        cudf.read_csv,
-        cudf.read_json,
-        cudf.read_orc,
-        cudf.read_avro,
-        cudf.read_text,
-        cudf.io.csv.to_csv,
-        cudf.io.json.to_json,
-        cudf.io.orc.to_orc,
-        cudf.io.parquet.to_parquet,
-        cudf.io.parquet.write_to_dataset,
-        cudf.DataFrame.to_parquet,
-        cudf.DataFrame.to_csv,
-        cudf.DataFrame.to_orc,
-    ],
-)
-def test_filesystem_kwarg_does_not_shift_positional_args(func):
-    """`filesystem` must never displace a pre-existing positional parameter."""
-    params = list(inspect.signature(func).parameters.values())
-    names = [p.name for p in params]
-    idx = names.index("filesystem")
-    kind = params[idx].kind
-
-    if kind is inspect.Parameter.KEYWORD_ONLY:
-        return
-    trailing = [n for n in names[idx + 1 :] if n != "kwargs"]
-    assert not trailing, (
-        f"{func.__name__}: `filesystem` precedes {trailing}, which shifts "
-        "existing positional arguments"
-    )
-
-
-def test_to_orc_accepts_legacy_positional_args(tmp_path):
-    """Regression: `index` used to bind to `filesystem` when passed positionally."""
-    df = cudf.DataFrame({"a": [1, 2, 3]})
-    target = str(tmp_path / "positional.orc")
-    # to_orc(df, fname, compression, statistics, stripe_size_bytes,
-    #        stripe_size_rows, row_index_stride, cols_as_map_type,
-    #        storage_options, index)
-    cudf.io.orc.to_orc(
-        df, target, "snappy", "ROWGROUP", None, None, None, None, None, True
-    )
-    assert_eq(cudf.read_orc(target)[["a"]], df)
-
-
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"filesystem": "not-a-filesystem"},
-        {
-            "filesystem": fsspec.filesystem("memory"),
-            "storage_options": {"a": 1},
-        },
-    ],
-)
-def test_invalid_filesystem_rejected_for_file_like_input(kwargs):
-    """Validation must not depend on the source being a string path."""
-    with pytest.raises(ValueError):
-        cudf.read_json(BytesIO(b'[{"a": 1}]'), engine="cudf", **kwargs)
 
 
 @pytest.fixture(params=["filepath", "pathobj", "bytes_io", "string_io", "url"])

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -3,6 +3,7 @@
 
 import copy
 import gzip
+import inspect
 import os
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -352,6 +353,69 @@ def test_cudf_json_writer_fsspec(tmp_path, pass_filesystem):
         path, engine="cudf", orient="records", lines=False, **kwargs
     )
     assert_eq(df, got)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        cudf.read_csv,
+        cudf.read_json,
+        cudf.read_orc,
+        cudf.read_avro,
+        cudf.read_text,
+        cudf.io.csv.to_csv,
+        cudf.io.json.to_json,
+        cudf.io.orc.to_orc,
+        cudf.io.parquet.to_parquet,
+        cudf.io.parquet.write_to_dataset,
+        cudf.DataFrame.to_parquet,
+        cudf.DataFrame.to_csv,
+        cudf.DataFrame.to_orc,
+    ],
+)
+def test_filesystem_kwarg_does_not_shift_positional_args(func):
+    """`filesystem` must never displace a pre-existing positional parameter."""
+    params = list(inspect.signature(func).parameters.values())
+    names = [p.name for p in params]
+    idx = names.index("filesystem")
+    kind = params[idx].kind
+
+    if kind is inspect.Parameter.KEYWORD_ONLY:
+        return
+    trailing = [n for n in names[idx + 1 :] if n != "kwargs"]
+    assert not trailing, (
+        f"{func.__name__}: `filesystem` precedes {trailing}, which shifts "
+        "existing positional arguments"
+    )
+
+
+def test_to_orc_accepts_legacy_positional_args(tmp_path):
+    """Regression: `index` used to bind to `filesystem` when passed positionally."""
+    df = cudf.DataFrame({"a": [1, 2, 3]})
+    target = str(tmp_path / "positional.orc")
+    # to_orc(df, fname, compression, statistics, stripe_size_bytes,
+    #        stripe_size_rows, row_index_stride, cols_as_map_type,
+    #        storage_options, index)
+    cudf.io.orc.to_orc(
+        df, target, "snappy", "ROWGROUP", None, None, None, None, None, True
+    )
+    assert_eq(cudf.read_orc(target)[["a"]], df)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"filesystem": "not-a-filesystem"},
+        {
+            "filesystem": fsspec.filesystem("memory"),
+            "storage_options": {"a": 1},
+        },
+    ],
+)
+def test_invalid_filesystem_rejected_for_file_like_input(kwargs):
+    """Validation must not depend on the source being a string path."""
+    with pytest.raises(ValueError):
+        cudf.read_json(BytesIO(b'[{"a": 1}]'), engine="cudf", **kwargs)
 
 
 @pytest.fixture(params=["filepath", "pathobj", "bytes_io", "string_io", "url"])

--- a/python/cudf/cudf/tests/input_output/test_parquet.py
+++ b/python/cudf/cudf/tests/input_output/test_parquet.py
@@ -5229,3 +5229,30 @@ def test_read_parquet_snappy_malformed_copy_elem(
 )
 def test_parquet_reader_one_null_row(datadir, filename):
     cudf.read_parquet(datadir / filename)
+
+
+def test_parquet_dataset_writer_explicit_filesystem(tmp_path):
+    """Chunked output must land on the configured filesystem, not local disk."""
+    import fsspec
+
+    fs = fsspec.filesystem("memory")
+    root = f"/{tmp_path.name}/pdw"
+    df1 = cudf.DataFrame({"a": [1, 1, 2], "b": [9, 8, 7]})
+    df2 = cudf.DataFrame({"a": [2, 3, 3], "b": [6, 5, 4]})
+
+    with ParquetDatasetWriter(
+        root, partition_cols=["a"], index=False, filesystem=fs
+    ) as cw:
+        cw.write_table(df1)
+        cw.write_table(df2)
+
+    written = sorted(fs.find(root))
+    assert written, "no files written to the configured filesystem"
+    # Nothing should have leaked onto the local filesystem
+    assert not os.path.exists(root)
+
+    got = cudf.concat(
+        [cudf.read_parquet(f, filesystem=fs) for f in written]
+    ).astype("int64")
+    expect = cudf.concat([df1, df2])["b"].sort_values().reset_index(drop=True)
+    assert_eq(got["b"].sort_values().reset_index(drop=True), expect)

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -55,6 +55,17 @@ def s3so(moto_server):
     return {"client_kwargs": {"endpoint_url": moto_server}}
 
 
+@pytest.fixture(params=["storage_options", "filesystem"])
+def fs_kwargs(request, s3so):
+    """
+    Yield the two equivalent ways of pointing an I/O call at the mock S3:
+    ``storage_options=<dict>`` and ``filesystem=<fsspec object>``.
+    """
+    if request.param == "storage_options":
+        return {"storage_options": s3so}
+    return {"filesystem": get_fs_token_paths("s3://", storage_options=s3so)[0]}
+
+
 @pytest.fixture
 def moto_s3_resource(moto_server):
     boto3 = pytest.importorskip("boto3")
@@ -113,7 +124,7 @@ def pdf_ext():
 
 
 @pytest.mark.parametrize("bytes_per_thread", [32, 1024])
-def test_read_csv(s3_bucket_public, s3so, pdf, bytes_per_thread):
+def test_read_csv(s3_bucket_public, fs_kwargs, pdf, bytes_per_thread):
     # Write to buffer
     fname = "test_csv_reader.csv"
     buffer = pdf.to_csv(index=False)
@@ -122,8 +133,8 @@ def test_read_csv(s3_bucket_public, s3so, pdf, bytes_per_thread):
     # Use fsspec file object
     got = cudf.read_csv(
         f"s3://{s3_bucket_public.name}/{fname}",
-        storage_options=s3so,
         bytes_per_thread=bytes_per_thread,
+        **fs_kwargs,
     )
     assert_eq(pdf, got)
 
@@ -149,7 +160,7 @@ def test_read_csv_byte_range(s3_bucket_public, s3so, pdf, bytes_per_thread):
 
 
 @pytest.mark.parametrize("chunksize", [None, 3])
-def test_write_csv(s3_bucket_public, s3so, pdf, chunksize):
+def test_write_csv(s3_bucket_public, s3so, fs_kwargs, pdf, chunksize):
     # Write to buffer
     fname = "test_csv_writer.csv"
     gdf = cudf.from_pandas(pdf)
@@ -157,7 +168,7 @@ def test_write_csv(s3_bucket_public, s3so, pdf, chunksize):
         f"s3://{s3_bucket_public.name}/{fname}",
         index=False,
         chunksize=chunksize,
-        storage_options=s3so,
+        **fs_kwargs,
     )
     got = pd.read_csv(
         f"s3://{s3_bucket_public.name}/{fname}", storage_options=s3so
@@ -171,6 +182,7 @@ def test_write_csv(s3_bucket_public, s3so, pdf, chunksize):
 def test_read_parquet(
     s3_bucket_public,
     s3so,
+    fs_kwargs,
     kvikio_remote_io,
     pdf,
     bytes_per_thread,
@@ -185,9 +197,9 @@ def test_read_parquet(
     s3_bucket_public.put_object(Key=fname, Body=buffer)
     got1 = cudf.read_parquet(
         f"s3://{s3_bucket_public.name}/{fname}",
-        storage_options=s3so,
         bytes_per_thread=bytes_per_thread,
         columns=columns,
+        **fs_kwargs,
     )
     expect = pdf[columns] if columns else pdf
     assert_eq(expect, got1)
@@ -341,7 +353,7 @@ def test_read_parquet_filters(s3_bucket_public, s3so, pdf_ext):
 
 
 @pytest.mark.parametrize("partition_cols", [None, ["String"]])
-def test_write_parquet(s3_bucket_public, s3so, pdf, partition_cols):
+def test_write_parquet(s3_bucket_public, s3so, fs_kwargs, pdf, partition_cols):
     fname_cudf = "test_parquet_writer_cudf"
     fname_pandas = "test_parquet_writer_pandas"
     gdf = cudf.from_pandas(pdf)
@@ -349,7 +361,7 @@ def test_write_parquet(s3_bucket_public, s3so, pdf, partition_cols):
     gdf.to_parquet(
         f"s3://{s3_bucket_public.name}/{fname_cudf}",
         partition_cols=partition_cols,
-        storage_options=s3so,
+        **fs_kwargs,
     )
     pdf.to_parquet(
         f"s3://{s3_bucket_public.name}/{fname_pandas}",
@@ -367,7 +379,7 @@ def test_write_parquet(s3_bucket_public, s3so, pdf, partition_cols):
     assert_eq(expect, got)
 
 
-def test_read_json(s3_bucket_public, s3so):
+def test_read_json(s3_bucket_public, fs_kwargs):
     fname = "test_json_reader.json"
     buffer = (
         '{"amount": 100, "name": "Alice"}\n'
@@ -382,7 +394,7 @@ def test_read_json(s3_bucket_public, s3so):
         engine="cudf",
         orient="records",
         lines=True,
-        storage_options=s3so,
+        **fs_kwargs,
     )
 
     expect = pd.read_json(StringIO(buffer), lines=True)
@@ -421,7 +433,7 @@ def test_read_jsonl_files_kvikio_remote(s3_bucket_public, s3so, monkeypatch):
 
 
 @pytest.mark.parametrize("columns", [None, ["string1"]])
-def test_read_orc(s3_bucket_public, s3so, datadir, columns):
+def test_read_orc(s3_bucket_public, fs_kwargs, datadir, columns):
     source_file = str(datadir / "orc" / "TestOrcFile.testSnappy.orc")
     fname = "test_orc_reader.orc"
     expect = pd.read_orc(source_file)
@@ -433,7 +445,7 @@ def test_read_orc(s3_bucket_public, s3so, datadir, columns):
     got = cudf.read_orc(
         f"s3://{s3_bucket_public.name}/{fname}",
         columns=columns,
-        storage_options=s3so,
+        **fs_kwargs,
     )
 
     if columns:
@@ -441,24 +453,24 @@ def test_read_orc(s3_bucket_public, s3so, datadir, columns):
     assert_eq(expect, got)
 
 
-def test_write_orc(s3_bucket_public, s3so, pdf):
+def test_write_orc(s3_bucket_public, fs_kwargs, pdf):
     fname = "test_orc_writer.orc"
     gdf = cudf.from_pandas(pdf)
-    gdf.to_orc(f"s3://{s3_bucket_public.name}/{fname}", storage_options=s3so)
+    gdf.to_orc(f"s3://{s3_bucket_public.name}/{fname}", **fs_kwargs)
 
     got = pd.read_orc(f"s3://{s3_bucket_public.name}/{fname}")
 
     assert_eq(pdf, got)
 
 
-def test_write_chunked_parquet(s3_bucket_public, s3so):
+def test_write_chunked_parquet(s3_bucket_public, s3so, fs_kwargs):
     df1 = cudf.DataFrame({"b": [10, 11, 12], "a": [1, 2, 3]})
     df2 = cudf.DataFrame({"b": [20, 30, 50], "a": [3, 2, 1]})
     dirname = "chunked_writer_directory"
     with ParquetDatasetWriter(
         f"s3://{s3_bucket_public.name}/{dirname}",
         partition_cols=["a"],
-        storage_options=s3so,
+        **fs_kwargs,
     ) as cw:
         cw.write_table(df1)
         cw.write_table(df2)
@@ -481,6 +493,20 @@ def test_write_chunked_parquet(s3_bucket_public, s3so):
         actual.sort_values(["b"]).reset_index(drop=True),
         cudf.concat([df1, df2]).sort_values(["b"]).reset_index(drop=True),
     )
+
+
+def test_filesystem_and_storage_options_are_exclusive(
+    s3_bucket_public, s3so, pdf
+):
+    fs = get_fs_token_paths("s3://", storage_options=s3so)[0]
+    path = f"s3://{s3_bucket_public.name}/exclusive.csv"
+    match = "Cannot specify storage_options"
+
+    with pytest.raises(ValueError, match=match):
+        cudf.read_csv(path, filesystem=fs, storage_options=s3so)
+
+    with pytest.raises(ValueError, match=match):
+        cudf.from_pandas(pdf).to_csv(path, filesystem=fs, storage_options=s3so)
 
 
 def test_no_s3fs_on_cudf_import():

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -369,6 +369,52 @@ def test_read_parquet_metadata_fetches_footer_only(
     assert max(fetched) < size / 100
 
 
+def test_read_parquet_metadata_footer_is_one_request_per_file(
+    s3_bucket_public, s3so, pdf
+):
+    """Footers are fetched with a single concurrent suffix read per file.
+
+    A size lookup would add an extra HEAD request per file, which matters when
+    collecting footers across many files.
+    """
+    import s3fs
+
+    n_files = 5
+    buffer = BytesIO()
+    pdf.to_parquet(path=buffer)
+    for i in range(n_files):
+        buffer.seek(0)
+        s3_bucket_public.put_object(
+            Key=f"footer_reqs_{i}.parquet", Body=buffer
+        )
+
+    fs = get_fs_token_paths("s3://", storage_options=s3so)[0]
+    fs.invalidate_cache()
+    paths = [
+        f"{s3_bucket_public.name}/footer_reqs_{i}.parquet"
+        for i in range(n_files)
+    ]
+
+    calls = []
+    original = s3fs.core.S3FileSystem._call_s3
+
+    async def spy(self, method, *args, **kwargs):
+        calls.append(method)
+        return await original(self, method, *args, **kwargs)
+
+    s3fs.core.S3FileSystem._call_s3 = spy
+    try:
+        buffers = cudf.utils.ioutils._get_remote_bytes_parquet_footer(
+            paths, fs
+        )
+    finally:
+        s3fs.core.S3FileSystem._call_s3 = original
+
+    assert len(buffers) == n_files
+    assert calls.count("get_object") == n_files
+    assert "head_object" not in calls
+
+
 def test_read_parquet_multi_file(s3_bucket_public, s3so, pdf):
     fname_1 = "test_parquet_reader_multi_file_1.parquet"
     buffer_1 = BytesIO()

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -6,7 +6,6 @@ import sys
 import uuid
 from io import BytesIO, StringIO
 
-import numpy as np
 import pandas as pd
 import pytest
 from fsspec.core import get_fs_token_paths
@@ -309,110 +308,6 @@ def test_read_parquet_filesystem(s3_bucket_public, s3so, pdf):
     path = f"s3://{s3_bucket_public.name}/{'data.*.parquet'}"
     got = cudf.read_parquet(path, filesystem=fs)
     assert_eq(pdf, got)
-
-
-def test_read_parquet_metadata(s3_bucket_public, fs_kwargs, pdf):
-    fname = "test_parquet_metadata.parquet"
-    buffer = BytesIO()
-    pdf.to_parquet(path=buffer)
-    buffer.seek(0)
-    s3_bucket_public.put_object(Key=fname, Body=buffer)
-
-    num_rows, num_row_groups, col_names, num_columns, _ = (
-        cudf.io.read_parquet_metadata(
-            f"s3://{s3_bucket_public.name}/{fname}", **fs_kwargs
-        )
-    )
-
-    assert num_rows == len(pdf)
-    assert num_row_groups == 1
-    assert num_columns == len(pdf.columns)
-    assert col_names == list(pdf.columns)
-
-
-def test_read_parquet_metadata_fetches_footer_only(
-    s3_bucket_public, s3so, monkeypatch
-):
-    # Incompressible data, so the file is far larger than both the footer and
-    # libcudf's 64 KiB speculative-read hint
-    rng = np.random.default_rng(0)
-    big = pd.DataFrame(rng.random((200_000, 4)), columns=list("abcd"))
-    fname = "test_parquet_metadata_footer.parquet"
-    buffer = BytesIO()
-    big.to_parquet(path=buffer, compression=None)
-    size = buffer.tell()
-    buffer.seek(0)
-    s3_bucket_public.put_object(Key=fname, Body=buffer)
-
-    fetched = []
-    original = cudf.utils.ioutils._get_remote_bytes_parquet_footer
-
-    def spy(remote_paths, fs, **kwargs):
-        buffers = original(remote_paths, fs, **kwargs)
-        fetched.extend(len(b) for b in buffers)
-        return buffers
-
-    monkeypatch.setattr(
-        cudf.utils.ioutils, "_get_remote_bytes_parquet_footer", spy
-    )
-
-    num_rows, _num_row_groups, col_names, _, _ = cudf.io.read_parquet_metadata(
-        f"s3://{s3_bucket_public.name}/{fname}", storage_options=s3so
-    )
-
-    assert num_rows == len(big)
-    assert col_names == list(big.columns)
-
-    # Only the footer should have been transferred, not the whole file
-    assert size > 1_000_000, "test file is too small to be meaningful"
-    assert fetched, "footer prefetcher was not used"
-    assert max(fetched) < size / 100
-
-
-def test_read_parquet_metadata_footer_is_one_request_per_file(
-    s3_bucket_public, s3so, pdf
-):
-    """Footers are fetched with a single concurrent suffix read per file.
-
-    A size lookup would add an extra HEAD request per file, which matters when
-    collecting footers across many files.
-    """
-    import s3fs
-
-    n_files = 5
-    buffer = BytesIO()
-    pdf.to_parquet(path=buffer)
-    for i in range(n_files):
-        buffer.seek(0)
-        s3_bucket_public.put_object(
-            Key=f"footer_reqs_{i}.parquet", Body=buffer
-        )
-
-    fs = get_fs_token_paths("s3://", storage_options=s3so)[0]
-    fs.invalidate_cache()
-    paths = [
-        f"{s3_bucket_public.name}/footer_reqs_{i}.parquet"
-        for i in range(n_files)
-    ]
-
-    calls = []
-    original = s3fs.core.S3FileSystem._call_s3
-
-    async def spy(self, method, *args, **kwargs):
-        calls.append(method)
-        return await original(self, method, *args, **kwargs)
-
-    s3fs.core.S3FileSystem._call_s3 = spy
-    try:
-        buffers = cudf.utils.ioutils._get_remote_bytes_parquet_footer(
-            paths, fs
-        )
-    finally:
-        s3fs.core.S3FileSystem._call_s3 = original
-
-    assert len(buffers) == n_files
-    assert calls.count("get_object") == n_files
-    assert "head_object" not in calls
 
 
 def test_read_parquet_multi_file(s3_bucket_public, s3so, pdf):

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -310,6 +310,25 @@ def test_read_parquet_filesystem(s3_bucket_public, s3so, pdf):
     assert_eq(pdf, got)
 
 
+def test_read_parquet_metadata(s3_bucket_public, fs_kwargs, pdf):
+    fname = "test_parquet_metadata.parquet"
+    buffer = BytesIO()
+    pdf.to_parquet(path=buffer)
+    buffer.seek(0)
+    s3_bucket_public.put_object(Key=fname, Body=buffer)
+
+    num_rows, num_row_groups, col_names, num_columns, _ = (
+        cudf.io.read_parquet_metadata(
+            f"s3://{s3_bucket_public.name}/{fname}", **fs_kwargs
+        )
+    )
+
+    assert num_rows == len(pdf)
+    assert num_row_groups == 1
+    assert num_columns == len(pdf.columns)
+    assert col_names == list(pdf.columns)
+
+
 def test_read_parquet_multi_file(s3_bucket_public, s3so, pdf):
     fname_1 = "test_parquet_reader_multi_file_1.parquet"
     buffer_1 = BytesIO()

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from io import BytesIO, StringIO
 
+import numpy as np
 import pandas as pd
 import pytest
 from fsspec.core import get_fs_token_paths
@@ -327,6 +328,45 @@ def test_read_parquet_metadata(s3_bucket_public, fs_kwargs, pdf):
     assert num_row_groups == 1
     assert num_columns == len(pdf.columns)
     assert col_names == list(pdf.columns)
+
+
+def test_read_parquet_metadata_fetches_footer_only(
+    s3_bucket_public, s3so, monkeypatch
+):
+    # Incompressible data, so the file is far larger than both the footer and
+    # libcudf's 64 KiB speculative-read hint
+    rng = np.random.default_rng(0)
+    big = pd.DataFrame(rng.random((200_000, 4)), columns=list("abcd"))
+    fname = "test_parquet_metadata_footer.parquet"
+    buffer = BytesIO()
+    big.to_parquet(path=buffer, compression=None)
+    size = buffer.tell()
+    buffer.seek(0)
+    s3_bucket_public.put_object(Key=fname, Body=buffer)
+
+    fetched = []
+    original = cudf.utils.ioutils._get_remote_bytes_parquet_footer
+
+    def spy(remote_paths, fs, **kwargs):
+        buffers = original(remote_paths, fs, **kwargs)
+        fetched.extend(len(b) for b in buffers)
+        return buffers
+
+    monkeypatch.setattr(
+        cudf.utils.ioutils, "_get_remote_bytes_parquet_footer", spy
+    )
+
+    num_rows, _num_row_groups, col_names, _, _ = cudf.io.read_parquet_metadata(
+        f"s3://{s3_bucket_public.name}/{fname}", storage_options=s3so
+    )
+
+    assert num_rows == len(big)
+    assert col_names == list(big.columns)
+
+    # Only the footer should have been transferred, not the whole file
+    assert size > 1_000_000, "test file is too small to be meaningful"
+    assert fetched, "footer prefetcher was not used"
+    assert max(fetched) < size / 100
 
 
 def test_read_parquet_multi_file(s3_bucket_public, s3so, pdf):

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -2394,6 +2394,74 @@ def _get_remote_bytes_parquet(
     return buffers
 
 
+# Parquet file layout:
+#   [4-byte "PAR1" header][data][footer][4-byte footer length]["PAR1"]
+_PARQUET_MAGIC = b"PAR1"
+_PARQUET_HEADER_LEN = 4
+_PARQUET_ENDER_LEN = 8
+# Mirrors libcudf's LIBCUDF_PARQUET_METADATA_SIZE_HINT default. Footers smaller
+# than this are fetched in a single round trip.
+_PARQUET_FOOTER_SIZE_HINT = 64 * 1024
+
+
+def _get_remote_bytes_parquet_footer(remote_paths, fs, **kwargs):
+    """Fetch only the Parquet footer of each remote file.
+
+    Returns one buffer per path, shaped as ``PAR1 + <footer> + <ender>`` -- a
+    self-contained miniature Parquet file. libcudf locates the footer relative
+    to the *end* of a source, so these parse identically to the real files
+    while transferring O(footer) rather than O(file) bytes.
+
+    Falls back to fetching a whole file for any input that does not look like
+    Parquet, so that libcudf still reports its usual error.
+    """
+    sizes = list(fs.sizes(remote_paths))
+    hint = max(_PARQUET_FOOTER_SIZE_HINT, _PARQUET_ENDER_LEN)
+    tails = fs.cat_ranges(
+        remote_paths, [max(0, size - hint) for size in sizes], sizes
+    )
+
+    buffers: list[bytes | None] = [None] * len(remote_paths)
+    # (index, start, end, prepend_magic) for paths needing a second round trip
+    refetch: list[tuple[int, int, int, bool]] = []
+
+    for i, (tail, size) in enumerate(zip(tails, sizes, strict=True)):
+        if (
+            size <= _PARQUET_HEADER_LEN + _PARQUET_ENDER_LEN
+            or tail[-_PARQUET_HEADER_LEN:] != _PARQUET_MAGIC
+        ):
+            # Not a Parquet file we can shortcut; hand libcudf the whole thing
+            refetch.append((i, 0, size, False))
+            continue
+
+        footer_len = int.from_bytes(
+            tail[-_PARQUET_ENDER_LEN:-_PARQUET_HEADER_LEN], "little"
+        )
+        needed = footer_len + _PARQUET_ENDER_LEN
+        if needed > size:
+            # Corrupt footer length; let libcudf produce the error
+            refetch.append((i, 0, size, False))
+        elif needed <= len(tail):
+            buffers[i] = _PARQUET_MAGIC + tail[-needed:]
+        else:
+            # Footer is larger than the speculative tail read
+            refetch.append((i, size - needed, size, True))
+
+    if refetch:
+        idx = [r[0] for r in refetch]
+        chunks = fs.cat_ranges(
+            [remote_paths[i] for i in idx],
+            [r[1] for r in refetch],
+            [r[2] for r in refetch],
+        )
+        for (i, _, _, prepend_magic), chunk in zip(
+            refetch, chunks, strict=True
+        ):
+            buffers[i] = _PARQUET_MAGIC + chunk if prepend_magic else chunk
+
+    return buffers
+
+
 def _prefetch_remote_buffers(
     paths,
     fs,
@@ -2406,12 +2474,13 @@ def _prefetch_remote_buffers(
         try:
             prefetcher = {
                 "parquet": _get_remote_bytes_parquet,
+                "parquet-footer": _get_remote_bytes_parquet_footer,
                 "all": _get_remote_bytes_all,
             }[method]
         except KeyError:
             raise ValueError(
                 f"{method} is not a supported remote-data prefetcher."
-                " Expected 'parquet' or 'all'."
+                " Expected 'parquet', 'parquet-footer' or 'all'."
             )
         return prefetcher(
             paths,

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1872,8 +1872,7 @@ def get_reader_filepath_or_buffer(
 ):
     """{docstring}"""
 
-    # Validate up front so that a bad `filesystem` is rejected for every input
-    # type, not just string paths.
+    # Validate up front so file-like inputs are checked too, not just paths.
     if filesystem is not None:
         _validate_filesystem(filesystem, storage_options)
 
@@ -2007,9 +2006,8 @@ def get_writer_filepath_or_buffer(
             fs = filesystem
 
         if not _is_local_filesystem(fs):
-            # Note: the paths returned by `get_fs_token_paths` are not usable
-            # here -- in write mode it expands them into numbered `.part`
-            # names. Strip the protocol off the original path instead.
+            # Not `get_fs_token_paths`' paths: in write mode it expands
+            # them into numbered `.part` names. Strip the original instead.
             return fsspec.core.OpenFile(
                 fs, fs._strip_protocol(path_or_data), mode=mode or "w"
             )
@@ -2207,10 +2205,8 @@ def _ensure_filesystem(passed_filesystem, path, storage_options):
             path[0] if isinstance(path, list) else path,
             storage_options={} if storage_options is None else storage_options,
         )[0]
-    # Note: `storage_options` is deliberately not checked for conflicts here.
-    # Internal callers (e.g. dask-cudf's `CudfEngine.write_partition`) legitimately
-    # pass both a resolved filesystem and the `storage_options` that produced it.
-    # The mutual-exclusion check belongs at the public `filesystem=` boundary.
+    # No `storage_options` conflict check: internal callers (dask-cudf's
+    # `write_partition`) pass both. That check lives at the public boundary.
     _validate_filesystem(passed_filesystem)
     return passed_filesystem
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1872,6 +1872,11 @@ def get_reader_filepath_or_buffer(
 ):
     """{docstring}"""
 
+    # Validate up front so that a bad `filesystem` is rejected for every input
+    # type, not just string paths.
+    if filesystem is not None:
+        _validate_filesystem(filesystem, storage_options)
+
     # Convert path_or_data to a list of input data sources
     input_sources = [
         stringify_pathlike(source)
@@ -1984,6 +1989,9 @@ def get_writer_filepath_or_buffer(
     filepath_or_buffer : str,
         Filepath string or buffer of data
     """
+    if filesystem is not None:
+        _validate_filesystem(filesystem, storage_options)
+
     if storage_options is None:
         storage_options = {}
 
@@ -1996,7 +2004,6 @@ def get_writer_filepath_or_buffer(
                 path_or_data, mode=mode or "w", storage_options=storage_options
             )[0]
         else:
-            _validate_filesystem(filesystem, storage_options)
             fs = filesystem
 
         if not _is_local_filesystem(fs):

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -64,6 +64,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 
 Returns
 -------
@@ -153,8 +156,8 @@ storage_options : dict, optional, default None
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
 filesystem : fsspec.AbstractFileSystem, default None
-    Filesystem object to use when reading the parquet data. This argument
-    should not be used at the same time as `storage_options`.
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 filters : list of tuple, list of lists of tuples, default None
     If not None, specifies a filter predicate used to filter out row groups
     using statistics stored for each row group as Parquet metadata. Row groups
@@ -321,6 +324,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when writing the data. This argument
+    should not be used at the same time as ``storage_options``.
 return_metadata : bool, default False
     Return parquet metadata for written data. Returned metadata will
     include the file path metadata (relative to `root_path`).
@@ -502,6 +508,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 bytes_per_thread : int, default None
     Determines the number of bytes to be allocated per thread to read the
     files in parallel. When there is a file of large size, we get slightly
@@ -570,6 +579,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when writing the data. This argument
+    should not be used at the same time as ``storage_options``.
 index : bool, default None
     If ``True``, include the dataframe's index(es) in the file output.
     If ``False``, they will not be written to the file.
@@ -759,6 +771,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 mixed_types_as_string : bool, default False
 
     .. admonition:: GPU-accelerated feature
@@ -927,6 +942,17 @@ index : bool, default True
     Whether to include the index values in the JSON string. Not
     including the index (``index=False``) is only supported when
     orient is 'split' or 'table'.
+storage_options : dict, optional, default None
+    Extra options that make sense for a particular storage connection,
+    e.g. host, port, username, password, etc. For HTTP(S) URLs the key-value
+    pairs are forwarded to ``urllib.request.Request`` as header options.
+    For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
+    pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
+    ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when writing the data. This argument
+    should not be used at the same time as ``storage_options``.
+    Only supported with ``engine='cudf'``.
 
 See Also
 --------
@@ -1227,6 +1253,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 bytes_per_thread : int, default None
     Determines the number of bytes to be allocated per thread to read the
     files in parallel. When there is a file of large size, we get slightly
@@ -1329,6 +1358,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when writing the data. This argument
+    should not be used at the same time as ``storage_options``.
 
 Returns
 -------
@@ -1437,6 +1469,9 @@ storage_options : dict, optional, default None
     For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
     pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
     ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 
 Returns
 -------
@@ -1682,6 +1717,26 @@ def _is_local_filesystem(fs):
     return isinstance(fs, LocalFileSystem)
 
 
+def _validate_filesystem(filesystem, storage_options=None):
+    """Validate a user-provided ``filesystem`` object.
+
+    ``filesystem`` must be an ``fsspec.AbstractFileSystem``, and cannot be
+    combined with a non-empty ``storage_options``.
+    """
+    import fsspec
+
+    if not isinstance(filesystem, fsspec.AbstractFileSystem):
+        raise ValueError(
+            f"Expected fsspec.AbstractFileSystem. Got {filesystem}"
+        )
+
+    if storage_options:
+        raise ValueError(
+            f"Cannot specify storage_options when an explicit "
+            f"filesystem object is specified. Got: {storage_options}"
+        )
+
+
 def _select_single_source(sources: list, caller: str):
     """Select the first element from a list of sources.
     Raise an error if sources contains multiple elements
@@ -1693,22 +1748,26 @@ def _select_single_source(sources: list, caller: str):
     return sources[0]
 
 
-def is_directory(path_or_data, storage_options=None):
+def is_directory(path_or_data, storage_options=None, filesystem=None):
     """Returns True if the provided filepath is a directory"""
     path_or_data = stringify_pathlike(path_or_data)
     if isinstance(path_or_data, str):
         import fsspec
 
         path_or_data = os.path.expanduser(path_or_data)
-        try:
-            fs = fsspec.core.get_fs_token_paths(
-                path_or_data, mode="rb", storage_options=storage_options
-            )[0]
-        except ValueError as e:
-            if str(e).startswith("Protocol not known"):
-                return False
-            else:
-                raise e
+        if filesystem is not None:
+            _validate_filesystem(filesystem, storage_options)
+            fs = filesystem
+        else:
+            try:
+                fs = fsspec.core.get_fs_token_paths(
+                    path_or_data, mode="rb", storage_options=storage_options
+                )[0]
+            except ValueError as e:
+                if str(e).startswith("Protocol not known"):
+                    return False
+                else:
+                    raise e
 
         return fs.isdir(path_or_data)
 
@@ -1757,16 +1816,7 @@ def _get_filesystem_and_paths(
                 else:
                     raise e
         else:
-            if not isinstance(filesystem, fsspec.AbstractFileSystem):
-                raise ValueError(
-                    f"Expected fsspec.AbstractFileSystem. Got {filesystem}"
-                )
-
-            if storage_options:
-                raise ValueError(
-                    f"Cannot specify storage_options when an explicit "
-                    f"filesystem object is specified. Got: {storage_options}"
-                )
+            _validate_filesystem(filesystem, storage_options)
 
             fs = filesystem
             return_paths = [
@@ -1812,6 +1862,7 @@ def get_reader_filepath_or_buffer(
     *,
     mode="rb",
     fs=None,
+    filesystem=None,
     iotypes=(BytesIO,),
     storage_options=None,
     bytes_per_thread=_BYTES_PER_THREAD_DEFAULT,
@@ -1844,7 +1895,9 @@ def get_reader_filepath_or_buffer(
         paths = input_sources
         raw_text_input = False
         if fs is None:
-            fs, paths = _get_filesystem_and_paths(paths, storage_options)
+            fs, paths = _get_filesystem_and_paths(
+                paths, storage_options, filesystem=filesystem
+            )
 
         # Expand directories (if necessary)
         paths = _maybe_expand_directories(paths, expand_dir_pattern, fs)
@@ -1902,7 +1955,9 @@ def get_reader_filepath_or_buffer(
     return filepaths_or_buffers
 
 
-def get_writer_filepath_or_buffer(path_or_data, mode, storage_options=None):
+def get_writer_filepath_or_buffer(
+    path_or_data, mode, storage_options=None, filesystem=None
+):
     """
     Return either a filepath string to data,
     or a open file object to the output filesystem
@@ -1920,6 +1975,9 @@ def get_writer_filepath_or_buffer(path_or_data, mode, storage_options=None):
         header options. For other URLs (e.g. starting with "s3://", and
         "gcs://") the key-value pairs are forwarded to ``fsspec.open``.
         Please see ``fsspec`` and ``urllib`` for more details.
+    filesystem : fsspec.AbstractFileSystem, optional, default None
+        Filesystem object to write the data with. This argument should not
+        be used at the same time as ``storage_options``.
 
     Returns
     -------
@@ -1933,15 +1991,21 @@ def get_writer_filepath_or_buffer(path_or_data, mode, storage_options=None):
         import fsspec
 
         path_or_data = os.path.expanduser(path_or_data)
-        fs = fsspec.core.get_fs_token_paths(
-            path_or_data, mode=mode or "w", storage_options=storage_options
-        )[0]
+        if filesystem is None:
+            fs = fsspec.core.get_fs_token_paths(
+                path_or_data, mode=mode or "w", storage_options=storage_options
+            )[0]
+        else:
+            _validate_filesystem(filesystem, storage_options)
+            fs = filesystem
 
         if not _is_local_filesystem(fs):
-            filepath_or_buffer = fsspec.open(
-                path_or_data, mode=mode or "w", **(storage_options)
+            # Note: the paths returned by `get_fs_token_paths` are not usable
+            # here -- in write mode it expands them into numbered `.part`
+            # names. Strip the protocol off the original path instead.
+            return fsspec.core.OpenFile(
+                fs, fs._strip_protocol(path_or_data), mode=mode or "w"
             )
-            return filepath_or_buffer
 
     return path_or_data
 
@@ -2136,6 +2200,11 @@ def _ensure_filesystem(passed_filesystem, path, storage_options):
             path[0] if isinstance(path, list) else path,
             storage_options={} if storage_options is None else storage_options,
         )[0]
+    # Note: `storage_options` is deliberately not checked for conflicts here.
+    # Internal callers (e.g. dask-cudf's `CudfEngine.write_partition`) legitimately
+    # pass both a resolved filesystem and the `storage_options` that produced it.
+    # The mutual-exclusion check belongs at the public `filesystem=` boundary.
+    _validate_filesystem(passed_filesystem)
     return passed_filesystem
 
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -103,16 +103,6 @@ Parameters
 ----------
 paths : List of strings or path objects
     Path of file(s) to be read
-storage_options : dict, optional, default None
-    Extra options that make sense for a particular storage connection,
-    e.g. host, port, username, password, etc. For HTTP(S) URLs the key-value
-    pairs are forwarded to ``urllib.request.Request`` as header options.
-    For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
-    pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
-    ``urllib`` for more details.
-filesystem : fsspec.AbstractFileSystem, default None
-    Filesystem object to use when reading the data. This argument
-    should not be used at the same time as ``storage_options``.
 
 Returns
 -------
@@ -2394,78 +2384,6 @@ def _get_remote_bytes_parquet(
     return buffers
 
 
-# Parquet file layout:
-#   [4-byte "PAR1" header][data][footer][4-byte footer length]["PAR1"]
-_PARQUET_MAGIC = b"PAR1"
-_PARQUET_HEADER_LEN = 4
-_PARQUET_ENDER_LEN = 8
-# Mirrors libcudf's LIBCUDF_PARQUET_METADATA_SIZE_HINT default. Footers smaller
-# than this are fetched in a single round trip.
-_PARQUET_FOOTER_SIZE_HINT = 64 * 1024
-
-
-def _get_remote_bytes_parquet_footer(remote_paths, fs, **kwargs):
-    """Fetch only the Parquet footer of each remote file.
-
-    Returns one buffer per path, shaped as ``PAR1 + <footer> + <ender>`` -- a
-    self-contained miniature Parquet file. libcudf locates the footer relative
-    to the *end* of a source, so these parse identically to the real files
-    while transferring O(footer) rather than O(file) bytes.
-
-    Falls back to handing libcudf a whole file for any input that does not
-    look like Parquet, so that it still reports its usual error.
-    """
-    hint = max(_PARQUET_FOOTER_SIZE_HINT, _PARQUET_ENDER_LEN)
-    n = len(remote_paths)
-
-    # Suffix ranges (negative start, per the fsspec `cat_file` contract) let us
-    # skip a size lookup, which would otherwise cost an extra request per file.
-    # `cat_ranges` fans out concurrently on async filesystems.
-    tails = fs.cat_ranges(remote_paths, [-hint] * n, [None] * n)
-
-    buffers: list[bytes | None] = [None] * n
-    # (index, start, prepend_magic) for paths needing a second round trip
-    refetch: list[tuple[int, int, bool]] = []
-
-    for i, tail in enumerate(tails):
-        if (
-            len(tail) <= _PARQUET_HEADER_LEN + _PARQUET_ENDER_LEN
-            or tail[-_PARQUET_HEADER_LEN:] != _PARQUET_MAGIC
-        ):
-            # Not a Parquet file we can shortcut. A short tail is already the
-            # whole file, so only a truncated one needs re-reading.
-            if len(tail) < hint:
-                buffers[i] = tail
-            else:
-                refetch.append((i, 0, False))
-            continue
-
-        footer_len = int.from_bytes(
-            tail[-_PARQUET_ENDER_LEN:-_PARQUET_HEADER_LEN], "little"
-        )
-        needed = footer_len + _PARQUET_ENDER_LEN
-        if needed <= len(tail):
-            buffers[i] = _PARQUET_MAGIC + tail[-needed:]
-        elif len(tail) < hint:
-            # Tail is the entire file, so `footer_len` is bogus. Hand the file
-            # over unmodified and let libcudf report the corruption.
-            buffers[i] = tail
-        else:
-            # Footer is larger than the speculative tail read
-            refetch.append((i, -needed, True))
-
-    if refetch:
-        chunks = fs.cat_ranges(
-            [remote_paths[i] for i, _, _ in refetch],
-            [start for _, start, _ in refetch],
-            [None] * len(refetch),
-        )
-        for (i, _, prepend_magic), chunk in zip(refetch, chunks, strict=True):
-            buffers[i] = _PARQUET_MAGIC + chunk if prepend_magic else chunk
-
-    return buffers
-
-
 def _prefetch_remote_buffers(
     paths,
     fs,
@@ -2478,13 +2396,12 @@ def _prefetch_remote_buffers(
         try:
             prefetcher = {
                 "parquet": _get_remote_bytes_parquet,
-                "parquet-footer": _get_remote_bytes_parquet_footer,
                 "all": _get_remote_bytes_all,
             }[method]
         except KeyError:
             raise ValueError(
                 f"{method} is not a supported remote-data prefetcher."
-                " Expected 'parquet', 'parquet-footer' or 'all'."
+                " Expected 'parquet' or 'all'."
             )
         return prefetcher(
             paths,

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -103,6 +103,16 @@ Parameters
 ----------
 paths : List of strings or path objects
     Path of file(s) to be read
+storage_options : dict, optional, default None
+    Extra options that make sense for a particular storage connection,
+    e.g. host, port, username, password, etc. For HTTP(S) URLs the key-value
+    pairs are forwarded to ``urllib.request.Request`` as header options.
+    For other URLs (e.g. starting with "s3://", and "gcs://") the key-value
+    pairs are forwarded to ``fsspec.open``. Please see ``fsspec`` and
+    ``urllib`` for more details.
+filesystem : fsspec.AbstractFileSystem, default None
+    Filesystem object to use when reading the data. This argument
+    should not be used at the same time as ``storage_options``.
 
 Returns
 -------

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -2412,51 +2412,55 @@ def _get_remote_bytes_parquet_footer(remote_paths, fs, **kwargs):
     to the *end* of a source, so these parse identically to the real files
     while transferring O(footer) rather than O(file) bytes.
 
-    Falls back to fetching a whole file for any input that does not look like
-    Parquet, so that libcudf still reports its usual error.
+    Falls back to handing libcudf a whole file for any input that does not
+    look like Parquet, so that it still reports its usual error.
     """
-    sizes = list(fs.sizes(remote_paths))
     hint = max(_PARQUET_FOOTER_SIZE_HINT, _PARQUET_ENDER_LEN)
-    tails = fs.cat_ranges(
-        remote_paths, [max(0, size - hint) for size in sizes], sizes
-    )
+    n = len(remote_paths)
 
-    buffers: list[bytes | None] = [None] * len(remote_paths)
-    # (index, start, end, prepend_magic) for paths needing a second round trip
-    refetch: list[tuple[int, int, int, bool]] = []
+    # Suffix ranges (negative start, per the fsspec `cat_file` contract) let us
+    # skip a size lookup, which would otherwise cost an extra request per file.
+    # `cat_ranges` fans out concurrently on async filesystems.
+    tails = fs.cat_ranges(remote_paths, [-hint] * n, [None] * n)
 
-    for i, (tail, size) in enumerate(zip(tails, sizes, strict=True)):
+    buffers: list[bytes | None] = [None] * n
+    # (index, start, prepend_magic) for paths needing a second round trip
+    refetch: list[tuple[int, int, bool]] = []
+
+    for i, tail in enumerate(tails):
         if (
-            size <= _PARQUET_HEADER_LEN + _PARQUET_ENDER_LEN
+            len(tail) <= _PARQUET_HEADER_LEN + _PARQUET_ENDER_LEN
             or tail[-_PARQUET_HEADER_LEN:] != _PARQUET_MAGIC
         ):
-            # Not a Parquet file we can shortcut; hand libcudf the whole thing
-            refetch.append((i, 0, size, False))
+            # Not a Parquet file we can shortcut. A short tail is already the
+            # whole file, so only a truncated one needs re-reading.
+            if len(tail) < hint:
+                buffers[i] = tail
+            else:
+                refetch.append((i, 0, False))
             continue
 
         footer_len = int.from_bytes(
             tail[-_PARQUET_ENDER_LEN:-_PARQUET_HEADER_LEN], "little"
         )
         needed = footer_len + _PARQUET_ENDER_LEN
-        if needed > size:
-            # Corrupt footer length; let libcudf produce the error
-            refetch.append((i, 0, size, False))
-        elif needed <= len(tail):
+        if needed <= len(tail):
             buffers[i] = _PARQUET_MAGIC + tail[-needed:]
+        elif len(tail) < hint:
+            # Tail is the entire file, so `footer_len` is bogus. Hand the file
+            # over unmodified and let libcudf report the corruption.
+            buffers[i] = tail
         else:
             # Footer is larger than the speculative tail read
-            refetch.append((i, size - needed, size, True))
+            refetch.append((i, -needed, True))
 
     if refetch:
-        idx = [r[0] for r in refetch]
         chunks = fs.cat_ranges(
-            [remote_paths[i] for i in idx],
-            [r[1] for r in refetch],
-            [r[2] for r in refetch],
+            [remote_paths[i] for i, _, _ in refetch],
+            [start for _, start, _ in refetch],
+            [None] * len(refetch),
         )
-        for (i, _, _, prepend_magic), chunk in zip(
-            refetch, chunks, strict=True
-        ):
+        for (i, _, prepend_magic), chunk in zip(refetch, chunks, strict=True):
             buffers[i] = _PARQUET_MAGIC + chunk if prepend_magic else chunk
 
     return buffers


### PR DESCRIPTION
## Description

Closes #20443

This PR adds a new `filesystem` param to our orc, json, csv and parquet readers and writers to accept a pre-built fsspec `filesystem` object. Added validation by a shared `_validate_filesystem` helper that keeps the existing "not at the same time as `storage_options`" contract.

Also two minor fixes: `_process_dataset` now passes its already-resolved filesystem to `is_directory()`, which previously inferred `LocalFileSystem` and answered `False` for every remote path; and `ParquetDatasetWriter.write_table` no longer drops `self.storage_options` for non-S3 remote paths.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
