### PR TITLE
CI: Preserve notebook test trigger

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -208,37 +208,10 @@ jobs:
           - '!notebooks/**'
           - '!python/**'
         test_notebooks:
-          - '**'
-          - '!**/REVIEW_GUIDELINES.md'
-          - '!.coderabbit.yaml'
-          - '!.clang-format'
-          - '!.devcontainer/**'
-          - '!.github/CODEOWNERS'
-          - '!.github/ISSUE_TEMPLATE/**'
-          - '!.github/PULL_REQUEST_TEMPLATE.md'
-          - '!.github/copy-pr-bot.yaml'
-          - '!.github/labeler.yml'
-          - '!.github/ops-bot.yaml'
-          - '!.github/release.yml'
-          - '!.github/workflows/auto-assign.yml'
-          - '!.github/workflows/build.yaml'
-          - '!.github/workflows/issue-release-scheduled.yml'
-          - '!.github/workflows/labeler.yml'
-          - '!.github/workflows/pr_issue_status_automation.yml'
-          - '!.github/workflows/test.yaml'
-          - '!.github/workflows/trigger-breaking-change-alert.yaml'
-          - '!.pre-commit-config.yaml'
-          - '!.yamllint.yaml'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!SECURITY.md'
-          - '!ci/build_wheel*.sh'
-          - '!ci/cudf_pandas_scripts/**'
-          - '!ci/release/update-version.sh'
-          - '!ci/test_wheel*.sh'
-          - '!ci/validate_wheel.sh'
-          - '!codecov.yml'
-          - '!java/**'
+          - 'python/cudf/**'
+          - '!python/cudf/cudf/pandas/**'
+          - 'python/dask_cudf/**'
+          - 'notebooks/**'
         test_python_conda:
           - '**'
           - '!**/REVIEW_GUIDELINES.md'
@@ -568,7 +541,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_wheel_dask_cudf
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
     with:
       build_type: pull-request
       node_type: "gpu-rtxpro6000-latest-1"


### PR DESCRIPTION
## Description

Use a positive change filter for the Conda notebooks job. It runs only for Dask cuDF changes, core cuDF Python changes excluding cuDF.pandas, or changes under notebooks/. This restores notebook-only coverage without running the job for unrelated C++ changes, and removes the unused broad workflow filter.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.