### PR TITLE
CI: Reduce dask-cuDF wheel test frequency

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -322,6 +322,10 @@ jobs:
           - '!img/**'
           - '!java/**'
           - '!notebooks/**'
+        test_wheel_dask_cudf:
+          - 'python/cudf/**'
+          - '!python/cudf/cudf/pandas/**'
+          - 'python/dask_cudf/**'
         not_cudf_polars:
           - '**'
           - '!python/cudf_polars/**'
@@ -564,7 +568,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_wheel_dask_cudf
     with:
       build_type: pull-request
       node_type: "gpu-rtxpro6000-latest-1"
@@ -818,7 +822,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).not_cudf_polars
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_wheel_dask_cudf
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))


### PR DESCRIPTION
## Description

Run the Dask cuDF wheel-test and Conda notebooks jobs only when a PR changes Dask cuDF or core cuDF Python, excluding the python/cudf/cudf/pandas subtree. This avoids running these Dask-related jobs for unrelated Python projects such as cuDF Polars, cuDF Kafka, and cuDF Streaming while preserving coverage for Dask cuDF and its cuDF dependency.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.