### PR TITLE
Update hybrid scan benchmark I/O policy

### DIFF
--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
@@ -78,7 +78,11 @@ std::vector<cudf::size_type> apply_row_group_filters(
     if (not dict_page_byte_ranges.empty()) {
       auto [dictionary_page_buffers, dictionary_page_data, dict_read_tasks] =
         cudf::io::parquet::fetch_byte_ranges_to_device_async(
-          datasource, dict_page_byte_ranges, stream, mr);
+          datasource,
+          dict_page_byte_ranges,
+          cudf::io::parquet::io_submission_policy::SERIALIZE,
+          stream,
+          mr);
       dict_read_tasks.get();
 
       dict_page_filtered_row_groups = reader.filter_row_groups_with_dictionary_pages(
@@ -102,7 +106,11 @@ std::vector<cudf::size_type> apply_row_group_filters(
       auto aligned_mr = rmm::mr::aligned_resource_adaptor(mr, bloom_filter_alignment);
       auto [bloom_filter_buffers, bloom_filter_data, bloom_read_tasks] =
         cudf::io::parquet::fetch_byte_ranges_to_device_async(
-          datasource, bloom_filter_byte_ranges, stream, aligned_mr);
+          datasource,
+          bloom_filter_byte_ranges,
+          cudf::io::parquet::io_submission_policy::SERIALIZE,
+          stream,
+          aligned_mr);
       bloom_read_tasks.get();
 
       bloom_filtered_row_groups = reader.filter_row_groups_with_bloom_filters(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Update the hybrid scan benchmark's dictionary-page and bloom-filter reads to use the new `fetch_byte_ranges_to_device_async` overload with an explicit `io_submission_policy::SERIALIZE` policy. This preserves the deprecated overload's behavior and removes the deprecation warnings.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing benchmark compilation covers these changes.
- [x] The documentation is up to date with these changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C01CW5L51QC/p1788383965327569?thread_ts=1788383965.327569&cid=C01CW5L51QC)

<div><a href="https://cursor.com/agents/bc-22cd57c1-97b8-55f0-84e8-8dd9d80f04d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22cd57c1-97b8-55f0-84e8-8dd9d80f04d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

