### PR TITLE
CI: Trigger cached Java build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -515,7 +515,7 @@ jobs:
       build_type: pull-request
       arch: ${{ matrix.ARCH }}
       node_type: ${{ matrix.ARCH == 'amd64' && 'gpu-rtxpro6000-latest-1' || 'gpu-l4-latest-1' }}
-      container_image: "rapidsai/ci-wheel:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      container_image: "rapidsai/citestwheel:26.10-latest"
       script: "ci/test_packaged_java.sh"
   conda-notebook-tests:
     needs: [conda-python-build, conda-python-build-noarch, changed-files]

--- a/java/README.md
+++ b/java/README.md
@@ -1,5 +1,6 @@
 # Java API for cudf
 
+
 This project provides java bindings for cudf, to be able to process large amounts of data on
 a GPU. This is still a work in progress so some APIs may change until the 1.0 release.
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,6 +1,5 @@
 # Java API for cudf
 
-
 This project provides java bindings for cudf, to be able to process large amounts of data on
 a GPU. This is still a work in progress so some APIs may change until the 1.0 release.
 


### PR DESCRIPTION
## Description

Run the packaged cuDF Java JAR tests in the slimmer citestwheel image rather than the ci-wheel build image. The test job consumes the prebuilt Java artifacts, so it does not require the build toolchain.

A temporary blank-line change in java/README.md is included solely to trigger the Java changed-files filter; it will be removed after validating the CI run.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.