### PR TITLE
DOC Add accelerated data engines and tools to landing page

### DIFF
--- a/docs/cudf/source/index.rst
+++ b/docs/cudf/source/index.rst
@@ -22,6 +22,37 @@ libraries and is composed of multiple sub-projects:
    * - `pylibcudf <pylibcudf/index.html>`_
      - A Python library providing `Cython <https://cython.org/>`_ bindings for libcudf.
 
+Accelerated Data Engines and Tools
+----------------------------------
+
+The following data engines and tools integrate with cuDF:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 45 35
+
+   * - Data engine or tool
+     - cuDF integration
+     - Technical documentation
+   * - Velox
+     - Velox on GPU (experimental)
+     - `Velox-cuDF documentation <https://github.com/facebookincubator/velox/blob/main/velox/experimental/cudf/README.md>`_
+   * - Apache Spark
+     - cuDF plugin for Apache Spark
+     - `cuDF for Apache Spark user guide <https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html>`_
+   * - Presto
+     - Presto-GPU
+     - `Presto on GPU tutorial <https://github.com/prestodb/prestorials/tree/main/docker-compose-native/gpu>`_
+   * - Polars
+     - Polars GPU engine
+     - `Polars GPU engine documentation <https://docs.rapids.ai/api/cudf/stable/cudf_polars/>`_
+   * - DuckDB
+     - SiriusDB
+     - `Sirius documentation <https://github.com/sirius-db/sirius>`_
+   * - pandas
+     - cudf.pandas
+     - `cudf.pandas documentation <https://docs.rapids.ai/api/cudf/stable/cudf_pandas/>`_
+
 .. toctree::
    :maxdepth: 1
    :caption: Libraries

--- a/docs/cudf/source/index.rst
+++ b/docs/cudf/source/index.rst
@@ -34,28 +34,29 @@ The following data engines and tools integrate with cuDF:
    * - Data engine or tool
      - cuDF integration
      - Technical documentation
-   * - Velox
-     - Velox on GPU (experimental)
-     - `Velox-cuDF documentation <https://github.com/facebookincubator/velox/blob/main/velox/experimental/cudf/README.md>`_
    * - Apache Spark
      - cuDF plugin for Apache Spark
-     - `cuDF for Apache Spark user guide <https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html>`_
-   * - Presto
-     - Presto-GPU
-     - `Presto on GPU tutorial <https://github.com/prestodb/prestorials/tree/main/docker-compose-native/gpu>`_
-   * - Polars
-     - Polars GPU engine
-     - `Polars GPU engine documentation <https://docs.rapids.ai/api/cudf/stable/cudf_polars/>`_
+     - `cuDF for Apache Spark user guide <https://docs.nvidia.com/spark-rapids/user-guide/latest/overview.html>`_
    * - DuckDB
-     - SiriusDB
+     - Sirius
      - `Sirius documentation <https://github.com/sirius-db/sirius>`_
    * - pandas
      - cudf.pandas
      - `cudf.pandas documentation <https://docs.rapids.ai/api/cudf/stable/cudf_pandas/>`_
+   * - Polars
+     - Polars GPU engine
+     - `Polars GPU engine documentation <https://docs.rapids.ai/api/cudf/stable/cudf_polars/>`_
+   * - Presto
+     - Presto-GPU
+     - `Presto on GPU tutorial <https://github.com/prestodb/prestorials/tree/main/docker-compose-native/gpu>`_
+   * - Velox
+     - Velox on GPU (experimental)
+     - `Velox-cuDF documentation <https://github.com/facebookincubator/velox/blob/main/velox/experimental/cudf/README.md>`_
 
 .. toctree::
    :maxdepth: 1
    :caption: Libraries
+   :hidden:
 
    cudf/index
    cudf_pandas/index


### PR DESCRIPTION
## Description

Adds an **Accelerated Data Engines and Tools** section to the cuDF documentation landing page. The table lists the six integrations currently featured on the CUDA-X cuDF page and links directly to their technical documentation:

- Velox
- Apache Spark
- Presto
- Polars
- DuckDB
- pandas

The change preserves the experimental label for Velox and does not add performance claims, marketing copy, or starter-kit content.

## Validation

- `git diff --check`
- Generated the Sphinx HTML with `make html`
- Hosted and inspected the rendered landing page at 1440 px, 720 px, and 390 px widths
- Confirmed exactly six table rows and six expected technical links

The local full-documentation build generated the reviewed HTML but exited nonzero because warnings are treated as errors. The warnings came from version skew between the main-branch documentation and the installed cuDF 26.08 package, plus unavailable generated C++ Doxygen XML. No warnings were attributable to `docs/cudf/source/index.rst` or the new table.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.