### PR TITLE
Throw on dictionary columns in cudf::binary_operation instead of silently comparing indices

### DIFF
--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -162,6 +162,7 @@ constexpr inline bool binary_op_has_common_type_v =
  * @throw cudf::logic_error if @p output_type dtype isn't boolean for comparison and logical
  * operations.
  * @throw cudf::data_type_error if the operation is not supported for the types of @p lhs and @p rhs
+ * @throw cudf::data_type_error if @p rhs or @p output_type is a dictionary type
  */
 std::unique_ptr<column> binary_operation(
   scalar const& lhs,
@@ -195,6 +196,7 @@ std::unique_ptr<column> binary_operation(
  * @throw cudf::logic_error if @p output_type dtype isn't boolean for comparison and logical
  * operations.
  * @throw cudf::data_type_error if the operation is not supported for the types of @p lhs and @p rhs
+ * @throw cudf::data_type_error if @p lhs or @p output_type is a dictionary type
  */
 std::unique_ptr<column> binary_operation(
   column_view const& lhs,
@@ -227,6 +229,7 @@ std::unique_ptr<column> binary_operation(
  * operations.
  * @throw cudf::logic_error if @p output_type dtype isn't fixed-width
  * @throw cudf::data_type_error if the operation is not supported for the types of @p lhs and @p rhs
+ * @throw cudf::data_type_error if @p lhs, @p rhs, or @p output_type is a dictionary type
  */
 std::unique_ptr<column> binary_operation(
   column_view const& lhs,

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -206,6 +206,13 @@ std::unique_ptr<column> binary_operation(LhsType const& lhs,
                                          cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
+  CUDF_EXPECTS(not cudf::is_dictionary(lhs.type()) and not cudf::is_dictionary(rhs.type()),
+               "Dictionary operands are not supported",
+               cudf::data_type_error);
+  CUDF_EXPECTS(not cudf::is_dictionary(output_type),
+               "Dictionary output type is not supported",
+               cudf::data_type_error);
+
   if constexpr (std::is_same_v<LhsType, column_view> and std::is_same_v<RhsType, column_view>)
     CUDF_EXPECTS(lhs.size() == rhs.size(), "Column sizes don't match", std::invalid_argument);
 

--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -207,6 +207,8 @@ std::optional<data_type> get_common_type(data_type out, data_type lhs, data_type
 
 bool is_supported_operation(data_type out, data_type lhs, data_type rhs, binary_operator op)
 {
+  // dictionary operands would resolve to their indices instead of their keys
+  if (is_dictionary(out) or is_dictionary(lhs) or is_dictionary(rhs)) { return false; }
   return double_type_dispatcher(lhs, rhs, is_supported_operation_functor{}, out, op);
 }
 }  // namespace cudf::binops::compiled

--- a/cpp/tests/binaryop/binop-verify-input-test.cpp
+++ b/cpp/tests/binaryop/binop-verify-input-test.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2018-2019 BlazingDB, Inc.
  * SPDX-FileCopyrightText: Copyright 2018 Christian Noboa Mardini <christian@blazingdb.com>
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /*
@@ -47,4 +47,54 @@ TEST_F(BinopVerifyInputTest, Vector_Vector_ErrorSecondOperandVectorZeroSize)
   EXPECT_THROW(cudf::binary_operation(
                  lhs, rhs, cudf::binary_operator::ADD, cudf::data_type(cudf::type_id::INT64)),
                std::invalid_argument);
+}
+
+TEST_F(BinopVerifyInputTest, Vector_Vector_ErrorDictionaryLhs)
+{
+  auto lhs = cudf::test::dictionary_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+  auto rhs = cudf::test::fixed_width_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+
+  EXPECT_THROW(cudf::binary_operation(
+                 lhs, rhs, cudf::binary_operator::ADD, cudf::data_type(cudf::type_id::INT64)),
+               cudf::data_type_error);
+}
+
+TEST_F(BinopVerifyInputTest, Vector_Vector_ErrorDictionaryRhs)
+{
+  auto lhs = cudf::test::fixed_width_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+  auto rhs = cudf::test::dictionary_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+
+  EXPECT_THROW(cudf::binary_operation(
+                 lhs, rhs, cudf::binary_operator::ADD, cudf::data_type(cudf::type_id::INT64)),
+               cudf::data_type_error);
+}
+
+TEST_F(BinopVerifyInputTest, Vector_Scalar_ErrorDictionaryLhs)
+{
+  auto lhs = cudf::test::dictionary_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+  auto rhs = cudf::scalar_type_t<int64_t>(1);
+
+  EXPECT_THROW(cudf::binary_operation(
+                 lhs, rhs, cudf::binary_operator::ADD, cudf::data_type(cudf::type_id::INT64)),
+               cudf::data_type_error);
+}
+
+TEST_F(BinopVerifyInputTest, Scalar_Vector_ErrorDictionaryRhs)
+{
+  auto lhs = cudf::scalar_type_t<int64_t>(1);
+  auto rhs = cudf::test::dictionary_column_wrapper<int64_t>{0, 1, 2, 3, 4};
+
+  EXPECT_THROW(cudf::binary_operation(
+                 lhs, rhs, cudf::binary_operator::ADD, cudf::data_type(cudf::type_id::INT64)),
+               cudf::data_type_error);
+}
+
+TEST_F(BinopVerifyInputTest, Vector_Vector_ErrorDictionaryCompare)
+{
+  auto lhs = cudf::test::dictionary_column_wrapper<int64_t>{5, 4, 3, 2, 1};
+  auto rhs = cudf::test::dictionary_column_wrapper<int64_t>{5, 4, 3, 2, 1};
+
+  EXPECT_THROW(cudf::binary_operation(
+                 lhs, rhs, cudf::binary_operator::EQUAL, cudf::data_type(cudf::type_id::BOOL8)),
+               cudf::data_type_error);
 }


### PR DESCRIPTION
## Description
`cudf::binary_operation` does not support dictionary columns, but it did not reject them consistently:

  - Arithmetic ops (`ADD`, `SUB`, ...) already threw `cudf::data_type_error`.
  - **Comparison ops (`EQUAL`, `LESS`, ...) silently succeeded.** Because
    `column_device_view` has a `dictionary32` element accessor, these compared the raw
    dictionary *index* values rather than the decoded keys, returning results that are
    wrong whenever the operands' key sets differ.
   
This PR makes the API reject dictionary operands (and a dictionary `output_type`) up front with `cudf::data_type_error`.
`binops::is_supported_operation` is updated to match.
  
Note the PTX/JIT overload is unchanged — it already rejects dictionaries via its fixed-width-only validation.

New gtests added as well.

Closes #23915

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
