### PR TITLE
Initialize NVML once per traced `do_evaluate` definition 

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/tracing.py
+++ b/python/cudf_polars/cudf_polars/dsl/tracing.py
@@ -162,6 +162,10 @@ def log_do_evaluate(
     if not LOG_TRACES:
         return func
     else:  # pragma: no cover; requires CUDF_POLARS_LOG_TRACES=1
+        # do this just once
+        pynvml.nvmlInit()
+        maybe_handle = get_device_handle()
+        pid = _getpid()
 
         @functools.wraps(func)
         def wrapper(
@@ -169,10 +173,6 @@ def log_do_evaluate(
             *args: P.args,
             **kwargs: P.kwargs,
         ) -> cudf_polars.containers.DataFrame:
-            # do this just once
-            pynvml.nvmlInit()
-            maybe_handle = get_device_handle()
-            pid = _getpid()
             log = structlog.get_logger()
 
             # By convention, all non-dataframe arguments (non-child) come first.


### PR DESCRIPTION
## Description

The comment said "do this just once", but `nvmlInit`, `get_device_handle` and `getpid` ran on every traced do_evaluate call. Move them to decoration time so the cost is paid once when CUDF_POLARS_LOG_TRACES is enabled, rather than once per call (when enabled).

These are all cached anyway, but there's no reason to call it repeatedly.

Spotted while working on https://github.com/NVIDIA/cudf/pull/23179 and split off from there.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
