### PR TITLE
Skip failing narhwals datetime to_string tests

### DIFF
--- a/ci/narwhals_cudf_polars_test_plugin.py
+++ b/ci/narwhals_cudf_polars_test_plugin.py
@@ -23,6 +23,9 @@ EXPECTED_FAILURES: Mapping[str, str] = {
     "tests/expr_and_series/lit_test.py::test_nested_structures[polars[lazy]-value4-None]": "cudf-polars mishandles list/tuple literals without nested lists.",
     "tests/expr_and_series/lit_test.py::test_nested_structures[polars[lazy]-value6-None]": "cudf-polars mishandles list/tuple literals without nested lists.",
     "tests/expr_and_series/lit_test.py::test_nested_structures[polars[lazy]-value7-None]": "cudf-polars mishandles list/tuple literals without nested lists.",
+    "tests/expr_and_series/dt/replace_time_zone_test.py::test_replace_time_zone[polars[lazy]]": "https://github.com/NVIDIA/cudf/issues/23935",
+    "tests/expr_and_series/dt/convert_time_zone_test.py::test_convert_time_zone[polars[lazy]]": "https://github.com/NVIDIA/cudf/issues/23935",
+    "tests/expr_and_series/dt/convert_time_zone_test.py::test_convert_time_zone_from_none[polars[lazy]]": "https://github.com/NVIDIA/cudf/issues/23935",
 }
 
 


### PR DESCRIPTION
## Description

This adds a skip for some tests that recently started failing on CI (https://github.com/NVIDIA/cudf/actions/runs/33631705030/job/100262514357?pr=23922#step:14:4243). https://github.com/NVIDIA/cudf/pull/23424/ added support for some functions that previously raised NotImplementedError and so fell back to CPU. After that was merged, we get further in the test from narwhals and hit this bug. This fix looks non-trivial so I've skipped it for now to get CI passing again.

https://github.com/NVIDIA/cudf/issues/23935 tracks the underlying issue.
