### PR TITLE
Require polars>=1.38 for max|min_by tests

### DIFF
--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -17,7 +17,6 @@ from cudf_polars.testing.asserts import (
 from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
-    POLARS_VERSION_LT_137,
     POLARS_VERSION_LT_138,
 )
 
@@ -137,7 +136,7 @@ def test_product(engine: pl.GPUEngine, data, dtype):
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("expr", ["max_by", "min_by"])
 @pytest.mark.parametrize(
@@ -169,7 +168,7 @@ def test_max_min_by(engine: pl.GPUEngine, expr: str, data, by_dtype) -> None:
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("expr", ["max_by", "min_by"])
 @pytest.mark.parametrize(
@@ -196,7 +195,7 @@ def test_max_min_by_float_nan(engine: pl.GPUEngine, expr: str, by) -> None:
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("expr", ["max_by", "min_by"])
 @pytest.mark.parametrize(
@@ -221,7 +220,7 @@ def test_max_min_by_mismatched_length_raises(
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("expr", ["max_by", "min_by"])
 def test_max_min_by_scalar_value(engine: pl.GPUEngine, expr: str) -> None:
@@ -236,7 +235,7 @@ def test_max_min_by_scalar_value(engine: pl.GPUEngine, expr: str) -> None:
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 @pytest.mark.parametrize(
@@ -294,7 +293,7 @@ def test_groupby_max_min_by(engine: pl.GPUEngine, agg: str, g, a, b, by_dtype) -
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 def test_groupby_max_min_by_nested_unsupported(engine: pl.GPUEngine, agg: str) -> None:
@@ -310,7 +309,7 @@ def test_groupby_max_min_by_nested_unsupported(engine: pl.GPUEngine, agg: str) -
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 @pytest.mark.parametrize(
@@ -332,7 +331,7 @@ def test_groupby_max_min_by_group_length_unsupported(
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 def test_groupby_max_min_by_literal_column_value_unsupported(
@@ -346,7 +345,7 @@ def test_groupby_max_min_by_literal_column_value_unsupported(
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 def test_groupby_max_min_by_scalar_value(engine: pl.GPUEngine, agg: str) -> None:
@@ -356,7 +355,7 @@ def test_groupby_max_min_by_scalar_value(engine: pl.GPUEngine, agg: str) -> None
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_137, reason="polars 1.37.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 def test_rolling_max_min_by_unsupported(engine: pl.GPUEngine, agg: str) -> None:


### PR DESCRIPTION
## Description

This changes our max/min_by tests to skip polars 1.37.0. When originally [implemented](https://github.com/pola-rs/polars/pull/25905/changes#diff-9b964e08c626ef53ec7c2373836e5ab5bd974db071c282516fa0a37f2b325b2aR70) this used an IrAggExpr. Our translation layer only handles the newer `Function` form, which was done in polars 1.38

For now, I've just required polars 1.38 for these tests.