### PR TITLE
Add cudf-polars DataFrame._size_bytes

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -106,6 +106,10 @@ class DataFrame:
         self.table = plc.Table([c.obj for c in self.columns], num_rows=num_rows)
         self.stream = stream
 
+    def _size_bytes(self) -> int:
+        """Return the size of the dataframe in bytes."""
+        return sum(c.device_buffer_size() for c in self.table.columns())
+
     def copy(self) -> Self:
         """Return a shallow copy of self."""
         return type(self)(

--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -106,10 +106,6 @@ class DataFrame:
         self.table = plc.Table([c.obj for c in self.columns], num_rows=num_rows)
         self.stream = stream
 
-    def _size_bytes(self) -> int:
-        """Return the size of the dataframe in bytes."""
-        return sum(c.device_buffer_size() for c in self.table.columns())
-
     def copy(self) -> Self:
         """Return a shallow copy of self."""
         return type(self)(
@@ -168,6 +164,11 @@ class DataFrame:
     def num_rows(self) -> int:
         """Number of rows."""
         return self.table.num_rows()
+
+    @cached_property
+    def _size_bytes(self) -> int:
+        """Return the size of the dataframe in bytes."""
+        return sum(c.device_buffer_size() for c in self.table.columns())
 
     @classmethod
     def from_polars(cls, df: pl.DataFrame, stream: Stream) -> Self:

--- a/python/cudf_polars/tests/containers/test_dataframe.py
+++ b/python/cudf_polars/tests/containers/test_dataframe.py
@@ -224,3 +224,14 @@ def test_serialization_roundtrip(polars_tbl):
     res = DataFrame.deserialize(header, frames, stream=stream)
 
     assert_frame_equal(df.to_polars(), res.to_polars())
+
+
+def test_size_bytes():
+    stream = get_cuda_stream()
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([1, 2, 3], dtype=pl.Int64()),
+        }
+    )
+    df = DataFrame.from_polars(df, stream=stream)
+    assert df._size_bytes() == 24

--- a/python/cudf_polars/tests/containers/test_dataframe.py
+++ b/python/cudf_polars/tests/containers/test_dataframe.py
@@ -234,4 +234,4 @@ def test_size_bytes():
         }
     )
     df = DataFrame.from_polars(df, stream=stream)
-    assert df._size_bytes() == 24
+    assert df._size_bytes == 24


### PR DESCRIPTION
## Description

Returns the total device buffer size of a DataFrame's columns, so callers that report memory usage don't have to sum column sizes themselves.

Split off from https://github.com/NVIDIA/cudf/pull/23179, which calls this in a few places.