### PR TITLE
CI: Filter CMake tests and C++ linters by source changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,6 +167,10 @@ jobs:
           - '!java/**'
           - '!notebooks/**'
           - '!python/**'
+        cpp_files:
+          - 'cpp/**'
+          - 'ci/test_cmake.sh'
+          - 'ci/cpp_linters.sh'
         unit_tests_cudf_pandas:
           - 'python/cudf/cudf/pandas/**'
         test_java:
@@ -362,7 +366,7 @@ jobs:
       node_type: cpu16
       script: ci/build_cpp.sh
   cmake-tests:
-    needs: checks
+    needs: [checks, changed-files]
     permissions:
       actions: read
       contents: read
@@ -371,6 +375,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_files
     with:
       build_type: pull-request
       node_type: cpu16
@@ -385,8 +390,9 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    needs: checks
+    needs: [checks, changed-files]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_files
     with:
       build_type: pull-request
       script: "ci/cpp_linters.sh"


### PR DESCRIPTION
## Description

Run the CMake test and C++ linter jobs only when a pull request changes files under cpp/. We don't need these tests to run for packaging or Python changes, only for changes to our C++ source or CMake.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.