### PR TITLE
Draft: Add dual-path Parquet level-prepass rollout

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -481,11 +481,13 @@ __device__ int update_validity_and_row_indices_nested(
         uint32_t const warp_validity_mask = ballot(is_valid);
         // lane 0 from each warp writes out validity
         if ((write_start >= 0) && ((t % cudf::detail::warp_size) == 0)) {
-          int const valid_map_offset = ni.valid_map_offset;
-          int const vindex     = value_count + thread_value_count;  // absolute input value index
-          int const bit_offset = (valid_map_offset + vindex + write_start) -
-                                 first_row;  // absolute bit offset into the output validity map
-          int const write_end = cudf::detail::warp_size -
+          // valid_map_offset is the output cursor for this depth.  It is
+          // advanced after every block below, so adding value_count here
+          // would apply block progress twice.  Each warp owns its contiguous
+          // portion of the current block.
+          int const warp_value_offset = t - (t % cudf::detail::warp_size);
+          int const bit_offset        = ni.valid_map_offset + warp_value_offset + write_start;
+          int const write_end         = cudf::detail::warp_size -
                                 __clz(in_write_row_bounds_mask);  // last bit in the warp to store
           int const bit_count = write_end - write_start;
 
@@ -493,7 +495,16 @@ __device__ int update_validity_and_row_indices_nested(
         }
       }
 
-      if (t == 0) { ni.null_count += (block_value_count - block_valid_count); }
+      if (t == 0) {
+        // Publish the same per-depth progress that gpuDecodeLevels leaves in
+        // the local state.  Consumers use valid_map_offset to delimit the
+        // selected validity range (not merely to address the bitmap), and
+        // string/nested finalization relies on the depth-local counts.
+        ni.null_count += (block_value_count - block_valid_count);
+        ni.valid_count += block_valid_count;
+        ni.value_count += block_value_count;
+        if (ni.valid_map != nullptr) { ni.valid_map_offset += block_value_count; }
+      }
 
       // if this is valid and we're at the leaf, output dst_pos
       if (d_idx == max_depth) {
@@ -506,6 +517,10 @@ __device__ int update_validity_and_row_indices_nested(
         // update stuff
         max_depth_valid_count += block_valid_count;
       }
+
+      // BlockScan temporary storage is reused for every nesting depth.  All
+      // threads must finish this depth before the next scan overwrites it.
+      __syncthreads();
 
     }  // end depth loop
 

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1747,15 +1747,19 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
 
-  if (!pp->nested_prepass_enabled || pp->nested_prepass_nesting == nullptr) { return; }
+  if ((!pp->nested_prepass_enabled && !pp->legacy_nested_prepass_enabled) ||
+      pp->nested_prepass_nesting == nullptr) {
+    return;
+  }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
-  if (!setup_local_page_info(s,
-                             pp,
-                             chunks,
-                             min_row,
-                             num_rows,
-                             mask_filter{NESTED_GENERIC_LEVEL_PREPASS_MASK},
-                             page_processing_stage::DECODE)) {
+  if (!setup_local_page_info(
+        s,
+        pp,
+        chunks,
+        min_row,
+        num_rows,
+        mask_filter{BitOr(NESTED_GENERIC_LEVEL_PREPASS_MASK, NESTED_LEGACY_LEVEL_PREPASS_MASK)},
+        page_processing_stage::DECODE)) {
     return;
   }
 

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1941,19 +1941,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
 
-  if (!(pp->generic_list_prepass_enabled || pp->legacy_list_prepass_enabled) ||
+  if (!(pp->generic_list_prepass_enabled || pp->legacy_list_prepass_enabled ||
+        pp->delta_list_prepass_enabled) ||
       pp->list_prepass_nesting == nullptr ||
-      BitAnd(pp->kernel_mask, LIST_LEVEL_PREPASS_MASK) == 0) {
+      BitAnd(pp->kernel_mask, BitOr(LIST_LEVEL_PREPASS_MASK, DELTA_LIST_LEVEL_PREPASS_MASK)) == 0) {
     return;
   }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
-  if (!setup_local_page_info(s,
-                             pp,
-                             chunks,
-                             min_row,
-                             num_rows,
-                             mask_filter{LIST_LEVEL_PREPASS_MASK},
-                             page_processing_stage::DECODE)) {
+  if (!setup_local_page_info(
+        s,
+        pp,
+        chunks,
+        min_row,
+        num_rows,
+        mask_filter{BitOr(LIST_LEVEL_PREPASS_MASK, DELTA_LIST_LEVEL_PREPASS_MASK)},
+        page_processing_stage::DECODE)) {
     return;
   }
 

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -402,9 +402,25 @@ __device__ int skip_validity_and_row_indices_nonlist(
  *
  * @return Maximum depth valid count after processing
  */
-template <int decode_block_size, typename level_t, typename state_buf>
+template <typename state_buf>
+struct rolling_nz_idx_sink {
+  state_buf* buffers;
+
+  __device__ void store(int valid_rank, uint32_t dst_pos) const
+  {
+    buffers->nz_idx[rolling_index<state_buf::nz_buf_size>(valid_rank)] = dst_pos;
+  }
+};
+
+struct global_nz_idx_sink {
+  uint32_t* indices;
+
+  __device__ void store(int valid_rank, uint32_t dst_pos) const { indices[valid_rank] = dst_pos; }
+};
+
+template <int decode_block_size, typename level_t, typename nz_idx_sink>
 __device__ int update_validity_and_row_indices_nested(
-  int32_t target_value_count, auto* s, state_buf* sb, level_t const* const def, int t)
+  int32_t target_value_count, auto* s, nz_idx_sink sink, level_t const* const def, int t)
 {
   constexpr int num_warps      = decode_block_size / cudf::detail::warp_size;
   constexpr int max_batch_size = num_warps * cudf::detail::warp_size;
@@ -485,7 +501,7 @@ __device__ int update_validity_and_row_indices_nested(
           int const dst_pos = value_count + thread_value_count;
           int const src_pos = max_depth_valid_count + thread_valid_count;
 
-          sb->nz_idx[rolling_index<state_buf::nz_buf_size>(src_pos)] = dst_pos;
+          sink.store(src_pos, dst_pos);
         }
         // update stuff
         max_depth_valid_count += block_valid_count;
@@ -977,6 +993,55 @@ __device__ void skip_ahead_in_decoding(auto* s,
   block.sync();
 }
 
+template <int decode_block_size_t, bool has_nesting_t, typename level_t>
+__device__ void seed_nonlist_level_state(
+  auto* s, bool process_nulls, level_t const* const def, int& processed_count, int& valid_count)
+{
+  int const first_row = s->setup.first_row;
+  if (first_row <= 0) { return; }
+
+  auto const t    = cg::this_thread_block().thread_rank();
+  processed_count = first_row;
+  valid_count     = !process_nulls
+                      ? first_row
+                      : skip_validity_and_row_indices_nonlist<decode_block_size_t, level_t>(
+                      first_row, s, def, has_nesting_t, t);
+  if (t == 0) {
+    auto& ni                      = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+    ni.valid_count                = valid_count;
+    ni.value_count                = processed_count;
+    s->progress.nz_count          = valid_count;
+    s->progress.input_value_count = processed_count;
+    s->progress.input_row_count   = processed_count;
+  }
+  cg::this_thread_block().sync();
+}
+
+template <int decode_block_size_t, typename level_t>
+__device__ void materialize_skipped_nested_nz_idx(auto* s,
+                                                  level_t const* const def,
+                                                  uint32_t* nz_idx)
+{
+  __shared__ typename cub::BlockScan<int, decode_block_size_t>::TempStorage scan_storage;
+  int const first_row = s->setup.first_row;
+  int const t         = cg::this_thread_block().thread_rank();
+  int const max_def_level =
+    s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].max_def_level;
+  int input_value_count = 0;
+  int valid_count       = 0;
+  while (input_value_count < first_row) {
+    int const batch_size = min(decode_block_size_t, first_row - input_value_count);
+    int const is_valid   = t >= batch_size ? 0 : (def[input_value_count + t] >= max_def_level);
+    int thread_valid_count, block_valid_count;
+    cub::BlockScan<int, decode_block_size_t>(scan_storage)
+      .ExclusiveSum(is_valid, thread_valid_count, block_valid_count);
+    if (is_valid) { nz_idx[valid_count + thread_valid_count] = input_value_count + t; }
+    input_value_count += batch_size;
+    valid_count += block_valid_count;
+    cg::this_thread_block().sync();
+  }
+}
+
 /**
  * @brief Check if the kernel mask decodes dictionary-encoded data (has a dictionary stream).
  *
@@ -1100,7 +1165,8 @@ __device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int count
 template <typename level_t,
           int decode_block_size_t,
           decode_kernel_mask kernel_mask_t,
-          bool use_flat_prepass_t>
+          bool use_flat_prepass_t,
+          bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   decode_page_data_generic_legacy(PageInfo* pages,
                                   device_span<ColumnChunkDesc const> chunks,
@@ -1141,10 +1207,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
 
   if constexpr (use_flat_prepass_t) {
     if (!pages[page_idx].flat_prepass_enabled) { return; }
+  } else if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].nested_prepass_enabled) { return; }
   } else {
     // The flat prepass consumer is launched separately. Keep this legacy kernel
     // available for every other page that shares this decode mask.
-    if (pages[page_idx].flat_prepass_enabled) { return; }
+    if (pages[page_idx].flat_prepass_enabled || pages[page_idx].nested_prepass_enabled) { return; }
   }
 
   // Exit early if the page is pruned
@@ -1251,6 +1319,27 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       s->progress.input_row_count   = processed_count;
     }
     block.sync();
+  } else if constexpr (use_nested_prepass_t) {
+    processed_count = first_row;
+    valid_count     = process_nulls
+                        ? flat_prepass_valid_count_before(
+                        pp->nested_prepass_nz_idx, pp->nested_prepass_nz_count, first_row)
+                        : first_row;
+    if constexpr (has_dict_t) {
+      skip_decode<rolling_buf_size>(dict_stream, valid_count, t);
+    } else if constexpr (has_bools_t) {
+      if (bools_are_rle_stream) {
+        skip_decode<rolling_buf_size>(bool_stream, valid_count, t);
+      } else if (t == 0) {
+        s->progress.dict_pos = valid_count;
+      }
+    }
+    if (t == 0) {
+      s->progress.nz_count          = valid_count;
+      s->progress.input_value_count = processed_count;
+      s->progress.input_row_count   = processed_count;
+    }
+    block.sync();
   } else {
     // Skip ahead in the decoding so that we don't repeat work
     skip_ahead_in_decoding<decode_block_size_t,
@@ -1278,16 +1367,20 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     block.sync();
     processed_count += min(rolling_buf_size, s->setup.page.num_input_values - processed_count);
 
-    if constexpr (use_flat_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+      auto const* const prepass_nz_idx =
+        use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
+      int const prepass_nz_count =
+        use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
       int const capped_target_value_count = min(processed_count, last_row);
-      next_valid_count = process_nulls ? flat_prepass_valid_count_before(pp->flat_prepass_nz_idx,
-                                                                         pp->flat_prepass_nz_count,
-                                                                         capped_target_value_count)
-                                       : capped_target_value_count;
+      next_valid_count                    = process_nulls
+                                              ? flat_prepass_valid_count_before(
+                               prepass_nz_idx, prepass_nz_count, capped_target_value_count)
+                                              : capped_target_value_count;
       for (int map_pos = valid_count + t; map_pos < next_valid_count;
            map_pos += decode_block_size_t) {
         sb->nz_idx[rolling_index<state_buf_t::nz_buf_size>(map_pos)] =
-          process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+          process_nulls ? prepass_nz_idx[map_pos] : map_pos;
       }
       if (t == 0) {
         s->progress.input_row_count =
@@ -1300,7 +1393,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
             processed_count, s, sb, def, rep, t);
       } else if constexpr (has_nesting_t) {
         next_valid_count = update_validity_and_row_indices_nested<decode_block_size_t, level_t>(
-          processed_count, s, sb, def, t);
+          processed_count, s, rolling_nz_idx_sink<state_buf_t>{sb}, def, t);
       } else {
         next_valid_count = update_validity_and_row_indices_flat<decode_block_size_t, level_t>(
           processed_count, s, sb, def, t);
@@ -1385,6 +1478,20 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       s->progress.input_row_count   = page_rows;
     }
     block.sync();
+  } else if constexpr (use_nested_prepass_t) {
+    if (t == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = valid_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
   }
 
   // Zero-fill null positions after decoding valid values
@@ -1413,7 +1520,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     // column construction. Otherwise, convert string sizes to final offsets.
 
     if constexpr (!has_lists_t) {
-      if constexpr (use_flat_prepass_t) {
+      if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
         if (t == 0) {
           s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].value_count =
             s->setup.first_row + s->setup.num_rows;
@@ -1463,7 +1570,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<size_t const> page_string_offset_indices,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
-                      bool use_flat_prepass)
+                      bool use_flat_prepass,
+                      bool use_nested_prepass)
 {
   // No template parameters on lambdas until C++20, so use type tags instead
   auto launch_kernel = [&](auto block_size_tag, auto kernel_mask_tag) {
@@ -1475,7 +1583,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
 
     if (use_flat_prepass) {
       if (level_type_size == 1) {
-        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, true>
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, true, false>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1485,7 +1593,31 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                      page_string_offset_indices,
                                                      error_code);
       } else {
-        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, true>
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, true, false>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
+      }
+      CUDF_CUDA_TRY(cudaGetLastError());
+    }
+    if (use_nested_prepass) {
+      if (level_type_size == 1) {
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, true>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
+      } else {
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, true>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1498,7 +1630,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
       CUDF_CUDA_TRY(cudaGetLastError());
     }
     if (level_type_size == 1) {
-      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false>
+      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1509,7 +1641,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                    error_code);
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
-      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false>
+      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1596,6 +1728,109 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
       break;
     default: CUDF_EXPECTS(false, "Kernel type not handled by this function"); break;
   }
+}
+
+namespace {
+
+template <typename level_t, int decode_block_size_t>
+CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
+  precompute_nested_level_state_kernel(PageInfo* pages,
+                                       device_span<ColumnChunkDesc const> chunks,
+                                       size_t min_row,
+                                       size_t num_rows,
+                                       cudf::device_span<bool const> page_mask)
+{
+  __shared__ __align__(16) full_page_decode_state state_g;
+  auto const block   = cg::this_thread_block();
+  auto* const s      = &state_g;
+  int const page_idx = blockIdx.x;
+  int const t        = block.thread_rank();
+  PageInfo* const pp = &pages[page_idx];
+
+  if (!pp->nested_prepass_enabled || pp->nested_prepass_nesting == nullptr) { return; }
+  if (!page_mask.empty() && !page_mask[page_idx]) { return; }
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{NESTED_GENERIC_LEVEL_PREPASS_MASK},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+
+  bool const process_nulls = should_process_nulls(s);
+  bool const is_required   = s->setup.col.max_level[level_type::DEFINITION] == 0;
+  if (!process_nulls) {
+    if (!is_required) { return; }
+    int const final_count =
+      min(s->setup.first_row + s->setup.num_rows, s->setup.page.num_input_values);
+    if (t == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                = s->nesting.nesting_info[depth];
+        pp->nested_prepass_nesting[depth] = {0, source.valid_map_offset, final_count, final_count};
+      }
+      pp->nested_prepass_nz_count          = final_count;
+      pp->nested_prepass_input_value_count = final_count;
+      pp->nested_prepass_input_row_count   = final_count;
+    }
+    return;
+  }
+
+  auto const* const def =
+    reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::DEFINITION]);
+  int processed_count = 0;
+  int valid_count     = 0;
+  if (s->setup.first_row > 0) {
+    materialize_skipped_nested_nz_idx<decode_block_size_t>(s, def, pp->nested_prepass_nz_idx);
+  }
+  seed_nonlist_level_state<decode_block_size_t, true>(
+    s, process_nulls, def, processed_count, valid_count);
+  constexpr int rolling_buf_size = decode_block_size_t * 2;
+  int const decoded_value_limit =
+    pp->num_decoded_level_values > 0
+      ? min(s->setup.page.num_input_values, pp->num_decoded_level_values)
+      : s->setup.page.num_input_values;
+  int const last_row = min(s->setup.first_row + s->setup.num_rows, decoded_value_limit);
+  while (processed_count < decoded_value_limit && s->progress.input_row_count <= last_row) {
+    processed_count += min(rolling_buf_size, decoded_value_limit - processed_count);
+    valid_count = update_validity_and_row_indices_nested<decode_block_size_t, level_t>(
+      processed_count, s, global_nz_idx_sink{pp->nested_prepass_nz_idx}, def, t);
+  }
+  if (t == 0) {
+    for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+      auto const& source                = s->nesting.nesting_info[depth];
+      pp->nested_prepass_nesting[depth] = {
+        source.null_count, source.valid_map_offset, source.valid_count, source.value_count};
+    }
+    pp->nested_prepass_nz_count          = valid_count;
+    pp->nested_prepass_input_value_count = s->progress.input_value_count;
+    pp->nested_prepass_input_row_count   = s->progress.input_row_count;
+  }
+}
+
+}  // namespace
+
+void precompute_nested_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                   cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                   cudf::device_span<bool const> page_mask,
+                                   size_t min_row,
+                                   size_t num_rows,
+                                   int level_type_size,
+                                   cuda::stream_ref stream)
+{
+  if (pages.size() == 0) { return; }
+  constexpr int decode_block_size = 128;
+  dim3 const block(decode_block_size, 1);
+  dim3 const grid(pages.size(), 1);
+  if (level_type_size == 1) {
+    precompute_nested_level_state_kernel<uint8_t, decode_block_size>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
+  } else {
+    precompute_nested_level_state_kernel<uint16_t, decode_block_size>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
+  }
+  CUDF_CUDA_TRY(cudaGetLastError());
 }
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1080,14 +1080,14 @@ CUDF_HOST_DEVICE constexpr bool is_split_decode()
  */
 template <typename level_t, int decode_block_size_t, decode_kernel_mask kernel_mask_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
-  decode_page_data_generic(PageInfo* pages,
-                           device_span<ColumnChunkDesc const> chunks,
-                           size_t min_row,
-                           size_t num_rows,
-                           cudf::device_span<bool const> page_mask,
-                           cudf::device_span<size_t> initial_str_offsets,
-                           cudf::device_span<size_t const> page_string_offset_indices,
-                           kernel_error::pointer error_code)
+  decode_page_data_generic_legacy(PageInfo* pages,
+                                  device_span<ColumnChunkDesc const> chunks,
+                                  size_t min_row,
+                                  size_t num_rows,
+                                  cudf::device_span<bool const> page_mask,
+                                  cudf::device_span<size_t> initial_str_offsets,
+                                  cudf::device_span<size_t const> page_string_offset_indices,
+                                  kernel_error::pointer error_code)
 {
   constexpr bool has_dict_t     = has_dict<kernel_mask_t>();
   constexpr bool has_bools_t    = has_bools<kernel_mask_t>();
@@ -1382,7 +1382,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
     if (level_type_size == 1) {
-      decode_page_data_generic<uint8_t, decode_block_size, mask>
+      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1393,7 +1393,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                    error_code);
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
-      decode_page_data_generic<uint16_t, decode_block_size, mask>
+      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -656,7 +656,8 @@ __device__ int update_validity_and_row_indices_lists(int32_t target_value_count,
                                                      state_buf* sb,
                                                      level_t const* const def,
                                                      level_t const* const rep,
-                                                     int t)
+                                                     int t,
+                                                     uint32_t* global_nz_idx = nullptr)
 {
   constexpr int num_warps      = decode_block_size / cudf::detail::warp_size;
   constexpr int max_batch_size = num_warps * cudf::detail::warp_size;
@@ -842,6 +843,7 @@ __device__ int update_validity_and_row_indices_lists(int32_t target_value_count,
           // Index from rolling buffer of values (which doesn't include nulls) to final array (which
           // includes gaps for nulls)
           sb->nz_idx[output_index] = dst_pos;
+          if (global_nz_idx != nullptr) { global_nz_idx[src_pos] = dst_pos; }
         }
         max_depth_valid_count += block_valid_count;
       }
@@ -1166,7 +1168,8 @@ template <typename level_t,
           int decode_block_size_t,
           decode_kernel_mask kernel_mask_t,
           bool use_flat_prepass_t,
-          bool use_nested_prepass_t>
+          bool use_nested_prepass_t,
+          bool use_list_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   decode_page_data_generic_legacy(PageInfo* pages,
                                   device_span<ColumnChunkDesc const> chunks,
@@ -1209,10 +1212,15 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     if (!pages[page_idx].flat_prepass_enabled) { return; }
   } else if constexpr (use_nested_prepass_t) {
     if (!pages[page_idx].nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].generic_list_prepass_enabled) { return; }
   } else {
     // The flat prepass consumer is launched separately. Keep this legacy kernel
     // available for every other page that shares this decode mask.
-    if (pages[page_idx].flat_prepass_enabled || pages[page_idx].nested_prepass_enabled) { return; }
+    if (pages[page_idx].flat_prepass_enabled || pages[page_idx].nested_prepass_enabled ||
+        pages[page_idx].generic_list_prepass_enabled) {
+      return;
+    }
   }
 
   // Exit early if the page is pruned
@@ -1288,6 +1296,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   int processed_count         = 0;
   int valid_count             = 0;
   size_t string_output_offset = 0;
+  // Retain the initial output-validity position for the common post-decode
+  // null fill. List prepass consumers publish their final nesting state only
+  // after value decoding, so this must be captured before either path runs.
   int const init_valid_map_offset =
     s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].valid_map_offset;
   int const first_row = s->setup.first_row;
@@ -1340,6 +1351,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       s->progress.input_row_count   = processed_count;
     }
     block.sync();
+  } else if constexpr (use_list_prepass_t) {
+    // The producer has already walked rep/def levels and advanced all nesting
+    // state. Keep the value-stream coordinate used by legacy list decoding,
+    // then consume the published valid-rank contract directly.
+    processed_count = s->setup.page.skipped_leaf_values;
+    if constexpr (has_dict_t) {
+      skip_decode<rolling_buf_size>(dict_stream, processed_count, t);
+    } else if constexpr (has_bools_t) {
+      if (bools_are_rle_stream) {
+        skip_decode<rolling_buf_size>(bool_stream, processed_count, t);
+      } else if (t == 0) {
+        s->progress.dict_pos = processed_count;
+      }
+    }
+    block.sync();
   } else {
     // Skip ahead in the decoding so that we don't repeat work
     skip_ahead_in_decoding<decode_block_size_t,
@@ -1361,13 +1387,19 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   // the core loop. decode batches of level stream data using rle_stream objects
   // and pass the results to decode_values
   // For chunked reads we may not process all of the rows on the page; if not stop early
-  while ((s->setup.error == 0) && (processed_count < s->setup.page.num_input_values) &&
-         (s->progress.input_row_count <= last_row)) {
+  while ((s->setup.error == 0) &&
+         (use_list_prepass_t ? valid_count < pp->list_prepass_nz_count
+                             : ((processed_count < s->setup.page.num_input_values) &&
+                                (s->progress.input_row_count <= last_row)))) {
     int next_valid_count;
     block.sync();
-    processed_count += min(rolling_buf_size, s->setup.page.num_input_values - processed_count);
+    if constexpr (!use_list_prepass_t) {
+      processed_count += min(rolling_buf_size, s->setup.page.num_input_values - processed_count);
+    }
 
-    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+    if constexpr (use_list_prepass_t) {
+      next_valid_count = min(valid_count + rolling_buf_size, pp->list_prepass_nz_count);
+    } else if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
       auto const* const prepass_nz_idx =
         use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
       int const prepass_nz_count =
@@ -1417,6 +1449,15 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       }
     }
     block.sync();
+
+    if constexpr (use_list_prepass_t) {
+      for (int map_pos = valid_count + t; map_pos < next_valid_count;
+           map_pos += decode_block_size_t) {
+        sb->nz_idx[rolling_index<state_buf_t::nz_buf_size>(map_pos)] =
+          pp->list_prepass_nz_idx[map_pos];
+      }
+      block.sync();
+    }
 
     // We want to limit the number of dictionary/bool/string items we decode,
     // that correspond to the rows we have processed in this iteration that are valid.
@@ -1490,6 +1531,20 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       s->progress.nz_count          = valid_count;
       s->progress.input_value_count = pp->nested_prepass_input_value_count;
       s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
+  } else if constexpr (use_list_prepass_t) {
+    if (t == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->list_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->list_prepass_nz_count;
+      s->progress.input_value_count = pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = pp->list_prepass_input_row_count;
     }
     block.sync();
   }
@@ -1571,7 +1626,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
                       bool use_flat_prepass,
-                      bool use_nested_prepass)
+                      bool use_nested_prepass,
+                      bool use_list_prepass)
 {
   // No template parameters on lambdas until C++20, so use type tags instead
   auto launch_kernel = [&](auto block_size_tag, auto kernel_mask_tag) {
@@ -1583,7 +1639,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
 
     if (use_flat_prepass) {
       if (level_type_size == 1) {
-        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, true, false>
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, true, false, false>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1593,7 +1649,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                      page_string_offset_indices,
                                                      error_code);
       } else {
-        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, true, false>
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, true, false, false>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1607,7 +1663,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     }
     if (use_nested_prepass) {
       if (level_type_size == 1) {
-        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, true>
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, true, false>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1617,7 +1673,31 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                      page_string_offset_indices,
                                                      error_code);
       } else {
-        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, true>
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, true, false>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
+      }
+      CUDF_CUDA_TRY(cudaGetLastError());
+    }
+    if (use_list_prepass) {
+      if (level_type_size == 1) {
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, false, true>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
+      } else {
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, false, true>
           <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                      chunks,
                                                      min_row,
@@ -1630,7 +1710,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
       CUDF_CUDA_TRY(cudaGetLastError());
     }
     if (level_type_size == 1) {
-      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, false>
+      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false, false, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1641,7 +1721,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                    error_code);
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
-      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, false>
+      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false, false, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1836,6 +1916,102 @@ void precompute_nested_level_state(cudf::detail::hostdevice_span<PageInfo> pages
       <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
   } else {
     precompute_nested_level_state_kernel<uint16_t, decode_block_size>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
+  }
+  CUDF_CUDA_TRY(cudaGetLastError());
+}
+
+namespace {
+
+template <typename level_t, int decode_block_size_t>
+CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
+  precompute_list_level_state_kernel(PageInfo* pages,
+                                     device_span<ColumnChunkDesc const> chunks,
+                                     size_t min_row,
+                                     size_t num_rows,
+                                     cudf::device_span<bool const> page_mask)
+{
+  __shared__ __align__(16) full_page_decode_state state_g;
+  using state_buf_t = page_state_buffers_s<decode_block_size_t * 2, 1, 1>;
+  __shared__ __align__(16) state_buf_t state_buffers;
+  auto const block   = cg::this_thread_block();
+  auto* const s      = &state_g;
+  auto* const sb     = &state_buffers;
+  int const page_idx = blockIdx.x;
+  int const t        = block.thread_rank();
+  PageInfo* const pp = &pages[page_idx];
+
+  if (!pp->generic_list_prepass_enabled || pp->list_prepass_nesting == nullptr ||
+      BitAnd(pp->kernel_mask, GENERIC_LIST_LEVEL_PREPASS_MASK) == 0) {
+    return;
+  }
+  if (!page_mask.empty() && !page_mask[page_idx]) { return; }
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{GENERIC_LIST_LEVEL_PREPASS_MASK},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+
+  bool const process_nulls = should_process_nulls(s);
+  auto const* const def =
+    reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::DEFINITION]);
+  auto const* const rep =
+    reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::REPETITION]);
+  int processed_count            = s->setup.page.skipped_leaf_values;
+  int valid_count                = 0;
+  int const decoded_value_limit  = s->setup.page.num_input_values;
+  int const last_row             = s->setup.first_row + s->setup.num_rows;
+  constexpr int rolling_buf_size = decode_block_size_t * 2;
+
+  while (processed_count < decoded_value_limit && s->progress.input_row_count <= last_row) {
+    processed_count += min(rolling_buf_size, decoded_value_limit - processed_count);
+    if (process_nulls) {
+      valid_count =
+        update_validity_and_row_indices_lists<decode_block_size_t, true, level_t, state_buf_t>(
+          processed_count, s, sb, def, rep, t, pp->list_prepass_nz_idx);
+    } else {
+      valid_count =
+        update_validity_and_row_indices_lists<decode_block_size_t, false, level_t, state_buf_t>(
+          processed_count, s, sb, nullptr, rep, t, pp->list_prepass_nz_idx);
+    }
+    block.sync();
+  }
+
+  if (t == 0) {
+    for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+      auto const& source              = s->nesting.nesting_info[depth];
+      pp->list_prepass_nesting[depth] = {
+        source.null_count, source.valid_map_offset, source.valid_count, source.value_count};
+    }
+    pp->list_prepass_nz_count          = valid_count;
+    pp->list_prepass_input_value_count = s->progress.input_value_count;
+    pp->list_prepass_input_row_count   = s->progress.input_row_count;
+  }
+}
+
+}  // namespace
+
+void precompute_list_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                 cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                 cudf::device_span<bool const> page_mask,
+                                 size_t min_row,
+                                 size_t num_rows,
+                                 int level_type_size,
+                                 cuda::stream_ref stream)
+{
+  if (pages.size() == 0) { return; }
+  constexpr int decode_block_size = 128;
+  dim3 const block(decode_block_size, 1);
+  dim3 const grid(pages.size(), 1);
+  if (level_type_size == 1) {
+    precompute_list_level_state_kernel<uint8_t, decode_block_size>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
+  } else {
+    precompute_list_level_state_kernel<uint16_t, decode_block_size>
       <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, min_row, num_rows, page_mask);
   }
   CUDF_CUDA_TRY(cudaGetLastError());

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1941,8 +1941,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
 
-  if (!pp->generic_list_prepass_enabled || pp->list_prepass_nesting == nullptr ||
-      BitAnd(pp->kernel_mask, GENERIC_LIST_LEVEL_PREPASS_MASK) == 0) {
+  if (!(pp->generic_list_prepass_enabled || pp->legacy_list_prepass_enabled) ||
+      pp->list_prepass_nesting == nullptr ||
+      BitAnd(pp->kernel_mask, LIST_LEVEL_PREPASS_MASK) == 0) {
     return;
   }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
@@ -1951,7 +1952,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
                              chunks,
                              min_row,
                              num_rows,
-                             mask_filter{GENERIC_LIST_LEVEL_PREPASS_MASK},
+                             mask_filter{LIST_LEVEL_PREPASS_MASK},
                              page_processing_stage::DECODE)) {
     return;
   }

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1747,19 +1747,23 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
 
-  if ((!pp->nested_prepass_enabled && !pp->legacy_nested_prepass_enabled) ||
+  if ((!pp->nested_prepass_enabled && !pp->legacy_nested_prepass_enabled &&
+       !pp->delta_nested_prepass_enabled) ||
       pp->nested_prepass_nesting == nullptr) {
     return;
   }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
-  if (!setup_local_page_info(
-        s,
-        pp,
-        chunks,
-        min_row,
-        num_rows,
-        mask_filter{BitOr(NESTED_GENERIC_LEVEL_PREPASS_MASK, NESTED_LEGACY_LEVEL_PREPASS_MASK)},
-        page_processing_stage::DECODE)) {
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{BitOr(NESTED_GENERIC_LEVEL_PREPASS_MASK,
+                                               NESTED_LEGACY_LEVEL_PREPASS_MASK,
+                                               decode_kernel_mask::DELTA_BINARY,
+                                               decode_kernel_mask::DELTA_BYTE_ARRAY,
+                                               decode_kernel_mask::DELTA_LENGTH_BA)},
+                             page_processing_stage::DECODE)) {
     return;
   }
 

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -412,10 +412,20 @@ struct rolling_nz_idx_sink {
   }
 };
 
-struct global_nz_idx_sink {
+/** @brief Write a page-local leaf-valid-rank to output-position map. */
+struct page_local_nz_idx_sink {
   uint32_t* indices;
+  int rank_base;
 
-  __device__ void store(int valid_rank, uint32_t dst_pos) const { indices[valid_rank] = dst_pos; }
+  __device__ void store(int valid_rank, uint32_t dst_pos) const
+  {
+    indices[valid_rank - rank_base] = dst_pos;
+  }
+};
+
+/** @brief Preserve level-state side effects without materializing a map. */
+struct discard_nz_idx_sink {
+  __device__ void store(int, int) const {}
 };
 
 template <int decode_block_size, typename level_t, typename nz_idx_sink>
@@ -534,6 +544,118 @@ __device__ int update_validity_and_row_indices_nested(
     s->progress.nz_count          = max_depth_valid_count;
     s->progress.input_value_count = value_count;
     s->progress.input_row_count   = value_count;
+  }
+
+  return max_depth_valid_count;
+}
+
+/**
+ * @brief Publish the complete non-list nested level state into page-global storage.
+ *
+ * This is intentionally separate from the legacy generic decoder helper above.
+ * Its map is page-local even though the state restored by setup_local_page_info()
+ * may carry a non-zero valid-rank base from prior output work.
+ */
+template <int decode_block_size, typename level_t, typename nz_idx_sink>
+__device__ int update_nested_level_prepass(int32_t target_value_count,
+                                           auto* s,
+                                           nz_idx_sink sink,
+                                           level_t const* const def,
+                                           int* const prefix_valid_count,
+                                           int const map_rank_base,
+                                           int t)
+{
+  constexpr int num_warps      = decode_block_size / cudf::detail::warp_size;
+  constexpr int max_batch_size = num_warps * cudf::detail::warp_size;
+
+  int value_count = s->progress.input_value_count;
+
+  int const first_row                 = s->setup.first_row;
+  int const last_row                  = first_row + s->setup.num_rows;
+  int const capped_target_value_count = min(target_value_count, last_row);
+
+  int const max_depth       = s->setup.col.max_nesting_depth - 1;
+  auto& max_depth_ni        = s->nesting.nesting_info[max_depth];
+  int max_depth_valid_count = max_depth_ni.valid_count;
+
+  using block_scan   = cub::BlockScan<int, decode_block_size>;
+  using block_reduce = cub::BlockReduce<int, decode_block_size>;
+  __shared__ union {
+    typename block_scan::TempStorage scan_storage;
+    typename block_reduce::TempStorage reduce_storage;
+  } temp_storage;
+
+  __syncthreads();
+
+  while (value_count < capped_target_value_count) {
+    int const batch_size = min(max_batch_size, capped_target_value_count - value_count);
+    int const def_level  = (t >= batch_size)
+                             ? -1
+                             : ((def != nullptr) ? def[value_count + t]
+                                                 : s->setup.col.max_level[level_type::DEFINITION]);
+
+    int const row_index                     = t + value_count;
+    int const in_row_bounds                 = row_index < last_row;
+    bool const in_write_row_bounds          = in_row_bounds && row_index >= first_row;
+    uint32_t const in_write_row_bounds_mask = ballot(in_write_row_bounds);
+    int const write_start                   = __ffs(in_write_row_bounds_mask) - 1;
+
+    for (int d_idx = 0; d_idx <= max_depth; ++d_idx) {
+      auto& ni           = s->nesting.nesting_info[d_idx];
+      int const is_valid = (def_level >= ni.max_def_level && in_row_bounds) ? 1 : 0;
+
+      int thread_valid_count, block_valid_count;
+      block_scan(temp_storage.scan_storage)
+        .ExclusiveSum(is_valid, thread_valid_count, block_valid_count);
+
+      __syncthreads();
+      int const selected_valid_count =
+        block_reduce(temp_storage.reduce_storage).Sum(is_valid && in_write_row_bounds);
+      __syncthreads();
+
+      if (ni.valid_map != nullptr) {
+        uint32_t const warp_validity_mask = ballot(is_valid);
+        if (write_start >= 0 && (t % cudf::detail::warp_size) == 0) {
+          int const vindex     = value_count + t;
+          int const bit_offset = ni.valid_map_offset + vindex + write_start - first_row;
+          int const write_end  = cudf::detail::warp_size - __clz(in_write_row_bounds_mask);
+          store_validity(
+            bit_offset, ni.valid_map, warp_validity_mask >> write_start, write_end - write_start);
+        }
+      }
+
+      if (t == 0) {
+        int const write_begin = max(value_count, first_row);
+        int const write_end   = min(value_count + batch_size, last_row);
+        int const write_count = max(0, write_end - write_begin);
+        ni.null_count += write_count - selected_valid_count;
+        ni.valid_count += block_valid_count;
+        ni.value_count += batch_size;
+      }
+
+      if (d_idx == max_depth) {
+        int const prefix_thread = first_row - value_count - 1;
+        if (prefix_valid_count != nullptr && prefix_thread >= 0 && prefix_thread < batch_size &&
+            t == prefix_thread) {
+          *prefix_valid_count =
+            max_depth_valid_count + thread_valid_count + is_valid - map_rank_base;
+        }
+        if (is_valid) { sink.store(max_depth_valid_count + thread_valid_count, value_count + t); }
+        max_depth_valid_count += block_valid_count;
+      }
+      __syncthreads();
+    }
+    value_count += batch_size;
+  }
+
+  if (t == 0) {
+    for (int d_idx = 0; d_idx <= max_depth; ++d_idx) {
+      auto& ni = s->nesting.nesting_info[d_idx];
+      if (ni.valid_map != nullptr) { ni.valid_map_offset += s->setup.num_rows; }
+    }
+    s->progress.nz_count          = max_depth_valid_count;
+    s->progress.input_value_count = target_value_count;
+    s->progress.input_row_count   = target_value_count;
   }
 
   return max_depth_valid_count;
@@ -1881,32 +2003,41 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t)
   }
 
   auto const* const def =
-    reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::DEFINITION]);
-  int processed_count = 0;
-  int valid_count     = 0;
-  if (s->setup.first_row > 0) {
-    materialize_skipped_nested_nz_idx<decode_block_size_t>(s, def, pp->nested_prepass_nz_idx);
-  }
-  seed_nonlist_level_state<decode_block_size_t, true>(
-    s, process_nulls, def, processed_count, valid_count);
-  constexpr int rolling_buf_size = decode_block_size_t * 2;
+    process_nulls ? reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::DEFINITION])
+                  : nullptr;
+  int const map_rank_base = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].valid_count;
+  if (t == 0) { pp->nested_prepass_prefix_valid_count = 0; }
+  block.sync();
   int const decoded_value_limit =
     pp->num_decoded_level_values > 0
       ? min(s->setup.page.num_input_values, pp->num_decoded_level_values)
       : s->setup.page.num_input_values;
-  int const last_row = min(s->setup.first_row + s->setup.num_rows, decoded_value_limit);
-  while (processed_count < decoded_value_limit && s->progress.input_row_count <= last_row) {
-    processed_count += min(rolling_buf_size, decoded_value_limit - processed_count);
-    valid_count = update_validity_and_row_indices_nested<decode_block_size_t, level_t>(
-      processed_count, s, global_nz_idx_sink{pp->nested_prepass_nz_idx}, def, t);
-  }
+  auto const sink = pp->nested_prepass_nz_idx != nullptr
+                      ? page_local_nz_idx_sink{pp->nested_prepass_nz_idx, map_rank_base}
+                      : page_local_nz_idx_sink{nullptr, map_rank_base};
+  int const final_valid_count =
+    pp->nested_prepass_nz_idx != nullptr
+      ? update_nested_level_prepass<decode_block_size_t>(decoded_value_limit,
+                                                         s,
+                                                         sink,
+                                                         def,
+                                                         &pp->nested_prepass_prefix_valid_count,
+                                                         map_rank_base,
+                                                         t)
+      : update_nested_level_prepass<decode_block_size_t>(decoded_value_limit,
+                                                         s,
+                                                         discard_nz_idx_sink{},
+                                                         def,
+                                                         &pp->nested_prepass_prefix_valid_count,
+                                                         map_rank_base,
+                                                         t);
   if (t == 0) {
     for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
       auto const& source                = s->nesting.nesting_info[depth];
       pp->nested_prepass_nesting[depth] = {
         source.null_count, source.valid_map_offset, source.valid_count, source.value_count};
     }
-    pp->nested_prepass_nz_count          = valid_count;
+    pp->nested_prepass_nz_count          = final_valid_count - map_rank_base;
     pp->nested_prepass_input_value_count = s->progress.input_value_count;
     pp->nested_prepass_input_row_count   = s->progress.input_row_count;
   }

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -240,55 +240,6 @@ __device__ void decode_fixed_width_values(
   }
 }
 
-template <typename level_t, int decode_block_size_t>
-CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
-  decode_page_data_generic_prepass(PageInfo* pages,
-                                   device_span<ColumnChunkDesc const> chunks,
-                                   size_t min_row,
-                                   size_t num_rows,
-                                   cudf::device_span<bool const> page_mask,
-                                   kernel_error::pointer error_code)
-{
-  constexpr int rolling_buf_size = decode_block_size_t * 2;
-  __shared__ __align__(16) full_page_decode_state state_g;
-  using state_buf_t = page_state_buffers_s<rolling_buf_size, 1, 1>;
-  __shared__ __align__(16) state_buf_t state_buffers;
-
-  auto const block   = cg::this_thread_block();
-  int const page_idx = cg::this_grid().block_rank();
-  int const t        = block.thread_rank();
-  PageInfo* const pp = &pages[page_idx];
-  if (!BitAnd(pp->kernel_mask, decode_kernel_mask::FIXED_WIDTH_NO_DICT)) { return; }
-  if (!page_mask.empty() && !page_mask[page_idx]) { return; }
-  if (!pp->flat_prepass_enabled || pp->flat_prepass_nz_count < 0) { return; }
-
-  auto* const s  = &state_g;
-  auto* const sb = &state_buffers;
-  [[maybe_unused]] null_count_back_copier _{s, t};
-  if (!setup_local_page_info(s,
-                             pp,
-                             chunks,
-                             min_row,
-                             num_rows,
-                             mask_filter{decode_kernel_mask::FIXED_WIDTH_NO_DICT},
-                             page_processing_stage::DECODE)) {
-    return;
-  }
-
-  int const first_rank = pp->flat_prepass_prefix_valid_count;
-  int const last_rank  = pp->flat_prepass_nz_count;
-  if (t == 0) { s->nesting.nesting_info[0].null_count = pp->flat_prepass_null_count; }
-  block.sync();
-  if (should_process_nulls(s)) {
-    decode_fixed_width_values<decode_block_size_t, false, copy_mode::INDIRECT>(
-      s, sb, first_rank, last_rank, t, pp->flat_prepass_nz_idx);
-  } else {
-    decode_fixed_width_values<decode_block_size_t, false, copy_mode::DIRECT>(
-      s, sb, first_rank, last_rank, t);
-  }
-  if (t == 0 && s->setup.error != 0) { set_error(s->setup.error, error_code); }
-}
-
 template <int block_size, bool has_lists_t, copy_mode copy_mode_t, typename state_buf>
 __device__ inline void decode_fixed_width_split_values(
   auto* s, state_buf* const sb, int start, int end, int t)
@@ -1130,7 +1081,26 @@ CUDF_HOST_DEVICE constexpr bool is_split_decode()
  * string offset buffer
  * @param error_code Error code to set if an error is encountered
  */
-template <typename level_t, int decode_block_size_t, decode_kernel_mask kernel_mask_t>
+/** Return the valid-rank immediately before a raw flat input position. */
+__device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int count, int input_pos)
+{
+  int first = 0;
+  int last  = count;
+  while (first < last) {
+    int const middle = first + (last - first) / 2;
+    if (static_cast<int>(nz_idx[middle]) < input_pos) {
+      first = middle + 1;
+    } else {
+      last = middle;
+    }
+  }
+  return first;
+}
+
+template <typename level_t,
+          int decode_block_size_t,
+          decode_kernel_mask kernel_mask_t,
+          bool use_flat_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   decode_page_data_generic_legacy(PageInfo* pages,
                                   device_span<ColumnChunkDesc const> chunks,
@@ -1169,9 +1139,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
 
   if (!(BitAnd(pages[page_idx].kernel_mask, kernel_mask_t))) { return; }
 
-  // The flat prepass consumer is launched separately. Keep this legacy kernel
-  // available for every other page that shares this decode mask.
-  if (pages[page_idx].flat_prepass_enabled) { return; }
+  if constexpr (use_flat_prepass_t) {
+    if (!pages[page_idx].flat_prepass_enabled) { return; }
+  } else {
+    // The flat prepass consumer is launched separately. Keep this legacy kernel
+    // available for every other page that shares this decode mask.
+    if (pages[page_idx].flat_prepass_enabled) { return; }
+  }
 
   // Exit early if the page is pruned
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
@@ -1248,36 +1222,78 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   size_t string_output_offset = 0;
   int const init_valid_map_offset =
     s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].valid_map_offset;
+  int const first_row = s->setup.first_row;
+  int const last_row  = first_row + s->setup.num_rows;
 
-  // Skip ahead in the decoding so that we don't repeat work
-  skip_ahead_in_decoding<decode_block_size_t,
-                         rolling_buf_size,
-                         has_lists_t,
-                         has_dict_t,
-                         has_bools_t,
-                         has_nesting_t,
-                         level_t>(s,
-                                  dict_stream,
-                                  bool_stream,
-                                  bools_are_rle_stream,
-                                  process_nulls,
-                                  def,
-                                  processed_count,
-                                  valid_count);
+  if constexpr (use_flat_prepass_t) {
+    // This instantiation is dispatched only for flat generic pages. Preserve
+    // value-stream alignment without replaying the definition-level walk.
+    processed_count = first_row;
+    valid_count     = process_nulls ? flat_prepass_valid_count_before(
+                                    pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, first_row)
+                                    : first_row;
+    if constexpr (has_dict_t) {
+      skip_decode<rolling_buf_size>(dict_stream, valid_count, t);
+    } else if constexpr (has_bools_t) {
+      if (bools_are_rle_stream) {
+        skip_decode<rolling_buf_size>(bool_stream, valid_count, t);
+      } else if (t == 0) {
+        s->progress.dict_pos = valid_count;
+      }
+    }
+    if (t == 0) {
+      auto& ni                      = s->nesting.nesting_info[0];
+      ni.valid_count                = valid_count;
+      ni.value_count                = processed_count;
+      ni.null_count                 = pp->flat_prepass_null_count;
+      s->progress.nz_count          = valid_count;
+      s->progress.input_value_count = processed_count;
+      s->progress.input_row_count   = processed_count;
+    }
+    block.sync();
+  } else {
+    // Skip ahead in the decoding so that we don't repeat work
+    skip_ahead_in_decoding<decode_block_size_t,
+                           rolling_buf_size,
+                           has_lists_t,
+                           has_dict_t,
+                           has_bools_t,
+                           has_nesting_t,
+                           level_t>(s,
+                                    dict_stream,
+                                    bool_stream,
+                                    bools_are_rle_stream,
+                                    process_nulls,
+                                    def,
+                                    processed_count,
+                                    valid_count);
+  }
 
   // the core loop. decode batches of level stream data using rle_stream objects
   // and pass the results to decode_values
   // For chunked reads we may not process all of the rows on the page; if not stop early
-  int const first_row = s->setup.first_row;
-  int const last_row  = first_row + s->setup.num_rows;
   while ((s->setup.error == 0) && (processed_count < s->setup.page.num_input_values) &&
          (s->progress.input_row_count <= last_row)) {
     int next_valid_count;
     block.sync();
     processed_count += min(rolling_buf_size, s->setup.page.num_input_values - processed_count);
 
-    // only need to process definition levels if this is a nullable column
-    if (process_nulls) {
+    if constexpr (use_flat_prepass_t) {
+      int const capped_target_value_count = min(processed_count, last_row);
+      next_valid_count = process_nulls ? flat_prepass_valid_count_before(pp->flat_prepass_nz_idx,
+                                                                         pp->flat_prepass_nz_count,
+                                                                         capped_target_value_count)
+                                       : capped_target_value_count;
+      for (int map_pos = valid_count + t; map_pos < next_valid_count;
+           map_pos += decode_block_size_t) {
+        sb->nz_idx[rolling_index<state_buf_t::nz_buf_size>(map_pos)] =
+          process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+      }
+      if (t == 0) {
+        s->progress.input_row_count =
+          processed_count >= last_row ? last_row + 1 : capped_target_value_count;
+      }
+    } else if (process_nulls) {
       if constexpr (has_lists_t) {
         next_valid_count =
           update_validity_and_row_indices_lists<decode_block_size_t, true, level_t>(
@@ -1438,22 +1454,32 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     dim3 dim_block(decode_block_size, 1);
     dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
-    if constexpr (mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT) {
-      if (use_flat_prepass) {
-        if (level_type_size == 1) {
-          decode_page_data_generic_prepass<uint8_t, decode_block_size>
-            <<<dim_grid, dim_block, 0, stream.get()>>>(
-              pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
-        } else {
-          decode_page_data_generic_prepass<uint16_t, decode_block_size>
-            <<<dim_grid, dim_block, 0, stream.get()>>>(
-              pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
-        }
-        CUDF_CUDA_TRY(cudaGetLastError());
+    if (use_flat_prepass) {
+      if (level_type_size == 1) {
+        decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, true>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
+      } else {
+        decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, true>
+          <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
+                                                     chunks,
+                                                     min_row,
+                                                     num_rows,
+                                                     page_mask,
+                                                     initial_str_offsets,
+                                                     page_string_offset_indices,
+                                                     error_code);
       }
+      CUDF_CUDA_TRY(cudaGetLastError());
     }
     if (level_type_size == 1) {
-      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask>
+      decode_page_data_generic_legacy<uint8_t, decode_block_size, mask, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,
@@ -1464,7 +1490,7 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                                                    error_code);
       CUDF_CUDA_TRY(cudaGetLastError());
     } else {
-      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask>
+      decode_page_data_generic_legacy<uint16_t, decode_block_size, mask, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),
                                                    chunks,
                                                    min_row,

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1374,6 +1374,19 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     valid_count = next_valid_count;
   }
 
+  if constexpr (use_flat_prepass_t) {
+    if (t == 0) {
+      auto& ni                      = s->nesting.nesting_info[0];
+      auto const page_rows          = min(processed_count, last_row);
+      ni.valid_count                = valid_count;
+      ni.value_count                = page_rows;
+      s->progress.nz_count          = valid_count;
+      s->progress.input_value_count = page_rows;
+      s->progress.input_row_count   = page_rows;
+    }
+    block.sync();
+  }
+
   // Zero-fill null positions after decoding valid values
   if constexpr (has_strings_t || has_lists_t || is_dict_int32_t) {
     if (process_nulls) {
@@ -1400,7 +1413,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     // column construction. Otherwise, convert string sizes to final offsets.
 
     if constexpr (!has_lists_t) {
-      if (!process_nulls) {
+      if constexpr (use_flat_prepass_t) {
+        if (t == 0) {
+          s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].value_count =
+            s->setup.first_row + s->setup.num_rows;
+        }
+        block.sync();
+      } else if (!process_nulls) {
         if (t == 0) {
           s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].value_count =
             s->progress.input_row_count;

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -149,7 +149,8 @@ __device__ void decode_dict_indices_as_int32(
 }
 
 template <int block_size, bool has_lists_t, copy_mode copy_mode_t, typename state_buf>
-__device__ void decode_fixed_width_values(auto* s, state_buf* const sb, int start, int end, int t)
+__device__ void decode_fixed_width_values(
+  auto* s, state_buf* const sb, int start, int end, int t, uint32_t const* global_nz_idx = nullptr)
 {
   constexpr int num_warps      = block_size / cudf::detail::warp_size;
   constexpr int max_batch_size = num_warps * cudf::detail::warp_size;
@@ -171,7 +172,9 @@ __device__ void decode_fixed_width_values(auto* s, state_buf* const sb, int star
       if constexpr (copy_mode_t == copy_mode::DIRECT) {
         return thread_pos - s->setup.first_row;
       } else {
-        int dst_pos = sb->nz_idx[rolling_index<state_buf::nz_buf_size>(thread_pos)];
+        int dst_pos = global_nz_idx == nullptr
+                        ? sb->nz_idx[rolling_index<state_buf::nz_buf_size>(thread_pos)]
+                        : global_nz_idx[thread_pos];
         if constexpr (!has_lists_t) { dst_pos -= s->setup.first_row; }
         return dst_pos;
       }
@@ -235,6 +238,55 @@ __device__ void decode_fixed_width_values(auto* s, state_buf* const sb, int star
 
     thread_pos += max_batch_size;
   }
+}
+
+template <typename level_t, int decode_block_size_t>
+CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
+  decode_page_data_generic_prepass(PageInfo* pages,
+                                   device_span<ColumnChunkDesc const> chunks,
+                                   size_t min_row,
+                                   size_t num_rows,
+                                   cudf::device_span<bool const> page_mask,
+                                   kernel_error::pointer error_code)
+{
+  constexpr int rolling_buf_size = decode_block_size_t * 2;
+  __shared__ __align__(16) full_page_decode_state state_g;
+  using state_buf_t = page_state_buffers_s<rolling_buf_size, 1, 1>;
+  __shared__ __align__(16) state_buf_t state_buffers;
+
+  auto const block   = cg::this_thread_block();
+  int const page_idx = cg::this_grid().block_rank();
+  int const t        = block.thread_rank();
+  PageInfo* const pp = &pages[page_idx];
+  if (!BitAnd(pp->kernel_mask, decode_kernel_mask::FIXED_WIDTH_NO_DICT)) { return; }
+  if (!page_mask.empty() && !page_mask[page_idx]) { return; }
+  if (!pp->flat_prepass_enabled || pp->flat_prepass_nz_count < 0) { return; }
+
+  auto* const s  = &state_g;
+  auto* const sb = &state_buffers;
+  [[maybe_unused]] null_count_back_copier _{s, t};
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::FIXED_WIDTH_NO_DICT},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+
+  int const first_rank = pp->flat_prepass_prefix_valid_count;
+  int const last_rank  = pp->flat_prepass_nz_count;
+  if (t == 0) { s->nesting.nesting_info[0].null_count = pp->flat_prepass_null_count; }
+  block.sync();
+  if (should_process_nulls(s)) {
+    decode_fixed_width_values<decode_block_size_t, false, copy_mode::INDIRECT>(
+      s, sb, first_rank, last_rank, t, pp->flat_prepass_nz_idx);
+  } else {
+    decode_fixed_width_values<decode_block_size_t, false, copy_mode::DIRECT>(
+      s, sb, first_rank, last_rank, t);
+  }
+  if (t == 0 && s->setup.error != 0) { set_error(s->setup.error, error_code); }
 }
 
 template <int block_size, bool has_lists_t, copy_mode copy_mode_t, typename state_buf>
@@ -1117,6 +1169,10 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
 
   if (!(BitAnd(pages[page_idx].kernel_mask, kernel_mask_t))) { return; }
 
+  // The flat prepass consumer is launched separately. Keep this legacy kernel
+  // available for every other page that shares this decode mask.
+  if (pages[page_idx].flat_prepass_enabled) { return; }
+
   // Exit early if the page is pruned
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
 
@@ -1371,7 +1427,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<size_t> initial_str_offsets,
                       cudf::device_span<size_t const> page_string_offset_indices,
                       kernel_error::pointer error_code,
-                      cuda::stream_ref stream)
+                      cuda::stream_ref stream,
+                      bool use_flat_prepass)
 {
   // No template parameters on lambdas until C++20, so use type tags instead
   auto launch_kernel = [&](auto block_size_tag, auto kernel_mask_tag) {
@@ -1381,6 +1438,20 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     dim3 dim_block(decode_block_size, 1);
     dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
+    if constexpr (mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT) {
+      if (use_flat_prepass) {
+        if (level_type_size == 1) {
+          decode_page_data_generic_prepass<uint8_t, decode_block_size>
+            <<<dim_grid, dim_block, 0, stream.get()>>>(
+              pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+        } else {
+          decode_page_data_generic_prepass<uint16_t, decode_block_size>
+            <<<dim_grid, dim_block, 0, stream.get()>>>(
+              pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+        }
+        CUDF_CUDA_TRY(cudaGetLastError());
+      }
+    }
     if (level_type_size == 1) {
       decode_page_data_generic_legacy<uint8_t, decode_block_size, mask>
         <<<dim_grid, dim_block, 0, stream.get()>>>(pages.device_ptr(),

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -39,6 +39,7 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
 {
   __shared__ __align__(16) full_page_decode_state state_g;
   __shared__ typename cub::BlockScan<int, level_decode_block_size>::TempStorage scan_storage;
+  __shared__ int block_valid_count_shared;
   auto const block   = cg::this_thread_block();
   int const page_idx = blockIdx.x;
   int const t        = block.thread_rank();
@@ -48,13 +49,8 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
 
   auto* const s = &state_g;
   null_count_back_copier _{s, t};
-  if (!setup_local_page_info(s,
-                             pp,
-                             chunks,
-                             min_row,
-                             num_rows,
-                             mask_filter{decode_kernel_mask::FIXED_WIDTH_NO_DICT},
-                             page_processing_stage::DECODE)) {
+  if (!setup_local_page_info(
+        s, pp, chunks, min_row, num_rows, all_types_filter{}, page_processing_stage::DECODE)) {
     return;
   }
 
@@ -93,7 +89,9 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
                      write_end - write_start);
     }
     if (is_valid) { pp->flat_prepass_nz_idx[valid_count + thread_valid_count] = value_pos; }
-    valid_count += block_valid_count;
+    if (t == 0) { block_valid_count_shared = block_valid_count; }
+    block.sync();
+    valid_count += block_valid_count_shared;
     block.sync();
   }
   if (t == 0) {

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -29,6 +29,88 @@ namespace {
 constexpr int preprocess_block_size   = 512;
 constexpr int level_decode_block_size = 128;
 
+template <typename level_t>
+CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
+  precompute_flat_level_state_kernel(PageInfo* pages,
+                                     device_span<ColumnChunkDesc const> chunks,
+                                     cudf::device_span<bool const> page_mask,
+                                     size_t min_row,
+                                     size_t num_rows)
+{
+  __shared__ __align__(16) full_page_decode_state state_g;
+  __shared__ typename cub::BlockScan<int, level_decode_block_size>::TempStorage scan_storage;
+  auto const block   = cg::this_thread_block();
+  int const page_idx = blockIdx.x;
+  int const t        = block.thread_rank();
+  PageInfo* const pp = &pages[page_idx];
+  if (!pp->flat_prepass_enabled) { return; }
+  if (!page_mask.empty() && !page_mask[page_idx]) { return; }
+
+  auto* const s = &state_g;
+  null_count_back_copier _{s, t};
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::FIXED_WIDTH_NO_DICT},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+
+  auto& ni              = s->nesting.nesting_info[0];
+  int const first_row   = min(s->setup.first_row, s->setup.page.num_input_values);
+  int const value_limit = min(s->setup.page.num_input_values, first_row + s->setup.num_rows);
+  if (!should_process_nulls(s)) {
+    if (t == 0) {
+      pp->flat_prepass_prefix_valid_count = first_row;
+      pp->flat_prepass_nz_count           = value_limit;
+      pp->flat_prepass_null_count         = 0;
+      ni.null_count                       = 0;
+    }
+    block.sync();
+    return;
+  }
+
+  auto const* def = reinterpret_cast<level_t const*>(pp->lvl_decode_buf[level_type::DEFINITION]);
+  int valid_count = 0;
+  for (int value_base = 0; value_base < value_limit; value_base += level_decode_block_size) {
+    int const value_pos = value_base + t;
+    int const is_valid  = value_pos < value_limit && def[value_pos] > 0;
+    int thread_valid_count, block_valid_count;
+    cub::BlockScan<int, level_decode_block_size>(scan_storage)
+      .ExclusiveSum(is_valid, thread_valid_count, block_valid_count);
+    auto const valid_mask  = ballot(is_valid);
+    bool const in_output   = value_pos >= first_row && value_pos < value_limit;
+    auto const output_mask = ballot(in_output);
+    int const write_start  = __ffs(output_mask) - 1;
+    if (write_start >= 0 && (t % cudf::detail::warp_size) == 0 && ni.valid_map != nullptr) {
+      int const write_end = cudf::detail::warp_size - __clz(output_mask);
+      store_validity(ni.valid_map_offset + value_base + (t - (t % cudf::detail::warp_size)) +
+                       write_start - first_row,
+                     ni.valid_map,
+                     valid_mask >> write_start,
+                     write_end - write_start);
+    }
+    if (is_valid) { pp->flat_prepass_nz_idx[valid_count + thread_valid_count] = value_pos; }
+    valid_count += block_valid_count;
+    block.sync();
+  }
+  if (t == 0) {
+    int prefix = 0;
+    while (prefix < valid_count && pp->flat_prepass_nz_idx[prefix] < first_row) {
+      ++prefix;
+    }
+    int const selected_value_count      = max(value_limit - first_row, 0);
+    int const selected_valid_count      = valid_count - prefix;
+    pp->flat_prepass_prefix_valid_count = prefix;
+    pp->flat_prepass_nz_count           = valid_count;
+    pp->flat_prepass_null_count         = selected_value_count - selected_valid_count;
+    ni.null_count                       = pp->flat_prepass_null_count;
+  }
+  block.sync();
+}
+
 using unused_state_buf = page_state_buffers_s<0, 0, 0>;
 
 /**
@@ -524,6 +606,27 @@ void preprocess_levels(cudf::detail::hostdevice_span<PageInfo> pages,
         pages.device_ptr(), chunks, page_mask, min_row, num_rows);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
+}
+
+void precompute_flat_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                 cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                 cudf::device_span<bool const> page_mask,
+                                 size_t min_row,
+                                 size_t num_rows,
+                                 int level_type_size,
+                                 cuda::stream_ref stream)
+{
+  if (pages.size() == 0) { return; }
+  dim3 const grid(pages.size(), 1);
+  dim3 const block(level_decode_block_size, 1);
+  if (level_type_size == 1) {
+    precompute_flat_level_state_kernel<uint8_t>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, page_mask, min_row, num_rows);
+  } else {
+    precompute_flat_level_state_kernel<uint16_t>
+      <<<grid, block, 0, stream.get()>>>(pages.device_ptr(), chunks, page_mask, min_row, num_rows);
+  }
+  CUDF_CUDA_TRY(cudaGetLastError());
 }
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -44,7 +44,7 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
   int const page_idx = blockIdx.x;
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
-  if (!pp->flat_prepass_enabled) { return; }
+  if (!pp->flat_prepass_enabled && !pp->legacy_flat_prepass_enabled) { return; }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
 
   auto* const s = &state_g;

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -57,9 +57,17 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
     return;
   }
 
-  auto& ni              = s->nesting.nesting_info[0];
-  int const first_row   = min(s->setup.first_row, s->setup.page.num_input_values);
-  int const value_limit = min(s->setup.page.num_input_values, first_row + s->setup.num_rows);
+  auto& ni = s->nesting.nesting_info[0];
+  // Bounds preprocessing deliberately materializes fewer level values than a
+  // page contains. The prepass must never scan past that decoded prefix: doing
+  // so reads beyond lvl_decode_buf and can silently corrupt an unrelated
+  // column when another prepass allocation changes the device-memory layout.
+  int const decoded_value_limit =
+    pp->num_decoded_level_values > 0
+      ? min(s->setup.page.num_input_values, pp->num_decoded_level_values)
+      : s->setup.page.num_input_values;
+  int const first_row   = min(s->setup.first_row, decoded_value_limit);
+  int const value_limit = min(decoded_value_limit, first_row + s->setup.num_rows);
   if (!should_process_nulls(s)) {
     if (t == 0) {
       pp->flat_prepass_prefix_valid_count = first_row;

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -44,7 +44,10 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
   int const page_idx = blockIdx.x;
   int const t        = block.thread_rank();
   PageInfo* const pp = &pages[page_idx];
-  if (!pp->flat_prepass_enabled && !pp->legacy_flat_prepass_enabled) { return; }
+  if (!pp->flat_prepass_enabled && !pp->legacy_flat_prepass_enabled &&
+      !pp->delta_flat_prepass_enabled) {
+    return;
+  }
   if (!page_mask.empty() && !page_mask[page_idx]) { return; }
 
   auto* const s = &state_g;

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -57,7 +57,11 @@ __device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int nz_co
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t, bool use_nested_prepass_t>
+template <int lvl_buf_size,
+          typename level_t,
+          bool use_flat_prepass_t,
+          bool use_nested_prepass_t,
+          bool use_list_prepass_t = false>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_split_page_data_kernel_legacy(PageInfo* pages,
                                        device_span<ColumnChunkDesc const> chunks,
@@ -81,9 +85,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
   } else if constexpr (use_nested_prepass_t) {
     if (!pages[page_idx].legacy_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].legacy_list_prepass_enabled) { return; }
   } else {
     if (pages[page_idx].legacy_flat_prepass_enabled ||
-        pages[page_idx].legacy_nested_prepass_enabled) {
+        pages[page_idx].legacy_nested_prepass_enabled ||
+        pages[page_idx].legacy_list_prepass_enabled) {
       return;
     }
   }
@@ -129,21 +136,25 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
                          : reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::DEFINITION]);
   auto* const rep    = reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::REPETITION]);
 
-  if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+  if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
-      auto const* const prepass_nz_idx =
-        use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
-      int const prepass_nz_count =
-        use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
-      auto const prefix_valid_count =
-        process_nulls
-          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
-          : static_cast<int>(s->setup.first_row);
-      auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
-      ni.null_count =
-        process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+      if constexpr (!use_list_prepass_t) {
+        auto const* const prepass_nz_idx =
+          use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
+        int const prepass_nz_count =
+          use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
+        auto const prefix_valid_count =
+          process_nulls
+            ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+            : static_cast<int>(s->setup.first_row);
+        auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+        ni.null_count =
+          process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+      }
       s->progress.input_value_count = s->setup.num_input_values;
-      s->progress.nz_count          = prepass_nz_count;
+      s->progress.nz_count          = use_flat_prepass_t     ? pp->flat_prepass_nz_count
+                                      : use_nested_prepass_t ? pp->nested_prepass_nz_count
+                                                             : pp->list_prepass_nz_count;
     }
     block.sync();
   }
@@ -159,7 +170,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
       target_pos =
         cuda::std::min<int32_t>(s->progress.nz_count, src_pos + decode_block_size - warp.size());
     } else if (warp.meta_group_rank() == 0) {
@@ -172,17 +183,19 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     // This needs to be here to prevent warp 1 modifying src_pos before all threads have read it
     block.sync();
 
-    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
       // The prepass owns level walking and validity updates. Warp 0 remains
       // structurally present but does no level work; the value warps refill
       // the existing rolling map from the page-global dense map.
       if (block.thread_rank() >= warp.size()) {
         for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
              map_pos += decode_block_size - warp.size()) {
-          auto const* const prepass_nz_idx =
-            use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
           sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
-            process_nulls ? prepass_nz_idx[map_pos] : map_pos;
+            use_list_prepass_t
+              ? pp->list_prepass_nz_idx[map_pos]
+              : (process_nulls ? (use_flat_prepass_t ? pp->flat_prepass_nz_idx
+                                                     : pp->nested_prepass_nz_idx)[map_pos]
+                               : map_pos);
         }
       }
       block.sync();
@@ -287,18 +300,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
-  if constexpr (use_nested_prepass_t) {
+  if constexpr (use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
       for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
-        auto const& source                              = pp->nested_prepass_nesting[depth];
+        auto const& source = use_nested_prepass_t ? pp->nested_prepass_nesting[depth]
+                                                  : pp->list_prepass_nesting[depth];
         s->nesting.nesting_info[depth].null_count       = source.null_count;
         s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
         s->nesting.nesting_info[depth].valid_count      = source.valid_count;
         s->nesting.nesting_info[depth].value_count      = source.value_count;
       }
-      s->progress.nz_count          = pp->nested_prepass_nz_count;
-      s->progress.input_value_count = pp->nested_prepass_input_value_count;
-      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+      s->progress.nz_count =
+        use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->list_prepass_nz_count;
+      s->progress.input_value_count = use_nested_prepass_t ? pp->nested_prepass_input_value_count
+                                                           : pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = use_nested_prepass_t ? pp->nested_prepass_input_row_count
+                                                           : pp->list_prepass_input_row_count;
     }
     block.sync();
   }
@@ -337,7 +354,11 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t, bool use_nested_prepass_t>
+template <int lvl_buf_size,
+          typename level_t,
+          bool use_flat_prepass_t,
+          bool use_nested_prepass_t,
+          bool use_list_prepass_t = false>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_page_data_legacy(PageInfo* pages,
                           device_span<ColumnChunkDesc const> chunks,
@@ -362,9 +383,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
   } else if constexpr (use_nested_prepass_t) {
     if (!pages[page_idx].legacy_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].legacy_list_prepass_enabled) { return; }
   } else {
     if (pages[page_idx].legacy_flat_prepass_enabled ||
-        pages[page_idx].legacy_nested_prepass_enabled) {
+        pages[page_idx].legacy_nested_prepass_enabled ||
+        pages[page_idx].legacy_list_prepass_enabled) {
       return;
     }
   }
@@ -420,21 +444,25 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const first_out_thread_id = out_warp_id * warp.size();
   // skipped_leaf_values will always be 0 for flat hierarchies.
   uint32_t skipped_leaf_values = s->setup.page.skipped_leaf_values;
-  if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+  if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
-      auto const* const prepass_nz_idx =
-        use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
-      int const prepass_nz_count =
-        use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
-      auto const prefix_valid_count =
-        process_nulls
-          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
-          : static_cast<int>(s->setup.first_row);
-      auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
-      ni.null_count =
-        process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+      if constexpr (!use_list_prepass_t) {
+        auto const* const prepass_nz_idx =
+          use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
+        int const prepass_nz_count =
+          use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
+        auto const prefix_valid_count =
+          process_nulls
+            ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+            : static_cast<int>(s->setup.first_row);
+        auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+        ni.null_count =
+          process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+      }
       s->progress.input_value_count = s->setup.num_input_values;
-      s->progress.nz_count          = prepass_nz_count;
+      s->progress.nz_count          = use_flat_prepass_t     ? pp->flat_prepass_nz_count
+                                      : use_nested_prepass_t ? pp->nested_prepass_nz_count
+                                                             : pp->list_prepass_nz_count;
     }
     block.sync();
   }
@@ -443,7 +471,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
       if (warp.meta_group_rank() < out_warp_id) {
         target_pos = cuda::std::min<int32_t>(
           s->progress.nz_count, src_pos + 2 * (decode_block_size - first_out_thread_id));
@@ -467,14 +495,16 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     }
     // this needs to be here to prevent warp 3 modifying src_pos before all threads have read it
     block.sync();
-    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t || use_list_prepass_t) {
       if (block.thread_rank() >= warp.size()) {
         for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
              map_pos += decode_block_size - warp.size()) {
-          auto const* const prepass_nz_idx =
-            use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
           sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
-            process_nulls ? prepass_nz_idx[map_pos] : map_pos;
+            use_list_prepass_t
+              ? pp->list_prepass_nz_idx[map_pos]
+              : (process_nulls ? (use_flat_prepass_t ? pp->flat_prepass_nz_idx
+                                                     : pp->nested_prepass_nz_idx)[map_pos]
+                               : map_pos);
         }
       }
       block.sync();
@@ -605,18 +635,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     __syncthreads();
   }
 
-  if constexpr (use_nested_prepass_t) {
+  if constexpr (use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
       for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
-        auto const& source                              = pp->nested_prepass_nesting[depth];
+        auto const& source = use_nested_prepass_t ? pp->nested_prepass_nesting[depth]
+                                                  : pp->list_prepass_nesting[depth];
         s->nesting.nesting_info[depth].null_count       = source.null_count;
         s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
         s->nesting.nesting_info[depth].valid_count      = source.valid_count;
         s->nesting.nesting_info[depth].value_count      = source.value_count;
       }
-      s->progress.nz_count          = pp->nested_prepass_nz_count;
-      s->progress.input_value_count = pp->nested_prepass_input_value_count;
-      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+      s->progress.nz_count =
+        use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->list_prepass_nz_count;
+      s->progress.input_value_count = use_nested_prepass_t ? pp->nested_prepass_input_value_count
+                                                           : pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = use_nested_prepass_t ? pp->nested_prepass_input_row_count
+                                                           : pp->list_prepass_input_row_count;
     }
     block.sync();
   }
@@ -671,7 +705,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
                       bool use_flat_prepass,
-                      bool use_nested_prepass)
+                      bool use_nested_prepass,
+                      bool use_list_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -689,6 +724,11 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
+    if (use_list_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint8_t, false, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
     decode_page_data_legacy<rolling_buf_size, uint8_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
@@ -701,6 +741,11 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     }
     if (use_nested_prepass) {
       decode_page_data_legacy<rolling_buf_size, uint16_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    if (use_list_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint16_t, false, false, true>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
@@ -723,7 +768,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             kernel_error::pointer error_code,
                             cuda::stream_ref stream,
                             bool use_flat_prepass,
-                            bool use_nested_prepass)
+                            bool use_nested_prepass,
+                            bool use_list_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -741,6 +787,11 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
+    if (use_list_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
     decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
@@ -753,6 +804,11 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
     }
     if (use_nested_prepass) {
       decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    if (use_list_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false, false, true>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -43,12 +43,12 @@ constexpr int rolling_buf_size  = decode_block_size * 2;
  */
 template <int lvl_buf_size, typename level_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
-  decode_split_page_data_kernel(PageInfo* pages,
-                                device_span<ColumnChunkDesc const> chunks,
-                                size_t min_row,
-                                size_t num_rows,
-                                cudf::device_span<bool const> page_mask,
-                                kernel_error::pointer error_code)
+  decode_split_page_data_kernel_legacy(PageInfo* pages,
+                                       device_span<ColumnChunkDesc const> chunks,
+                                       size_t min_row,
+                                       size_t num_rows,
+                                       cudf::device_span<bool const> page_mask,
+                                       kernel_error::pointer error_code)
 {
   __shared__ __align__(16) full_page_decode_state state_g;
   __shared__ __align__(16)
@@ -257,12 +257,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
  */
 template <int lvl_buf_size, typename level_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
-  decode_page_data(PageInfo* pages,
-                   device_span<ColumnChunkDesc const> chunks,
-                   size_t min_row,
-                   size_t num_rows,
-                   cudf::device_span<bool const> page_mask,
-                   kernel_error::pointer error_code)
+  decode_page_data_legacy(PageInfo* pages,
+                          device_span<ColumnChunkDesc const> chunks,
+                          size_t min_row,
+                          size_t num_rows,
+                          cudf::device_span<bool const> page_mask,
+                          kernel_error::pointer error_code)
 {
   __shared__ __align__(16) full_page_decode_state state_g;
   __shared__ __align__(16)
@@ -527,11 +527,11 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_page_data<rolling_buf_size, uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_page_data_legacy<rolling_buf_size, uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_page_data<rolling_buf_size, uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_page_data_legacy<rolling_buf_size, uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
@@ -555,12 +555,12 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_split_page_data_kernel<rolling_buf_size, uint8_t>
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_split_page_data_kernel<rolling_buf_size, uint16_t>
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -24,6 +24,22 @@ namespace {
 constexpr int decode_block_size = 128;
 constexpr int rolling_buf_size  = decode_block_size * 2;
 
+/** Return the number of dense prepass-map entries before an input row. */
+__device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int nz_count, int input_row)
+{
+  int first = 0;
+  int last  = nz_count;
+  while (first < last) {
+    int const mid = first + (last - first) / 2;
+    if (nz_idx[mid] < input_row) {
+      first = mid + 1;
+    } else {
+      last = mid;
+    }
+  }
+  return first;
+}
+
 /**
  * @brief Kernel for computing the BYTE_STREAM_SPLIT column data stored in the pages
  *
@@ -41,7 +57,7 @@ constexpr int rolling_buf_size  = decode_block_size * 2;
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t>
+template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_split_page_data_kernel_legacy(PageInfo* pages,
                                        device_span<ColumnChunkDesc const> chunks,
@@ -60,6 +76,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   int const page_idx = cg::this_grid().block_rank();
   auto const block   = cg::this_thread_block();
   auto const warp    = cg::tiled_partition<cudf::detail::warp_size>(block);
+
+  if constexpr (use_flat_prepass_t) {
+    if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  } else {
+    if (pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  }
 
   // Exit early if the page is pruned
   if (not page_mask.empty() and not page_mask[page_idx]) { return; }
@@ -102,6 +124,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
                          : reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::DEFINITION]);
   auto* const rep    = reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::REPETITION]);
 
+  if constexpr (use_flat_prepass_t) {
+    if (block.thread_rank() == 0) {
+      auto const prefix_valid_count =
+        process_nulls ? flat_prepass_valid_count_before(
+                          pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
+                      : static_cast<int>(s->setup.first_row);
+      auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+      ni.null_count =
+        process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+      s->progress.input_value_count = s->setup.num_input_values;
+      s->progress.nz_count          = pp->flat_prepass_nz_count;
+    }
+    block.sync();
+  }
+
   // Capture initial valid_map_offset before any processing that might modify it
   int const init_valid_map_offset =
     s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1].valid_map_offset;
@@ -113,7 +150,10 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if (warp.meta_group_rank() == 0) {
+    if constexpr (use_flat_prepass_t) {
+      target_pos =
+        cuda::std::min<int32_t>(s->progress.nz_count, src_pos + decode_block_size - warp.size());
+    } else if (warp.meta_group_rank() == 0) {
       target_pos = cuda::std::min(src_pos + 2 * (decode_block_size - warp.size()),
                                   s->progress.nz_count + (decode_block_size - warp.size()));
     } else {
@@ -123,13 +163,28 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     // This needs to be here to prevent warp 1 modifying src_pos before all threads have read it
     block.sync();
 
-    if (warp.meta_group_rank() == 0) {
-      // WARP0: decode repetition and definition levels.
-      // - update validity vectors
-      // - updates offsets (for nested columns)
-      // - produces non-NULL value indices in s->nz_idx for subsequent decoding
-      gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, warp);
+    if constexpr (use_flat_prepass_t) {
+      // The prepass owns level walking and validity updates. Warp 0 remains
+      // structurally present but does no level work; the value warps refill
+      // the existing rolling map from the page-global dense map.
+      if (block.thread_rank() >= warp.size()) {
+        for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
+             map_pos += decode_block_size - warp.size()) {
+          sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
+            process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+        }
+      }
+      block.sync();
     } else {
+      if (warp.meta_group_rank() == 0) {
+        // WARP0: decode repetition and definition levels.
+        // - update validity vectors
+        // - updates offsets (for nested columns)
+        // - produces non-NULL value indices in s->nz_idx for subsequent decoding
+        gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, warp);
+      }
+    }
+    if (warp.meta_group_rank() != 0) {
       // WARP1..WARP3: Decode values
       Type const dtype = s->setup.col.physical_type;
       src_pos += block.thread_rank() - warp.size();
@@ -255,7 +310,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t>
+template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_page_data_legacy(PageInfo* pages,
                           device_span<ColumnChunkDesc const> chunks,
@@ -275,6 +330,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const block   = cg::this_thread_block();
   auto const warp    = cg::tiled_partition<cudf::detail::warp_size>(block);
   int out_warp_id;
+
+  if constexpr (use_flat_prepass_t) {
+    if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  } else {
+    if (pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  }
 
   // Exit early if the page is pruned
   if (not page_mask.empty() and not page_mask[page_idx]) { return; }
@@ -327,12 +388,37 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const first_out_thread_id = out_warp_id * warp.size();
   // skipped_leaf_values will always be 0 for flat hierarchies.
   uint32_t skipped_leaf_values = s->setup.page.skipped_leaf_values;
+  if constexpr (use_flat_prepass_t) {
+    if (block.thread_rank() == 0) {
+      auto const prefix_valid_count =
+        process_nulls ? flat_prepass_valid_count_before(
+                          pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
+                      : static_cast<int>(s->setup.first_row);
+      auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+      ni.null_count =
+        process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+      s->progress.input_value_count = s->setup.num_input_values;
+      s->progress.nz_count          = pp->flat_prepass_nz_count;
+    }
+    block.sync();
+  }
   while (s->setup.error == 0 && (s->progress.input_value_count < s->setup.num_input_values ||
                                  s->progress.src_pos < s->progress.nz_count)) {
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if (warp.meta_group_rank() < out_warp_id) {
+    if constexpr (use_flat_prepass_t) {
+      if (warp.meta_group_rank() < out_warp_id) {
+        target_pos = cuda::std::min<int32_t>(
+          s->progress.nz_count, src_pos + 2 * (decode_block_size - first_out_thread_id));
+      } else {
+        target_pos = cuda::std::min<int32_t>(s->progress.nz_count,
+                                             src_pos + decode_block_size - first_out_thread_id);
+        if (out_warp_id > 1) {
+          target_pos = cuda::std::min<int32_t>(target_pos, s->progress.dict_pos);
+        }
+      }
+    } else if (warp.meta_group_rank() < out_warp_id) {
       target_pos =
         cuda::std::min<int32_t>(src_pos + 2 * (decode_block_size - first_out_thread_id),
                                 s->progress.nz_count + (decode_block_size - first_out_thread_id));
@@ -345,13 +431,23 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     }
     // this needs to be here to prevent warp 3 modifying src_pos before all threads have read it
     block.sync();
-    if (warp.meta_group_rank() == 0) {
+    if constexpr (use_flat_prepass_t) {
+      if (block.thread_rank() >= warp.size()) {
+        for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
+             map_pos += decode_block_size - warp.size()) {
+          sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
+            process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+        }
+      }
+      block.sync();
+    } else if (warp.meta_group_rank() == 0) {
       // decode repetition and definition levels.
       // - update validity vectors
       // - updates offsets (for nested columns)
       // - produces non-NULL value indices in s->nz_idx for subsequent decoding
       gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, warp);
-    } else if (warp.meta_group_rank() < out_warp_id) {
+    }
+    if (warp.meta_group_rank() != 0 && warp.meta_group_rank() < out_warp_id) {
       // skipped_leaf_values will always be 0 for flat hierarchies.
       uint32_t src_target_pos = target_pos + skipped_leaf_values;
 
@@ -370,7 +466,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
         initialize_string_descriptors<is_calc_sizes_only::NO>(s, sb, src_target_pos, warp);
       }
       if (warp.thread_rank() == 0) { s->progress.dict_pos = src_target_pos; }
-    } else {
+    } else if (warp.meta_group_rank() >= out_warp_id) {
       // WARP1..WARP3: Decode values
       src_pos += block.thread_rank() - first_out_thread_id;
 
@@ -519,7 +615,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       int level_type_size,
                       cudf::device_span<bool const> page_mask,
                       kernel_error::pointer error_code,
-                      cuda::stream_ref stream)
+                      cuda::stream_ref stream,
+                      bool use_flat_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -527,12 +624,24 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_page_data_legacy<rolling_buf_size, uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
-      pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    if (use_flat_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint8_t, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_page_data_legacy<rolling_buf_size, uint8_t, false>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_page_data_legacy<rolling_buf_size, uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
-      pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    if (use_flat_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint16_t, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_page_data_legacy<rolling_buf_size, uint16_t, false>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
 }
@@ -547,7 +656,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             int level_type_size,
                             cudf::device_span<bool const> page_mask,
                             kernel_error::pointer error_code,
-                            cuda::stream_ref stream)
+                            cuda::stream_ref stream,
+                            bool use_flat_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -555,12 +665,22 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t>
+    if (use_flat_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t>
+    if (use_flat_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -57,7 +57,7 @@ __device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int nz_co
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t>
+template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t, bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_split_page_data_kernel_legacy(PageInfo* pages,
                                        device_span<ColumnChunkDesc const> chunks,
@@ -79,8 +79,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   if constexpr (use_flat_prepass_t) {
     if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  } else if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].legacy_nested_prepass_enabled) { return; }
   } else {
-    if (pages[page_idx].legacy_flat_prepass_enabled) { return; }
+    if (pages[page_idx].legacy_flat_prepass_enabled ||
+        pages[page_idx].legacy_nested_prepass_enabled) {
+      return;
+    }
   }
 
   // Exit early if the page is pruned
@@ -124,17 +129,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
                          : reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::DEFINITION]);
   auto* const rep    = reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::REPETITION]);
 
-  if constexpr (use_flat_prepass_t) {
+  if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
     if (block.thread_rank() == 0) {
+      auto const* const prepass_nz_idx =
+        use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
+      int const prepass_nz_count =
+        use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
       auto const prefix_valid_count =
-        process_nulls ? flat_prepass_valid_count_before(
-                          pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
-                      : static_cast<int>(s->setup.first_row);
+        process_nulls
+          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+          : static_cast<int>(s->setup.first_row);
       auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
       ni.null_count =
-        process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+        process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
       s->progress.input_value_count = s->setup.num_input_values;
-      s->progress.nz_count          = pp->flat_prepass_nz_count;
+      s->progress.nz_count          = prepass_nz_count;
     }
     block.sync();
   }
@@ -150,7 +159,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if constexpr (use_flat_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
       target_pos =
         cuda::std::min<int32_t>(s->progress.nz_count, src_pos + decode_block_size - warp.size());
     } else if (warp.meta_group_rank() == 0) {
@@ -163,15 +172,17 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     // This needs to be here to prevent warp 1 modifying src_pos before all threads have read it
     block.sync();
 
-    if constexpr (use_flat_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
       // The prepass owns level walking and validity updates. Warp 0 remains
       // structurally present but does no level work; the value warps refill
       // the existing rolling map from the page-global dense map.
       if (block.thread_rank() >= warp.size()) {
         for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
              map_pos += decode_block_size - warp.size()) {
+          auto const* const prepass_nz_idx =
+            use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
           sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
-            process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+            process_nulls ? prepass_nz_idx[map_pos] : map_pos;
         }
       }
       block.sync();
@@ -276,6 +287,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
+  if constexpr (use_nested_prepass_t) {
+    if (block.thread_rank() == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->nested_prepass_nz_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
+  }
+
   // Zero-fill null positions after decoding valid values
   if (has_repetition) {
     int const leaf_level_index = s->setup.col.max_nesting_depth - 1;
@@ -310,7 +337,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
  * @param page_mask Boolean vector indicating which pages need to be decoded
  * @param error_code Error code to set if an error is encountered
  */
-template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t>
+template <int lvl_buf_size, typename level_t, bool use_flat_prepass_t, bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_page_data_legacy(PageInfo* pages,
                           device_span<ColumnChunkDesc const> chunks,
@@ -333,8 +360,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   if constexpr (use_flat_prepass_t) {
     if (!pages[page_idx].legacy_flat_prepass_enabled) { return; }
+  } else if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].legacy_nested_prepass_enabled) { return; }
   } else {
-    if (pages[page_idx].legacy_flat_prepass_enabled) { return; }
+    if (pages[page_idx].legacy_flat_prepass_enabled ||
+        pages[page_idx].legacy_nested_prepass_enabled) {
+      return;
+    }
   }
 
   // Exit early if the page is pruned
@@ -388,17 +420,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const first_out_thread_id = out_warp_id * warp.size();
   // skipped_leaf_values will always be 0 for flat hierarchies.
   uint32_t skipped_leaf_values = s->setup.page.skipped_leaf_values;
-  if constexpr (use_flat_prepass_t) {
+  if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
     if (block.thread_rank() == 0) {
+      auto const* const prepass_nz_idx =
+        use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
+      int const prepass_nz_count =
+        use_flat_prepass_t ? pp->flat_prepass_nz_count : pp->nested_prepass_nz_count;
       auto const prefix_valid_count =
-        process_nulls ? flat_prepass_valid_count_before(
-                          pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
-                      : static_cast<int>(s->setup.first_row);
+        process_nulls
+          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+          : static_cast<int>(s->setup.first_row);
       auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
       ni.null_count =
-        process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+        process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
       s->progress.input_value_count = s->setup.num_input_values;
-      s->progress.nz_count          = pp->flat_prepass_nz_count;
+      s->progress.nz_count          = prepass_nz_count;
     }
     block.sync();
   }
@@ -407,7 +443,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->progress.src_pos;
 
-    if constexpr (use_flat_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
       if (warp.meta_group_rank() < out_warp_id) {
         target_pos = cuda::std::min<int32_t>(
           s->progress.nz_count, src_pos + 2 * (decode_block_size - first_out_thread_id));
@@ -431,12 +467,14 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     }
     // this needs to be here to prevent warp 3 modifying src_pos before all threads have read it
     block.sync();
-    if constexpr (use_flat_prepass_t) {
+    if constexpr (use_flat_prepass_t || use_nested_prepass_t) {
       if (block.thread_rank() >= warp.size()) {
         for (int map_pos = src_pos + block.thread_rank() - warp.size(); map_pos < target_pos;
              map_pos += decode_block_size - warp.size()) {
+          auto const* const prepass_nz_idx =
+            use_flat_prepass_t ? pp->flat_prepass_nz_idx : pp->nested_prepass_nz_idx;
           sb->nz_idx[rolling_index<rolling_buf_size>(map_pos)] =
-            process_nulls ? pp->flat_prepass_nz_idx[map_pos] : map_pos;
+            process_nulls ? prepass_nz_idx[map_pos] : map_pos;
         }
       }
       block.sync();
@@ -567,6 +605,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     __syncthreads();
   }
 
+  if constexpr (use_nested_prepass_t) {
+    if (block.thread_rank() == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->nested_prepass_nz_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
+  }
+
   // Zero-fill null positions after decoding valid values
   auto const is_string =
     ((dtype == Type::BYTE_ARRAY) && !is_decimal) || (dtype == Type::FIXED_LEN_BYTE_ARRAY);
@@ -616,7 +670,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<bool const> page_mask,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
-                      bool use_flat_prepass)
+                      bool use_flat_prepass,
+                      bool use_nested_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -625,21 +680,31 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
 
   if (level_type_size == 1) {
     if (use_flat_prepass) {
-      decode_page_data_legacy<rolling_buf_size, uint8_t, true>
+      decode_page_data_legacy<rolling_buf_size, uint8_t, true, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
-    decode_page_data_legacy<rolling_buf_size, uint8_t, false>
+    if (use_nested_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint8_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_page_data_legacy<rolling_buf_size, uint8_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     if (use_flat_prepass) {
-      decode_page_data_legacy<rolling_buf_size, uint16_t, true>
+      decode_page_data_legacy<rolling_buf_size, uint16_t, true, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
-    decode_page_data_legacy<rolling_buf_size, uint16_t, false>
+    if (use_nested_prepass) {
+      decode_page_data_legacy<rolling_buf_size, uint16_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_page_data_legacy<rolling_buf_size, uint16_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
@@ -657,7 +722,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             cudf::device_span<bool const> page_mask,
                             kernel_error::pointer error_code,
                             cuda::stream_ref stream,
-                            bool use_flat_prepass)
+                            bool use_flat_prepass,
+                            bool use_nested_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -666,21 +732,31 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
 
   if (level_type_size == 1) {
     if (use_flat_prepass) {
-      decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, true>
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, true, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
-    decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false>
+    if (use_nested_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint8_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
     if (use_flat_prepass) {
-      decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, true>
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, true, false>
         <<<dim_grid, dim_block, 0, stream.get()>>>(
           pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
-    decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false>
+    if (use_nested_prepass) {
+      decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    decode_split_page_data_kernel_legacy<rolling_buf_size, uint16_t, false, false>
       <<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -539,7 +539,7 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 // Flat DELTA_BINARY_PACKED consumer for the opt-in page-global level prepass.
 // Keep decode_delta_binary_kernel_legacy above independent and byte-for-byte
 // stable: the dual-path rollout must leave the rollback kernel untouched.
-template <typename level_t>
+template <typename level_t, bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   decode_delta_binary_kernel_prepass(PageInfo* pages,
                                      device_span<ColumnChunkDesc const> chunks,
@@ -558,7 +558,11 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   auto* const db     = &db_state;
 
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
-  if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
+  if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].delta_nested_prepass_enabled) { return; }
+  } else {
+    if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
+  }
 
   [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
   if (!setup_local_page_info(s,
@@ -571,27 +575,25 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
     return;
   }
 
-  // delta_flat_prepass_enabled is host-classified as flat only. Keep this
-  // defensive guard in the standalone consumer rather than altering legacy
-  // dispatch semantics if a future classifier widens that contract.
   bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
-  if (has_repetition) { return; }
+  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1)) { return; }
   bool const process_nulls = should_process_nulls(s);
   auto* const pp           = &pages[page_idx];
-  if (pp->flat_prepass_nz_count < 0 || (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
-    return;
-  }
+  auto const* const prepass_nz_idx =
+    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count =
+    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
+  if (prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) { return; }
 
   auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
   if (block.thread_rank() == 0) {
     auto const prefix_valid_count =
-      process_nulls ? flat_prepass_valid_count_before(
-                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
-                    : static_cast<int>(s->setup.first_row);
-    ni.null_count =
-      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+      process_nulls
+        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+        : static_cast<int>(s->setup.first_row);
+    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
     s->progress.input_value_count = s->setup.num_input_values;
-    s->progress.nz_count          = pp->flat_prepass_nz_count;
+    s->progress.nz_count          = prepass_nz_count;
   }
   block.sync();
 
@@ -632,9 +634,9 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 
     if (warp.meta_group_rank() == 2 && src_pos < target_pos) {
       for (uint32_t sp = src_pos + warp.thread_rank(); sp < target_pos; sp += warp.size()) {
-        int32_t dst_pos = process_nulls ? static_cast<int32_t>(pp->flat_prepass_nz_idx[sp])
-                                        : static_cast<int32_t>(sp);
-        dst_pos -= s->setup.first_row;
+        int32_t dst_pos =
+          process_nulls ? static_cast<int32_t>(prepass_nz_idx[sp]) : static_cast<int32_t>(sp);
+        if (!has_repetition) { dst_pos -= s->setup.first_row; }
         if (dst_pos >= 0) {
           void* const dst = ni.data_out + dst_pos * s->output_cvt.dtype_len;
           auto const val  = db->value_at(sp + skipped_leaf_values);
@@ -647,6 +649,22 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
         }
       }
       if (warp.thread_rank() == 0) { s->progress.src_pos = target_pos; }
+    }
+    block.sync();
+  }
+
+  if constexpr (use_nested_prepass_t) {
+    if (block.thread_rank() == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->nested_prepass_nz_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
     }
     block.sync();
   }
@@ -664,8 +682,9 @@ CUDF_KERNEL void filter_delta_legacy_pages(PageInfo const* pages,
 {
   auto const page_idx = static_cast<size_t>(blockIdx.x * blockDim.x + threadIdx.x);
   if (page_idx < num_pages) {
-    legacy_page_mask[page_idx] =
-      (page_mask.empty() || page_mask[page_idx]) && !pages[page_idx].delta_flat_prepass_enabled;
+    legacy_page_mask[page_idx] = (page_mask.empty() || page_mask[page_idx]) &&
+                                 !pages[page_idx].delta_flat_prepass_enabled &&
+                                 !pages[page_idx].delta_nested_prepass_enabled;
   }
 }
 
@@ -1124,6 +1143,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 // independent while the runtime selector is in place.  The page-global map
 // replaces only warp 0's level producer; the prefix, suffix, and writer warp
 // roles retain their legacy arrangement.
+template <bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_delta_byte_array_kernel_flat_prepass(PageInfo* pages,
                                               device_span<ColumnChunkDesc const> chunks,
@@ -1156,7 +1176,11 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
   PageInfo* const pp = &pages[page_idx];
-  if (!pp->delta_flat_prepass_enabled) { return; }
+  if constexpr (use_nested_prepass_t) {
+    if (!pp->delta_nested_prepass_enabled) { return; }
+  } else {
+    if (!pp->delta_flat_prepass_enabled) { return; }
+  }
 
   if (s->setup.col.logical_type.has_value() &&
       s->setup.col.logical_type->type == LogicalType::DECIMAL) {
@@ -1170,14 +1194,23 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   bool const process_nulls  = should_process_nulls(s);
   // Host classification only selects flat pages. Keep this guard so an
   // accidental mixed-family launch cannot consume an incompatible contract.
-  if (has_repetition || pp->flat_prepass_nz_count < 0 ||
-      (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
+  auto const* const prepass_nz_idx =
+    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count =
+    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
+  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) ||
+      prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) {
     return;
   }
 
   int const leaf_level_index      = s->setup.col.max_nesting_depth - 1;
   int const init_valid_map_offset = s->nesting.nesting_info[leaf_level_index].valid_map_offset;
   PageNestingDecodeInfo const* nesting_info_base = s->nesting.nesting_info;
+  // A bounds page in a non-repeated nested hierarchy can resume after leaf
+  // values that precede the selected rows.  The delta streams retain those
+  // values in their decode position, so retain the legacy adjustment when
+  // looking up the unpacked prefix and suffix lengths.
+  uint32_t const skipped_leaf_values = s->setup.page.skipped_leaf_values;
   auto const use_char_ll =
     s->setup.page.num_valids > 0 &&
     (s->setup.page.str_bytes / s->setup.page.num_valids) > cudf::detail::warp_size;
@@ -1185,13 +1218,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   if (block.thread_rank() == 0) {
     auto& ni = s->nesting.nesting_info[leaf_level_index];
     auto const prefix_valid =
-      process_nulls ? flat_prepass_valid_count_before(
-                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
-                    : static_cast<int>(s->setup.first_row);
-    ni.null_count =
-      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid) : 0;
+      process_nulls
+        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+        : static_cast<int>(s->setup.first_row);
+    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
     s->progress.input_value_count = s->setup.num_input_values;
-    s->progress.nz_count          = pp->flat_prepass_nz_count;
+    s->progress.nz_count          = prepass_nz_count;
     dba->init(s->stream.data_start,
               s->stream.data_end,
               s->setup.page.start_val,
@@ -1256,13 +1288,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
       for (uint32_t sp = src_pos + warp.thread_rank(); sp < src_pos + batch_size;
            sp += warp.size()) {
         if (sp < target_pos) {
-          int const dst_pos =
-            (process_nulls ? static_cast<int>(pp->flat_prepass_nz_idx[sp]) : static_cast<int>(sp)) -
-            s->setup.first_row;
+          int dst_pos = process_nulls ? static_cast<int>(prepass_nz_idx[sp]) : static_cast<int>(sp);
+          if (!has_repetition) { dst_pos -= s->setup.first_row; }
           if (dst_pos >= 0) {
             auto const offptr =
               reinterpret_cast<size_type*>(nesting_info_base[leaf_level_index].data_out) + dst_pos;
-            *offptr = prefix_db->value_at(sp) + suffix_db->value_at(sp);
+            auto const src_idx = sp + skipped_leaf_values;
+            *offptr            = prefix_db->value_at(src_idx) + suffix_db->value_at(src_idx);
           }
         }
         warp.sync();
@@ -1272,7 +1304,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
-  if (block.thread_rank() == 0) {
+  if constexpr (use_nested_prepass_t) {
+    if (block.thread_rank() == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->nested_prepass_nz_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
+  } else if (block.thread_rank() == 0) {
     auto& ni = s->nesting.nesting_info[leaf_level_index];
     auto const page_rows =
       min(s->setup.page.num_input_values, s->setup.first_row + s->setup.num_rows);
@@ -1303,6 +1349,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
 // Flat DELTA_LENGTH_BYTE_ARRAY prepass consumer. See the DELTA_BYTE_ARRAY
 // counterpart above for why this remains distinct from the legacy kernel.
+template <bool use_nested_prepass_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_delta_length_byte_array_kernel_flat_prepass(PageInfo* pages,
                                                      device_span<ColumnChunkDesc const> chunks,
@@ -1335,7 +1382,11 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
   PageInfo* const pp = &pages[page_idx];
-  if (!pp->delta_flat_prepass_enabled) { return; }
+  if constexpr (use_nested_prepass_t) {
+    if (!pp->delta_nested_prepass_enabled) { return; }
+  } else {
+    if (!pp->delta_flat_prepass_enabled) { return; }
+  }
 
   if (s->setup.col.logical_type.has_value() &&
       s->setup.col.logical_type->type == LogicalType::DECIMAL) {
@@ -1347,25 +1398,29 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
   bool const process_nulls  = should_process_nulls(s);
-  if (has_repetition || pp->flat_prepass_nz_count < 0 ||
-      (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
+  auto const* const prepass_nz_idx =
+    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count =
+    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
+  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) ||
+      prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) {
     return;
   }
 
   int const leaf_level_index      = s->setup.col.max_nesting_depth - 1;
   int const init_valid_map_offset = s->nesting.nesting_info[leaf_level_index].valid_map_offset;
   PageNestingDecodeInfo const* nesting_info_base = s->nesting.nesting_info;
+  uint32_t const skipped_leaf_values             = s->setup.page.skipped_leaf_values;
 
   if (block.thread_rank() == 0) {
     auto& ni = s->nesting.nesting_info[leaf_level_index];
     auto const prefix_valid =
-      process_nulls ? flat_prepass_valid_count_before(
-                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
-                    : static_cast<int>(s->setup.first_row);
-    ni.null_count =
-      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid) : 0;
+      process_nulls
+        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+        : static_cast<int>(s->setup.first_row);
+    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
     s->progress.input_value_count = s->setup.num_input_values;
-    s->progress.nz_count          = pp->flat_prepass_nz_count;
+    s->progress.nz_count          = prepass_nz_count;
     string_offset                 = 0;
     page_string_data              = db->find_end_of_block(s->stream.data_start, s->stream.data_end);
   }
@@ -1416,13 +1471,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
       for (uint32_t sp = src_pos + warp.thread_rank(); sp < src_pos + batch_size;
            sp += warp.size()) {
         if (sp < target_pos) {
-          int const dst_pos =
-            (process_nulls ? static_cast<int>(pp->flat_prepass_nz_idx[sp]) : static_cast<int>(sp)) -
-            s->setup.first_row;
+          int dst_pos = process_nulls ? static_cast<int>(prepass_nz_idx[sp]) : static_cast<int>(sp);
+          if (!has_repetition) { dst_pos -= s->setup.first_row; }
           if (dst_pos >= 0) {
             auto const offptr =
               reinterpret_cast<size_type*>(nesting_info_base[leaf_level_index].data_out) + dst_pos;
-            *offptr = db->value_at(sp);
+            *offptr = db->value_at(sp + skipped_leaf_values);
           }
         }
         warp.sync();
@@ -1432,7 +1486,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
-  if (block.thread_rank() == 0) {
+  if constexpr (use_nested_prepass_t) {
+    if (block.thread_rank() == 0) {
+      for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
+        auto const& source                              = pp->nested_prepass_nesting[depth];
+        s->nesting.nesting_info[depth].null_count       = source.null_count;
+        s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
+        s->nesting.nesting_info[depth].valid_count      = source.valid_count;
+        s->nesting.nesting_info[depth].value_count      = source.value_count;
+      }
+      s->progress.nz_count          = pp->nested_prepass_nz_count;
+      s->progress.input_value_count = pp->nested_prepass_input_value_count;
+      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+    }
+    block.sync();
+  } else if (block.thread_rank() == 0) {
     auto& ni = s->nesting.nesting_info[leaf_level_index];
     auto const page_rows =
       min(s->setup.page.num_input_values, s->setup.first_row + s->setup.num_rows);
@@ -1477,7 +1545,8 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          cudf::device_span<bool const> page_mask,
                          kernel_error::pointer error_code,
                          cuda::stream_ref stream,
-                         bool use_flat_prepass)
+                         bool use_flat_prepass,
+                         bool use_nested_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1486,17 +1555,26 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
 
   if (use_flat_prepass) {
     if (level_type_size == 1) {
-      decode_delta_binary_kernel_prepass<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+      decode_delta_binary_kernel_prepass<uint8_t, false><<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     } else {
-      decode_delta_binary_kernel_prepass<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+      decode_delta_binary_kernel_prepass<uint16_t, false><<<dim_grid, dim_block, 0, stream.get()>>>(
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     }
     CUDF_CUDA_TRY(cudaGetLastError());
+  }
+  if (use_nested_prepass) {
+    if (level_type_size == 1) {
+      decode_delta_binary_kernel_prepass<uint8_t, true><<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    } else {
+      decode_delta_binary_kernel_prepass<uint16_t, true><<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
 
-    // Every nested/list (and otherwise non-selected) page still uses the
-    // unmodified legacy kernel. A materialized mask lets it retain its normal
-    // empty-mask semantics without touching selected flat pages.
+  if (use_flat_prepass || use_nested_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid          = (pages.size() + filter_block_size - 1) / filter_block_size;
@@ -1505,7 +1583,6 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
     CUDF_CUDA_TRY(cudaGetLastError());
     page_mask = cudf::device_span<bool const>{legacy_page_mask.data(), legacy_page_mask.size()};
   }
-
   if (level_type_size == 1) {
     decode_delta_binary_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
@@ -1529,7 +1606,8 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              cudf::device_span<size_t> initial_str_offsets,
                              kernel_error::pointer error_code,
                              cuda::stream_ref stream,
-                             bool use_flat_prepass)
+                             bool use_flat_prepass,
+                             bool use_nested_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1537,10 +1615,16 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (use_flat_prepass) {
-    decode_delta_byte_array_kernel_flat_prepass<<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_byte_array_kernel_flat_prepass<false><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
-
+  }
+  if (use_nested_prepass) {
+    decode_delta_byte_array_kernel_flat_prepass<true><<<dim_grid, dim_block, 0, stream.get()>>>(
+      pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
+  if (use_flat_prepass || use_nested_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid =
@@ -1574,7 +1658,8 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     cudf::device_span<size_t> initial_str_offsets,
                                     kernel_error::pointer error_code,
                                     cuda::stream_ref stream,
-                                    bool use_flat_prepass)
+                                    bool use_flat_prepass,
+                                    bool use_nested_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1582,10 +1667,18 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (use_flat_prepass) {
-    decode_delta_length_byte_array_kernel_flat_prepass<<<dim_grid, dim_block, 0, stream.get()>>>(
-      pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    decode_delta_length_byte_array_kernel_flat_prepass<false>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
-
+  }
+  if (use_nested_prepass) {
+    decode_delta_length_byte_array_kernel_flat_prepass<true>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
+  if (use_flat_prepass || use_nested_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid =

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -353,12 +353,12 @@ struct delta_byte_array_decoder {
 // this kernel only needs 96 threads (3 warps)(for now).
 template <typename level_t>
 CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
-  decode_delta_binary_kernel(PageInfo* pages,
-                             device_span<ColumnChunkDesc const> chunks,
-                             size_t min_row,
-                             size_t num_rows,
-                             cudf::device_span<bool const> page_mask,
-                             kernel_error::pointer error_code)
+  decode_delta_binary_kernel_legacy(PageInfo* pages,
+                                    device_span<ColumnChunkDesc const> chunks,
+                                    size_t min_row,
+                                    size_t num_rows,
+                                    cudf::device_span<bool const> page_mask,
+                                    kernel_error::pointer error_code)
 {
   __shared__ __align__(16) delta_binary_decoder db_state;
   __shared__ __align__(16) full_page_decode_state state_g;
@@ -526,13 +526,13 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 // to find the start/end of each structure.
 template <typename level_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
-  decode_delta_byte_array_kernel(PageInfo* pages,
-                                 device_span<ColumnChunkDesc const> chunks,
-                                 size_t min_row,
-                                 size_t num_rows,
-                                 cudf::device_span<bool const> page_mask,
-                                 cudf::device_span<size_t> initial_str_offsets,
-                                 kernel_error::pointer error_code)
+  decode_delta_byte_array_kernel_legacy(PageInfo* pages,
+                                        device_span<ColumnChunkDesc const> chunks,
+                                        size_t min_row,
+                                        size_t num_rows,
+                                        cudf::device_span<bool const> page_mask,
+                                        cudf::device_span<size_t> initial_str_offsets,
+                                        kernel_error::pointer error_code)
 {
   __shared__ __align__(16) delta_byte_array_decoder db_state;
   __shared__ __align__(16) full_page_decode_state state_g;
@@ -748,13 +748,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 // DELTA_BINARY_PACKED array of string lengths, followed by the string data.
 template <typename level_t>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
-  decode_delta_length_byte_array_kernel(PageInfo* pages,
-                                        device_span<ColumnChunkDesc const> chunks,
-                                        size_t min_row,
-                                        size_t num_rows,
-                                        cudf::device_span<bool const> page_mask,
-                                        cudf::device_span<size_t> initial_str_offsets,
-                                        kernel_error::pointer error_code)
+  decode_delta_length_byte_array_kernel_legacy(PageInfo* pages,
+                                               device_span<ColumnChunkDesc const> chunks,
+                                               size_t min_row,
+                                               size_t num_rows,
+                                               cudf::device_span<bool const> page_mask,
+                                               cudf::device_span<size_t> initial_str_offsets,
+                                               kernel_error::pointer error_code)
 {
   __shared__ __align__(16) delta_binary_decoder db_state;
   __shared__ __align__(16) full_page_decode_state state_g;
@@ -987,11 +987,11 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_delta_binary_kernel<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_binary_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_delta_binary_kernel<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_binary_kernel_legacy<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
@@ -1016,11 +1016,11 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_delta_byte_array_kernel<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_byte_array_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_delta_byte_array_kernel<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_byte_array_kernel_legacy<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
@@ -1045,12 +1045,13 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   if (level_type_size == 1) {
-    decode_delta_length_byte_array_kernel<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+    decode_delta_length_byte_array_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   } else {
-    decode_delta_length_byte_array_kernel<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
-      pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    decode_delta_length_byte_array_kernel_legacy<uint16_t>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
 }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -11,6 +11,7 @@
 
 #include <cudf/detail/utilities/cuda.cuh>
 
+#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/transform_scan.h>
@@ -29,6 +30,24 @@ constexpr int decode_delta_binary_block_size = 96;
 // its target by up to a warp of values, so this needs to exceed 3 * delta_max_batch_size +
 // warp_size; anything smaller lets the level decoder wrap onto entries the consumer is reading.
 constexpr int delta_nz_buf_size = 4 * delta_max_batch_size;
+
+// The flat prepass publishes a sorted valid-rank-to-input-row map.  A sliced
+// page still needs the number of valid values preceding first_row to report
+// its null count to the legacy output-state plumbing.
+__device__ int flat_prepass_valid_count_before(uint32_t const* nz_idx, int count, int input_row)
+{
+  int first = 0;
+  int last  = count;
+  while (first < last) {
+    int const mid = first + (last - first) / 2;
+    if (nz_idx[mid] < input_row) {
+      first = mid + 1;
+    } else {
+      last = mid;
+    }
+  }
+  return first;
+}
 
 // DELTA_BYTE_ARRAY encoding (incremental encoding or front compression), is used for BYTE_ARRAY
 // columns. For each element in a sequence of strings, a prefix length from the preceding string
@@ -517,6 +536,139 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
 }
 
+// Flat DELTA_BINARY_PACKED consumer for the opt-in page-global level prepass.
+// Keep decode_delta_binary_kernel_legacy above independent and byte-for-byte
+// stable: the dual-path rollout must leave the rollback kernel untouched.
+template <typename level_t>
+CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
+  decode_delta_binary_kernel_prepass(PageInfo* pages,
+                                     device_span<ColumnChunkDesc const> chunks,
+                                     size_t min_row,
+                                     size_t num_rows,
+                                     cudf::device_span<bool const> page_mask,
+                                     kernel_error::pointer error_code)
+{
+  __shared__ __align__(16) delta_binary_decoder db_state;
+  __shared__ __align__(16) full_page_decode_state state_g;
+
+  auto* const s      = &state_g;
+  int const page_idx = cg::this_grid().block_rank();
+  auto const block   = cg::this_thread_block();
+  auto const warp    = cg::tiled_partition<cudf::detail::warp_size>(block);
+  auto* const db     = &db_state;
+
+  if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
+
+  [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
+  if (!setup_local_page_info(s,
+                             &pages[page_idx],
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::DELTA_BINARY},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+
+  // delta_flat_prepass_enabled is host-classified as flat only. Keep this
+  // defensive guard in the standalone consumer rather than altering legacy
+  // dispatch semantics if a future classifier widens that contract.
+  bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
+  if (has_repetition) { return; }
+  bool const process_nulls = should_process_nulls(s);
+  auto* const pp           = &pages[page_idx];
+  if (pp->flat_prepass_nz_count < 0 || (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
+    return;
+  }
+
+  auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
+  if (block.thread_rank() == 0) {
+    auto const prefix_valid_count =
+      process_nulls ? flat_prepass_valid_count_before(
+                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
+                    : static_cast<int>(s->setup.first_row);
+    ni.null_count =
+      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid_count) : 0;
+    s->progress.input_value_count = s->setup.num_input_values;
+    s->progress.nz_count          = pp->flat_prepass_nz_count;
+  }
+  block.sync();
+
+  if (block.thread_rank() == 0) { db->init_binary_block(s->stream.data_start, s->stream.data_end); }
+  block.sync();
+  if (db->error) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
+    return;
+  }
+
+  uint32_t const skipped_leaf_values = s->setup.page.skipped_leaf_values;
+  bool const is_skip_resume          = skipped_leaf_values > 0;
+  uint32_t const batch_size =
+    is_skip_resume ? cudf::detail::warp_size
+                   : min(db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
+  uint32_t const passes_per_batch = batch_size / cudf::detail::warp_size;
+  if (is_skip_resume) { db->skip_values(skipped_leaf_values, block, warp); }
+
+  // Warp 0 intentionally has no level-decode work in this variant.  Warp 1
+  // remains the delta producer and warp 2 remains the value consumer; only
+  // their producer input changes from the rolling level state to the map.
+  while (s->setup.error == 0 && s->progress.src_pos < s->progress.nz_count) {
+    uint32_t const src_pos    = s->progress.src_pos;
+    uint32_t const target_pos = min(s->progress.nz_count, src_pos + batch_size);
+    block.sync();
+
+    if (warp.meta_group_rank() == 1) {
+      for (uint32_t i = 0; i < passes_per_batch; ++i) {
+        if (i > 0) { warp.sync(); }
+        db->decode_next_pass(warp);
+      }
+    }
+    // Preserve the legacy block handoff between the delta producer and writer.
+    block.sync();
+
+    if (warp.meta_group_rank() == 2 && src_pos < target_pos) {
+      for (uint32_t sp = src_pos + warp.thread_rank(); sp < target_pos; sp += warp.size()) {
+        int32_t dst_pos = process_nulls ? static_cast<int32_t>(pp->flat_prepass_nz_idx[sp])
+                                        : static_cast<int32_t>(sp);
+        dst_pos -= s->setup.first_row;
+        if (dst_pos >= 0) {
+          void* const dst = ni.data_out + dst_pos * s->output_cvt.dtype_len;
+          auto const val  = db->value_at(sp + skipped_leaf_values);
+          switch (s->output_cvt.dtype_len) {
+            case 1: *static_cast<int8_t*>(dst) = val; break;
+            case 2: *static_cast<int16_t*>(dst) = val; break;
+            case 4: *static_cast<int32_t*>(dst) = val; break;
+            case 8: *static_cast<int64_t*>(dst) = val; break;
+          }
+        }
+      }
+      if (warp.thread_rank() == 0) { s->progress.src_pos = target_pos; }
+    }
+    block.sync();
+  }
+
+  if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
+}
+
+// Build a launch mask for the unchanged legacy binary-delta kernel.  Keeping
+// this filtering outside that kernel is what makes legacy mode a true rollback
+// path: its device body and symbol remain independent of the selector.
+CUDF_KERNEL void filter_delta_legacy_pages(PageInfo const* pages,
+                                           cudf::device_span<bool const> page_mask,
+                                           bool* legacy_page_mask,
+                                           size_t num_pages)
+{
+  auto const page_idx = static_cast<size_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (page_idx < num_pages) {
+    legacy_page_mask[page_idx] =
+      (page_mask.empty() || page_mask[page_idx]) && !pages[page_idx].delta_flat_prepass_enabled;
+  }
+}
+
 // Decode page data that is DELTA_BYTE_ARRAY packed. This encoding consists of a DELTA_BINARY_PACKED
 // array of prefix lengths, followed by a DELTA_BINARY_PACKED array of suffix lengths, followed by
 // the suffixes (technically the suffixes are DELTA_LENGTH_BYTE_ARRAY encoded). The latter two can
@@ -967,6 +1119,351 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
 }
 
+// Flat DELTA_BYTE_ARRAY prepass consumer.  This is intentionally a distinct
+// kernel from the legacy decoder: the latter must remain byte-for-byte
+// independent while the runtime selector is in place.  The page-global map
+// replaces only warp 0's level producer; the prefix, suffix, and writer warp
+// roles retain their legacy arrangement.
+CUDF_KERNEL void __launch_bounds__(decode_block_size)
+  decode_delta_byte_array_kernel_flat_prepass(PageInfo* pages,
+                                              device_span<ColumnChunkDesc const> chunks,
+                                              size_t min_row,
+                                              size_t num_rows,
+                                              cudf::device_span<bool const> page_mask,
+                                              cudf::device_span<size_t> initial_str_offsets,
+                                              kernel_error::pointer error_code)
+{
+  __shared__ __align__(16) delta_byte_array_decoder db_state;
+  __shared__ __align__(16) full_page_decode_state state_g;
+
+  auto* const s         = &state_g;
+  int const page_idx    = cg::this_grid().block_rank();
+  auto const block      = cg::this_thread_block();
+  auto const warp       = cg::tiled_partition<cudf::detail::warp_size>(block);
+  auto* const prefix_db = &db_state.prefixes;
+  auto* const suffix_db = &db_state.suffixes;
+  auto* const dba       = &db_state;
+  if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
+
+  if (!setup_local_page_info(s,
+                             &pages[page_idx],
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::DELTA_BYTE_ARRAY},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+  PageInfo* const pp = &pages[page_idx];
+  if (!pp->delta_flat_prepass_enabled) { return; }
+
+  if (s->setup.col.logical_type.has_value() &&
+      s->setup.col.logical_type->type == LogicalType::DECIMAL) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::INVALID_DATA_TYPE), error_code);
+    }
+    return;
+  }
+
+  bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
+  bool const process_nulls  = should_process_nulls(s);
+  // Host classification only selects flat pages. Keep this guard so an
+  // accidental mixed-family launch cannot consume an incompatible contract.
+  if (has_repetition || pp->flat_prepass_nz_count < 0 ||
+      (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
+    return;
+  }
+
+  int const leaf_level_index      = s->setup.col.max_nesting_depth - 1;
+  int const init_valid_map_offset = s->nesting.nesting_info[leaf_level_index].valid_map_offset;
+  PageNestingDecodeInfo const* nesting_info_base = s->nesting.nesting_info;
+  auto const use_char_ll =
+    s->setup.page.num_valids > 0 &&
+    (s->setup.page.str_bytes / s->setup.page.num_valids) > cudf::detail::warp_size;
+
+  if (block.thread_rank() == 0) {
+    auto& ni = s->nesting.nesting_info[leaf_level_index];
+    auto const prefix_valid =
+      process_nulls ? flat_prepass_valid_count_before(
+                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
+                    : static_cast<int>(s->setup.first_row);
+    ni.null_count =
+      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid) : 0;
+    s->progress.input_value_count = s->setup.num_input_values;
+    s->progress.nz_count          = pp->flat_prepass_nz_count;
+    dba->init(s->stream.data_start,
+              s->stream.data_end,
+              s->setup.page.start_val,
+              s->setup.page.temp_string_buf,
+              s->setup.page.temp_string_size);
+  }
+  block.sync();
+
+  if (prefix_db->error or suffix_db->error) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
+    return;
+  }
+  if (prefix_db->values_per_mb != suffix_db->values_per_mb ||
+      prefix_db->block_size != suffix_db->block_size ||
+      prefix_db->value_count != suffix_db->value_count) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAM_MISMATCH),
+                error_code);
+    }
+    return;
+  }
+
+  auto strings_data = nesting_info_base[leaf_level_index].string_out;
+  int string_pos    = 0;
+  uint32_t const batch_size =
+    min(prefix_db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
+  uint32_t const passes_per_batch = batch_size / cudf::detail::warp_size;
+
+  while (!s->setup.error && s->progress.src_pos < s->progress.nz_count) {
+    uint32_t const src_pos    = s->progress.src_pos;
+    uint32_t const target_pos = min(s->progress.nz_count, src_pos + batch_size);
+    block.sync();
+
+    // Warp 0 intentionally has no work: the prepass owns level decoding.
+    if (warp.meta_group_rank() == 1) {
+      for (uint32_t i = 0; i < passes_per_batch; ++i) {
+        if (i > 0) { warp.sync(); }
+        prefix_db->decode_next_pass(warp);
+      }
+    } else if (warp.meta_group_rank() == 2) {
+      for (uint32_t i = 0; i < passes_per_batch; ++i) {
+        if (i > 0) { warp.sync(); }
+        suffix_db->decode_next_pass(warp);
+      }
+    }
+    // The legacy schedule got a producer lead from warp 0. The independent
+    // map has no such lead, so publish both delta streams before the writer.
+    block.sync();
+
+    if (warp.meta_group_rank() == 3 && src_pos < target_pos) {
+      int const nproc =
+        min(static_cast<int>(target_pos - src_pos), s->setup.page.end_val - string_pos);
+      strings_data +=
+        use_char_ll
+          ? dba->calculate_string_values_cp(strings_data, string_pos, nproc, warp.thread_rank())
+          : dba->calculate_string_values(strings_data, string_pos, nproc, warp.thread_rank());
+      string_pos += nproc;
+
+      for (uint32_t sp = src_pos + warp.thread_rank(); sp < src_pos + batch_size;
+           sp += warp.size()) {
+        if (sp < target_pos) {
+          int const dst_pos =
+            (process_nulls ? static_cast<int>(pp->flat_prepass_nz_idx[sp]) : static_cast<int>(sp)) -
+            s->setup.first_row;
+          if (dst_pos >= 0) {
+            auto const offptr =
+              reinterpret_cast<size_type*>(nesting_info_base[leaf_level_index].data_out) + dst_pos;
+            *offptr = prefix_db->value_at(sp) + suffix_db->value_at(sp);
+          }
+        }
+        warp.sync();
+      }
+      if (warp.thread_rank() == 0) { s->progress.src_pos = target_pos; }
+    }
+    block.sync();
+  }
+
+  if (block.thread_rank() == 0) {
+    auto& ni = s->nesting.nesting_info[leaf_level_index];
+    auto const page_rows =
+      min(s->setup.page.num_input_values, s->setup.first_row + s->setup.num_rows);
+    ni.valid_count                = pp->flat_prepass_nz_count;
+    ni.value_count                = page_rows;
+    s->progress.input_value_count = page_rows;
+    s->progress.input_row_count   = page_rows;
+  }
+  block.sync();
+
+  auto const& ni = s->nesting.nesting_info[leaf_level_index];
+  if (ni.valid_map != nullptr) {
+    zero_fill_null_positions_shared<decode_block_size>(s,
+                                                       sizeof(size_type),
+                                                       init_valid_map_offset,
+                                                       s->setup.num_rows,
+                                                       static_cast<int>(block.thread_rank()));
+  }
+  if (s->setup.col.is_large_string_col) {
+    auto const chunks_per_rowgroup = initial_str_offsets.size();
+    auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
+    compute_initial_large_strings_offset<false>(s, initial_str_offsets[input_col_idx]);
+  } else {
+    convert_small_string_lengths_to_offsets<decode_block_size, false>(s);
+  }
+  if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
+}
+
+// Flat DELTA_LENGTH_BYTE_ARRAY prepass consumer. See the DELTA_BYTE_ARRAY
+// counterpart above for why this remains distinct from the legacy kernel.
+CUDF_KERNEL void __launch_bounds__(decode_block_size)
+  decode_delta_length_byte_array_kernel_flat_prepass(PageInfo* pages,
+                                                     device_span<ColumnChunkDesc const> chunks,
+                                                     size_t min_row,
+                                                     size_t num_rows,
+                                                     cudf::device_span<bool const> page_mask,
+                                                     cudf::device_span<size_t> initial_str_offsets,
+                                                     kernel_error::pointer error_code)
+{
+  __shared__ __align__(16) delta_binary_decoder db_state;
+  __shared__ __align__(16) full_page_decode_state state_g;
+  __shared__ __align__(8) uint8_t const* page_string_data;
+  __shared__ size_t string_offset;
+
+  auto* const s      = &state_g;
+  int const page_idx = cg::this_grid().block_rank();
+  auto const block   = cg::this_thread_block();
+  auto const warp    = cg::tiled_partition<cudf::detail::warp_size>(block);
+  auto* const db     = &db_state;
+  if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
+
+  if (!setup_local_page_info(s,
+                             &pages[page_idx],
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::DELTA_LENGTH_BA},
+                             page_processing_stage::DECODE)) {
+    return;
+  }
+  PageInfo* const pp = &pages[page_idx];
+  if (!pp->delta_flat_prepass_enabled) { return; }
+
+  if (s->setup.col.logical_type.has_value() &&
+      s->setup.col.logical_type->type == LogicalType::DECIMAL) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::INVALID_DATA_TYPE), error_code);
+    }
+    return;
+  }
+
+  bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
+  bool const process_nulls  = should_process_nulls(s);
+  if (has_repetition || pp->flat_prepass_nz_count < 0 ||
+      (process_nulls && pp->flat_prepass_nz_idx == nullptr)) {
+    return;
+  }
+
+  int const leaf_level_index      = s->setup.col.max_nesting_depth - 1;
+  int const init_valid_map_offset = s->nesting.nesting_info[leaf_level_index].valid_map_offset;
+  PageNestingDecodeInfo const* nesting_info_base = s->nesting.nesting_info;
+
+  if (block.thread_rank() == 0) {
+    auto& ni = s->nesting.nesting_info[leaf_level_index];
+    auto const prefix_valid =
+      process_nulls ? flat_prepass_valid_count_before(
+                        pp->flat_prepass_nz_idx, pp->flat_prepass_nz_count, s->setup.first_row)
+                    : static_cast<int>(s->setup.first_row);
+    ni.null_count =
+      process_nulls ? s->setup.num_rows - (pp->flat_prepass_nz_count - prefix_valid) : 0;
+    s->progress.input_value_count = s->setup.num_input_values;
+    s->progress.nz_count          = pp->flat_prepass_nz_count;
+    string_offset                 = 0;
+    page_string_data              = db->find_end_of_block(s->stream.data_start, s->stream.data_end);
+  }
+  block.sync();
+
+  if (db->error) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
+    return;
+  }
+
+  auto const is_bounds_pg =
+    is_bounds_page(s->setup.page, s->setup.col.start_row, min_row, num_rows, has_repetition);
+  bool const is_skip_resume = is_bounds_pg && s->setup.page.start_val > 0;
+  uint32_t const batch_size = min(db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
+  uint32_t const passes_per_batch = batch_size / cudf::detail::warp_size;
+  if (is_skip_resume) {
+    if (warp.meta_group_rank() == 0) {
+      auto const string_off = db->skip_values_and_sum(s->setup.page.start_val, warp);
+      warp.sync();
+      if (warp.thread_rank() == 0) {
+        string_offset = string_off;
+        db->init_binary_block(s->stream.data_start, s->stream.data_end);
+      }
+    }
+    block.sync();
+  }
+
+  int string_pos = 0;
+  while (!s->setup.error && s->progress.src_pos < s->progress.nz_count) {
+    uint32_t const src_pos    = s->progress.src_pos;
+    uint32_t const target_pos = min(s->progress.nz_count, src_pos + batch_size);
+    block.sync();
+
+    // Warp 0 is intentionally idle; warp 1 remains the delta producer.
+    if (warp.meta_group_rank() == 1) {
+      for (uint32_t i = 0; i < passes_per_batch; ++i) {
+        if (i > 0) { warp.sync(); }
+        db->decode_next_pass(warp);
+      }
+    }
+    block.sync();
+
+    if (warp.meta_group_rank() == 2 && src_pos < target_pos) {
+      string_pos += min(static_cast<int>(target_pos - src_pos), s->setup.page.end_val - string_pos);
+      for (uint32_t sp = src_pos + warp.thread_rank(); sp < src_pos + batch_size;
+           sp += warp.size()) {
+        if (sp < target_pos) {
+          int const dst_pos =
+            (process_nulls ? static_cast<int>(pp->flat_prepass_nz_idx[sp]) : static_cast<int>(sp)) -
+            s->setup.first_row;
+          if (dst_pos >= 0) {
+            auto const offptr =
+              reinterpret_cast<size_type*>(nesting_info_base[leaf_level_index].data_out) + dst_pos;
+            *offptr = db->value_at(sp);
+          }
+        }
+        warp.sync();
+      }
+      if (warp.thread_rank() == 0) { s->progress.src_pos = target_pos; }
+    }
+    block.sync();
+  }
+
+  if (block.thread_rank() == 0) {
+    auto& ni = s->nesting.nesting_info[leaf_level_index];
+    auto const page_rows =
+      min(s->setup.page.num_input_values, s->setup.first_row + s->setup.num_rows);
+    ni.valid_count                = pp->flat_prepass_nz_count;
+    ni.value_count                = page_rows;
+    s->progress.input_value_count = page_rows;
+    s->progress.input_row_count   = page_rows;
+  }
+  block.sync();
+
+  auto const& ni = nesting_info_base[leaf_level_index];
+  if (ni.valid_map != nullptr) {
+    zero_fill_null_positions_shared<decode_block_size>(s,
+                                                       sizeof(size_type),
+                                                       init_valid_map_offset,
+                                                       s->setup.num_rows,
+                                                       static_cast<int>(block.thread_rank()));
+  }
+  if (s->setup.col.is_large_string_col) {
+    auto const chunks_per_rowgroup = initial_str_offsets.size();
+    auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
+    compute_initial_large_strings_offset<false>(s, initial_str_offsets[input_col_idx]);
+  } else {
+    convert_small_string_lengths_to_offsets<decode_block_size, false>(s);
+  }
+  auto const dst = nesting_info_base[leaf_level_index].string_out;
+  auto const src = page_string_data + string_offset;
+  memcpy_block<decode_block_size, true>(dst, src, s->setup.page.str_bytes, block);
+  if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
+}
+
 }  // anonymous namespace
 
 /**
@@ -979,12 +1476,35 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          int level_type_size,
                          cudf::device_span<bool const> page_mask,
                          kernel_error::pointer error_code,
-                         cuda::stream_ref stream)
+                         cuda::stream_ref stream,
+                         bool use_flat_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
   dim3 dim_block(decode_delta_binary_block_size, 1);
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
+
+  if (use_flat_prepass) {
+    if (level_type_size == 1) {
+      decode_delta_binary_kernel_prepass<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    } else {
+      decode_delta_binary_kernel_prepass<uint16_t><<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    CUDF_CUDA_TRY(cudaGetLastError());
+
+    // Every nested/list (and otherwise non-selected) page still uses the
+    // unmodified legacy kernel. A materialized mask lets it retain its normal
+    // empty-mask semantics without touching selected flat pages.
+    rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
+    constexpr int filter_block_size = 256;
+    auto const filter_grid          = (pages.size() + filter_block_size - 1) / filter_block_size;
+    filter_delta_legacy_pages<<<filter_grid, filter_block_size, 0, stream.get()>>>(
+      pages.device_ptr(), page_mask, legacy_page_mask.data(), pages.size());
+    CUDF_CUDA_TRY(cudaGetLastError());
+    page_mask = cudf::device_span<bool const>{legacy_page_mask.data(), legacy_page_mask.size()};
+  }
 
   if (level_type_size == 1) {
     decode_delta_binary_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
@@ -1008,12 +1528,28 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              cudf::device_span<bool const> page_mask,
                              cudf::device_span<size_t> initial_str_offsets,
                              kernel_error::pointer error_code,
-                             cuda::stream_ref stream)
+                             cuda::stream_ref stream,
+                             bool use_flat_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
   dim3 const dim_block(decode_block_size, 1);
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
+
+  if (use_flat_prepass) {
+    decode_delta_byte_array_kernel_flat_prepass<<<dim_grid, dim_block, 0, stream.get()>>>(
+      pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+
+    rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
+    constexpr int filter_block_size = 256;
+    auto const filter_grid =
+      cudf::util::div_rounding_up_safe<size_t>(pages.size(), filter_block_size);
+    filter_delta_legacy_pages<<<filter_grid, filter_block_size, 0, stream.get()>>>(
+      pages.device_ptr(), page_mask, legacy_page_mask.data(), pages.size());
+    CUDF_CUDA_TRY(cudaGetLastError());
+    page_mask = cudf::device_span<bool const>{legacy_page_mask.data(), legacy_page_mask.size()};
+  }
 
   if (level_type_size == 1) {
     decode_delta_byte_array_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(
@@ -1037,12 +1573,28 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     cudf::device_span<bool const> page_mask,
                                     cudf::device_span<size_t> initial_str_offsets,
                                     kernel_error::pointer error_code,
-                                    cuda::stream_ref stream)
+                                    cuda::stream_ref stream,
+                                    bool use_flat_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
   dim3 const dim_block(decode_block_size, 1);
   dim3 const dim_grid(pages.size(), 1);  // 1 threadblock per page
+
+  if (use_flat_prepass) {
+    decode_delta_length_byte_array_kernel_flat_prepass<<<dim_grid, dim_block, 0, stream.get()>>>(
+      pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+
+    rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
+    constexpr int filter_block_size = 256;
+    auto const filter_grid =
+      cudf::util::div_rounding_up_safe<size_t>(pages.size(), filter_block_size);
+    filter_delta_legacy_pages<<<filter_grid, filter_block_size, 0, stream.get()>>>(
+      pages.device_ptr(), page_mask, legacy_page_mask.data(), pages.size());
+    CUDF_CUDA_TRY(cudaGetLastError());
+    page_mask = cudf::device_span<bool const>{legacy_page_mask.data(), legacy_page_mask.size()};
+  }
 
   if (level_type_size == 1) {
     decode_delta_length_byte_array_kernel_legacy<uint8_t><<<dim_grid, dim_block, 0, stream.get()>>>(

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -1178,6 +1178,14 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto* const suffix_db = &db_state.suffixes;
   auto* const dba       = &db_state;
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].delta_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].delta_list_prepass_enabled) { return; }
+  } else {
+    if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
+  }
+
   [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
 
   if (!setup_local_page_info(s,
@@ -1190,13 +1198,6 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
   PageInfo* const pp = &pages[page_idx];
-  if constexpr (use_nested_prepass_t) {
-    if (!pp->delta_nested_prepass_enabled) { return; }
-  } else if constexpr (use_list_prepass_t) {
-    if (!pp->delta_list_prepass_enabled) { return; }
-  } else {
-    if (!pp->delta_flat_prepass_enabled) { return; }
-  }
 
   if (s->setup.col.logical_type.has_value() &&
       s->setup.col.logical_type->type == LogicalType::DECIMAL) {
@@ -1402,6 +1403,14 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const warp    = cg::tiled_partition<cudf::detail::warp_size>(block);
   auto* const db     = &db_state;
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  if constexpr (use_nested_prepass_t) {
+    if (!pages[page_idx].delta_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].delta_list_prepass_enabled) { return; }
+  } else {
+    if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
+  }
+
   [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
 
   if (!setup_local_page_info(s,
@@ -1414,13 +1423,6 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
   PageInfo* const pp = &pages[page_idx];
-  if constexpr (use_nested_prepass_t) {
-    if (!pp->delta_nested_prepass_enabled) { return; }
-  } else if constexpr (use_list_prepass_t) {
-    if (!pp->delta_list_prepass_enabled) { return; }
-  } else {
-    if (!pp->delta_flat_prepass_enabled) { return; }
-  }
 
   if (s->setup.col.logical_type.has_value() &&
       s->setup.col.logical_type->type == LogicalType::DECIMAL) {

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -539,7 +539,7 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 // Flat DELTA_BINARY_PACKED consumer for the opt-in page-global level prepass.
 // Keep decode_delta_binary_kernel_legacy above independent and byte-for-byte
 // stable: the dual-path rollout must leave the rollback kernel untouched.
-template <typename level_t, bool use_nested_prepass_t>
+template <typename level_t, bool use_nested_prepass_t, bool use_list_prepass_t = false>
 CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   decode_delta_binary_kernel_prepass(PageInfo* pages,
                                      device_span<ColumnChunkDesc const> chunks,
@@ -560,6 +560,8 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
   if constexpr (use_nested_prepass_t) {
     if (!pages[page_idx].delta_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pages[page_idx].delta_list_prepass_enabled) { return; }
   } else {
     if (!pages[page_idx].delta_flat_prepass_enabled) { return; }
   }
@@ -576,22 +578,30 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   }
 
   bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
-  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1)) { return; }
-  bool const process_nulls = should_process_nulls(s);
-  auto* const pp           = &pages[page_idx];
-  auto const* const prepass_nz_idx =
-    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
-  int const prepass_nz_count =
-    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
+  if ((!use_list_prepass_t && has_repetition) ||
+      (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1)) {
+    return;
+  }
+  bool const process_nulls         = should_process_nulls(s);
+  auto* const pp                   = &pages[page_idx];
+  auto const* const prepass_nz_idx = use_nested_prepass_t ? pp->nested_prepass_nz_idx
+                                     : use_list_prepass_t ? pp->list_prepass_nz_idx
+                                                          : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count       = use_nested_prepass_t ? pp->nested_prepass_nz_count
+                                     : use_list_prepass_t ? pp->list_prepass_nz_count
+                                                          : pp->flat_prepass_nz_count;
   if (prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) { return; }
 
   auto& ni = s->nesting.nesting_info[s->setup.col.max_nesting_depth - 1];
   if (block.thread_rank() == 0) {
-    auto const prefix_valid_count =
-      process_nulls
-        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
-        : static_cast<int>(s->setup.first_row);
-    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+    if constexpr (!use_list_prepass_t) {
+      auto const prefix_valid_count =
+        process_nulls
+          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+          : static_cast<int>(s->setup.first_row);
+      ni.null_count =
+        process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid_count) : 0;
+    }
     s->progress.input_value_count = s->setup.num_input_values;
     s->progress.nz_count          = prepass_nz_count;
   }
@@ -653,18 +663,22 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
     block.sync();
   }
 
-  if constexpr (use_nested_prepass_t) {
+  if constexpr (use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
       for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
-        auto const& source                              = pp->nested_prepass_nesting[depth];
+        auto const& source = use_nested_prepass_t ? pp->nested_prepass_nesting[depth]
+                                                  : pp->list_prepass_nesting[depth];
         s->nesting.nesting_info[depth].null_count       = source.null_count;
         s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
         s->nesting.nesting_info[depth].valid_count      = source.valid_count;
         s->nesting.nesting_info[depth].value_count      = source.value_count;
       }
-      s->progress.nz_count          = pp->nested_prepass_nz_count;
-      s->progress.input_value_count = pp->nested_prepass_input_value_count;
-      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+      s->progress.nz_count =
+        use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->list_prepass_nz_count;
+      s->progress.input_value_count = use_nested_prepass_t ? pp->nested_prepass_input_value_count
+                                                           : pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = use_nested_prepass_t ? pp->nested_prepass_input_row_count
+                                                           : pp->list_prepass_input_row_count;
     }
     block.sync();
   }
@@ -682,9 +696,9 @@ CUDF_KERNEL void filter_delta_legacy_pages(PageInfo const* pages,
 {
   auto const page_idx = static_cast<size_t>(blockIdx.x * blockDim.x + threadIdx.x);
   if (page_idx < num_pages) {
-    legacy_page_mask[page_idx] = (page_mask.empty() || page_mask[page_idx]) &&
-                                 !pages[page_idx].delta_flat_prepass_enabled &&
-                                 !pages[page_idx].delta_nested_prepass_enabled;
+    legacy_page_mask[page_idx] =
+      (page_mask.empty() || page_mask[page_idx]) && !pages[page_idx].delta_flat_prepass_enabled &&
+      !pages[page_idx].delta_nested_prepass_enabled && !pages[page_idx].delta_list_prepass_enabled;
   }
 }
 
@@ -1143,7 +1157,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 // independent while the runtime selector is in place.  The page-global map
 // replaces only warp 0's level producer; the prefix, suffix, and writer warp
 // roles retain their legacy arrangement.
-template <bool use_nested_prepass_t>
+template <bool use_nested_prepass_t, bool use_list_prepass_t = false>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_delta_byte_array_kernel_flat_prepass(PageInfo* pages,
                                               device_span<ColumnChunkDesc const> chunks,
@@ -1178,6 +1192,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   PageInfo* const pp = &pages[page_idx];
   if constexpr (use_nested_prepass_t) {
     if (!pp->delta_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pp->delta_list_prepass_enabled) { return; }
   } else {
     if (!pp->delta_flat_prepass_enabled) { return; }
   }
@@ -1190,16 +1206,17 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
 
-  bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
-  bool const process_nulls  = should_process_nulls(s);
-  // Host classification only selects flat pages. Keep this guard so an
-  // accidental mixed-family launch cannot consume an incompatible contract.
-  auto const* const prepass_nz_idx =
-    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
-  int const prepass_nz_count =
-    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
-  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) ||
-      prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) {
+  bool const has_repetition        = s->setup.col.max_level[level_type::REPETITION] > 0;
+  bool const process_nulls         = should_process_nulls(s);
+  auto const* const prepass_nz_idx = use_nested_prepass_t ? pp->nested_prepass_nz_idx
+                                     : use_list_prepass_t ? pp->list_prepass_nz_idx
+                                                          : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count       = use_nested_prepass_t ? pp->nested_prepass_nz_count
+                                     : use_list_prepass_t ? pp->list_prepass_nz_count
+                                                          : pp->flat_prepass_nz_count;
+  if ((!use_list_prepass_t && has_repetition) ||
+      (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) || prepass_nz_count < 0 ||
+      (process_nulls && prepass_nz_idx == nullptr)) {
     return;
   }
 
@@ -1216,12 +1233,14 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     (s->setup.page.str_bytes / s->setup.page.num_valids) > cudf::detail::warp_size;
 
   if (block.thread_rank() == 0) {
-    auto& ni = s->nesting.nesting_info[leaf_level_index];
-    auto const prefix_valid =
-      process_nulls
-        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
-        : static_cast<int>(s->setup.first_row);
-    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
+    if constexpr (!use_list_prepass_t) {
+      auto& ni = s->nesting.nesting_info[leaf_level_index];
+      auto const prefix_valid =
+        process_nulls
+          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+          : static_cast<int>(s->setup.first_row);
+      ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
+    }
     s->progress.input_value_count = s->setup.num_input_values;
     s->progress.nz_count          = prepass_nz_count;
     dba->init(s->stream.data_start,
@@ -1250,10 +1269,16 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   }
 
   auto strings_data = nesting_info_base[leaf_level_index].string_out;
-  int string_pos    = 0;
+  int string_pos    = has_repetition ? s->setup.page.start_val : 0;
+  auto const is_bounds_pg =
+    is_bounds_page(s->setup.page, s->setup.col.start_row, min_row, num_rows, has_repetition);
+  bool const is_skip_resume = is_bounds_pg && string_pos > 0;
   uint32_t const batch_size =
-    min(prefix_db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
+    is_skip_resume ? cudf::detail::warp_size
+                   : min(prefix_db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
   uint32_t const passes_per_batch = batch_size / cudf::detail::warp_size;
+
+  if (is_skip_resume) { dba->skip(use_char_ll, block, warp); }
 
   while (!s->setup.error && s->progress.src_pos < s->progress.nz_count) {
     uint32_t const src_pos    = s->progress.src_pos;
@@ -1304,18 +1329,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
-  if constexpr (use_nested_prepass_t) {
+  if constexpr (use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
       for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
-        auto const& source                              = pp->nested_prepass_nesting[depth];
+        auto const& source = use_nested_prepass_t ? pp->nested_prepass_nesting[depth]
+                                                  : pp->list_prepass_nesting[depth];
         s->nesting.nesting_info[depth].null_count       = source.null_count;
         s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
         s->nesting.nesting_info[depth].valid_count      = source.valid_count;
         s->nesting.nesting_info[depth].value_count      = source.value_count;
       }
-      s->progress.nz_count          = pp->nested_prepass_nz_count;
-      s->progress.input_value_count = pp->nested_prepass_input_value_count;
-      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+      s->progress.nz_count =
+        use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->list_prepass_nz_count;
+      s->progress.input_value_count = use_nested_prepass_t ? pp->nested_prepass_input_value_count
+                                                           : pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = use_nested_prepass_t ? pp->nested_prepass_input_row_count
+                                                           : pp->list_prepass_input_row_count;
     }
     block.sync();
   } else if (block.thread_rank() == 0) {
@@ -1331,25 +1360,28 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   auto const& ni = s->nesting.nesting_info[leaf_level_index];
   if (ni.valid_map != nullptr) {
+    int const num_values = (use_nested_prepass_t || use_list_prepass_t)
+                             ? ni.valid_map_offset - init_valid_map_offset
+                             : s->setup.num_rows;
     zero_fill_null_positions_shared<decode_block_size>(s,
                                                        sizeof(size_type),
                                                        init_valid_map_offset,
-                                                       s->setup.num_rows,
+                                                       num_values,
                                                        static_cast<int>(block.thread_rank()));
   }
   if (s->setup.col.is_large_string_col) {
     auto const chunks_per_rowgroup = initial_str_offsets.size();
     auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
-    compute_initial_large_strings_offset<false>(s, initial_str_offsets[input_col_idx]);
+    compute_initial_large_strings_offset<use_list_prepass_t>(s, initial_str_offsets[input_col_idx]);
   } else {
-    convert_small_string_lengths_to_offsets<decode_block_size, false>(s);
+    convert_small_string_lengths_to_offsets<decode_block_size, use_list_prepass_t>(s);
   }
   if (block.thread_rank() == 0 and s->setup.error != 0) { set_error(s->setup.error, error_code); }
 }
 
 // Flat DELTA_LENGTH_BYTE_ARRAY prepass consumer. See the DELTA_BYTE_ARRAY
 // counterpart above for why this remains distinct from the legacy kernel.
-template <bool use_nested_prepass_t>
+template <bool use_nested_prepass_t, bool use_list_prepass_t = false>
 CUDF_KERNEL void __launch_bounds__(decode_block_size)
   decode_delta_length_byte_array_kernel_flat_prepass(PageInfo* pages,
                                                      device_span<ColumnChunkDesc const> chunks,
@@ -1384,6 +1416,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   PageInfo* const pp = &pages[page_idx];
   if constexpr (use_nested_prepass_t) {
     if (!pp->delta_nested_prepass_enabled) { return; }
+  } else if constexpr (use_list_prepass_t) {
+    if (!pp->delta_list_prepass_enabled) { return; }
   } else {
     if (!pp->delta_flat_prepass_enabled) { return; }
   }
@@ -1396,14 +1430,17 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
 
-  bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
-  bool const process_nulls  = should_process_nulls(s);
-  auto const* const prepass_nz_idx =
-    use_nested_prepass_t ? pp->nested_prepass_nz_idx : pp->flat_prepass_nz_idx;
-  int const prepass_nz_count =
-    use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->flat_prepass_nz_count;
-  if (has_repetition || (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) ||
-      prepass_nz_count < 0 || (process_nulls && prepass_nz_idx == nullptr)) {
+  bool const has_repetition        = s->setup.col.max_level[level_type::REPETITION] > 0;
+  bool const process_nulls         = should_process_nulls(s);
+  auto const* const prepass_nz_idx = use_nested_prepass_t ? pp->nested_prepass_nz_idx
+                                     : use_list_prepass_t ? pp->list_prepass_nz_idx
+                                                          : pp->flat_prepass_nz_idx;
+  int const prepass_nz_count       = use_nested_prepass_t ? pp->nested_prepass_nz_count
+                                     : use_list_prepass_t ? pp->list_prepass_nz_count
+                                                          : pp->flat_prepass_nz_count;
+  if ((!use_list_prepass_t && has_repetition) ||
+      (use_nested_prepass_t && s->setup.col.max_nesting_depth <= 1) || prepass_nz_count < 0 ||
+      (process_nulls && prepass_nz_idx == nullptr)) {
     return;
   }
 
@@ -1413,12 +1450,14 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   uint32_t const skipped_leaf_values             = s->setup.page.skipped_leaf_values;
 
   if (block.thread_rank() == 0) {
-    auto& ni = s->nesting.nesting_info[leaf_level_index];
-    auto const prefix_valid =
-      process_nulls
-        ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
-        : static_cast<int>(s->setup.first_row);
-    ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
+    if constexpr (!use_list_prepass_t) {
+      auto& ni = s->nesting.nesting_info[leaf_level_index];
+      auto const prefix_valid =
+        process_nulls
+          ? flat_prepass_valid_count_before(prepass_nz_idx, prepass_nz_count, s->setup.first_row)
+          : static_cast<int>(s->setup.first_row);
+      ni.null_count = process_nulls ? s->setup.num_rows - (prepass_nz_count - prefix_valid) : 0;
+    }
     s->progress.input_value_count = s->setup.num_input_values;
     s->progress.nz_count          = prepass_nz_count;
     string_offset                 = 0;
@@ -1436,8 +1475,11 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   auto const is_bounds_pg =
     is_bounds_page(s->setup.page, s->setup.col.start_row, min_row, num_rows, has_repetition);
-  bool const is_skip_resume = is_bounds_pg && s->setup.page.start_val > 0;
-  uint32_t const batch_size = min(db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
+  bool const is_skip_resume   = is_bounds_pg && s->setup.page.start_val > 0;
+  bool const resumes_mid_page = is_skip_resume && has_repetition;
+  uint32_t const batch_size =
+    resumes_mid_page ? cudf::detail::warp_size
+                     : min(db->values_per_mb, static_cast<uint32_t>(delta_max_batch_size));
   uint32_t const passes_per_batch = batch_size / cudf::detail::warp_size;
   if (is_skip_resume) {
     if (warp.meta_group_rank() == 0) {
@@ -1445,13 +1487,17 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
       warp.sync();
       if (warp.thread_rank() == 0) {
         string_offset = string_off;
-        db->init_binary_block(s->stream.data_start, s->stream.data_end);
+        // Flat pages still decode the whole page after deriving the byte offset,
+        // whereas repetition-level pages resume the length stream at start_val.
+        // Reinitializing the latter makes the first selected list element consume
+        // the first page length, truncating every selected string after a slice.
+        if (!has_repetition) { db->init_binary_block(s->stream.data_start, s->stream.data_end); }
       }
     }
     block.sync();
   }
 
-  int string_pos = 0;
+  int string_pos = has_repetition ? s->setup.page.start_val : 0;
   while (!s->setup.error && s->progress.src_pos < s->progress.nz_count) {
     uint32_t const src_pos    = s->progress.src_pos;
     uint32_t const target_pos = min(s->progress.nz_count, src_pos + batch_size);
@@ -1486,18 +1532,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     block.sync();
   }
 
-  if constexpr (use_nested_prepass_t) {
+  if constexpr (use_nested_prepass_t || use_list_prepass_t) {
     if (block.thread_rank() == 0) {
       for (int depth = 0; depth < s->setup.page.nesting_info_size; ++depth) {
-        auto const& source                              = pp->nested_prepass_nesting[depth];
+        auto const& source = use_nested_prepass_t ? pp->nested_prepass_nesting[depth]
+                                                  : pp->list_prepass_nesting[depth];
         s->nesting.nesting_info[depth].null_count       = source.null_count;
         s->nesting.nesting_info[depth].valid_map_offset = source.valid_map_offset;
         s->nesting.nesting_info[depth].valid_count      = source.valid_count;
         s->nesting.nesting_info[depth].value_count      = source.value_count;
       }
-      s->progress.nz_count          = pp->nested_prepass_nz_count;
-      s->progress.input_value_count = pp->nested_prepass_input_value_count;
-      s->progress.input_row_count   = pp->nested_prepass_input_row_count;
+      s->progress.nz_count =
+        use_nested_prepass_t ? pp->nested_prepass_nz_count : pp->list_prepass_nz_count;
+      s->progress.input_value_count = use_nested_prepass_t ? pp->nested_prepass_input_value_count
+                                                           : pp->list_prepass_input_value_count;
+      s->progress.input_row_count   = use_nested_prepass_t ? pp->nested_prepass_input_row_count
+                                                           : pp->list_prepass_input_row_count;
     }
     block.sync();
   } else if (block.thread_rank() == 0) {
@@ -1513,18 +1563,21 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   auto const& ni = nesting_info_base[leaf_level_index];
   if (ni.valid_map != nullptr) {
+    int const num_values = (use_nested_prepass_t || use_list_prepass_t)
+                             ? ni.valid_map_offset - init_valid_map_offset
+                             : s->setup.num_rows;
     zero_fill_null_positions_shared<decode_block_size>(s,
                                                        sizeof(size_type),
                                                        init_valid_map_offset,
-                                                       s->setup.num_rows,
+                                                       num_values,
                                                        static_cast<int>(block.thread_rank()));
   }
   if (s->setup.col.is_large_string_col) {
     auto const chunks_per_rowgroup = initial_str_offsets.size();
     auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
-    compute_initial_large_strings_offset<false>(s, initial_str_offsets[input_col_idx]);
+    compute_initial_large_strings_offset<use_list_prepass_t>(s, initial_str_offsets[input_col_idx]);
   } else {
-    convert_small_string_lengths_to_offsets<decode_block_size, false>(s);
+    convert_small_string_lengths_to_offsets<decode_block_size, use_list_prepass_t>(s);
   }
   auto const dst = nesting_info_base[leaf_level_index].string_out;
   auto const src = page_string_data + string_offset;
@@ -1546,7 +1599,8 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          kernel_error::pointer error_code,
                          cuda::stream_ref stream,
                          bool use_flat_prepass,
-                         bool use_nested_prepass)
+                         bool use_nested_prepass,
+                         bool use_list_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1573,8 +1627,20 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
     }
     CUDF_CUDA_TRY(cudaGetLastError());
   }
+  if (use_list_prepass) {
+    if (level_type_size == 1) {
+      decode_delta_binary_kernel_prepass<uint8_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    } else {
+      decode_delta_binary_kernel_prepass<uint16_t, false, true>
+        <<<dim_grid, dim_block, 0, stream.get()>>>(
+          pages.device_ptr(), chunks, min_row, num_rows, page_mask, error_code);
+    }
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
 
-  if (use_flat_prepass || use_nested_prepass) {
+  if (use_flat_prepass || use_nested_prepass || use_list_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid          = (pages.size() + filter_block_size - 1) / filter_block_size;
@@ -1607,7 +1673,8 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              kernel_error::pointer error_code,
                              cuda::stream_ref stream,
                              bool use_flat_prepass,
-                             bool use_nested_prepass)
+                             bool use_nested_prepass,
+                             bool use_list_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1624,7 +1691,13 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
       pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
-  if (use_flat_prepass || use_nested_prepass) {
+  if (use_list_prepass) {
+    decode_delta_byte_array_kernel_flat_prepass<false, true>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
+  if (use_flat_prepass || use_nested_prepass || use_list_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid =
@@ -1659,7 +1732,8 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     kernel_error::pointer error_code,
                                     cuda::stream_ref stream,
                                     bool use_flat_prepass,
-                                    bool use_nested_prepass)
+                                    bool use_nested_prepass,
+                                    bool use_list_prepass)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
 
@@ -1678,7 +1752,13 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
         pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
-  if (use_flat_prepass || use_nested_prepass) {
+  if (use_list_prepass) {
+    decode_delta_length_byte_array_kernel_flat_prepass<false, true>
+      <<<dim_grid, dim_block, 0, stream.get()>>>(
+        pages.device_ptr(), chunks, min_row, num_rows, page_mask, initial_str_offsets, error_code);
+    CUDF_CUDA_TRY(cudaGetLastError());
+  }
+  if (use_flat_prepass || use_nested_prepass || use_list_prepass) {
     rmm::device_uvector<bool> legacy_page_mask(pages.size(), stream);
     constexpr int filter_block_size = 256;
     auto const filter_grid =

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -17,6 +17,7 @@
 #include <cudf/io/detail/codec.hpp>
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/export.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -260,6 +261,39 @@ enum class decode_kernel_mask {
   DICT_INT32               = (1 << 26),  // Run decode kernel for dict string → INT32 indices
 };
 
+/** @brief Mutually exclusive consumer families used by the temporary prepass selector. */
+enum class level_prepass_family : uint16_t {
+  NONE,
+  GENERIC_FLAT,
+  LEGACY_FLAT,
+  DELTA_FLAT,
+  GENERIC_NESTED,
+  LEGACY_NESTED,
+  DELTA_NESTED,
+  GENERIC_LIST,
+  LEGACY_LIST,
+  DELTA_LIST,
+};
+
+constexpr uint32_t level_prepass_generic_flat   = 0x001;
+constexpr uint32_t level_prepass_legacy_flat    = 0x002;
+constexpr uint32_t level_prepass_delta_flat     = 0x004;
+constexpr uint32_t level_prepass_generic_nested = 0x008;
+constexpr uint32_t level_prepass_legacy_nested  = 0x010;
+constexpr uint32_t level_prepass_delta_nested   = 0x020;
+constexpr uint32_t level_prepass_generic_list   = 0x040;
+constexpr uint32_t level_prepass_legacy_list    = 0x080;
+constexpr uint32_t level_prepass_delta_list     = 0x100;
+constexpr uint32_t level_prepass_all            = 0x1ff;
+
+/**
+ * @brief Read the temporary Parquet level-prepass selector from the environment.
+ *
+ * This is an internal rollout control. Until a family is migrated, its bit is
+ * intentionally inert and the legacy decoder remains selected.
+ */
+CUDF_EXPORT [[nodiscard]] uint32_t level_prepass_mode_from_environment();
+
 constexpr uint32_t STRINGS_MASK_NON_DELTA = BitOr(decode_kernel_mask::STRING,
                                                   decode_kernel_mask::STRING_NESTED,
                                                   decode_kernel_mask::STRING_LIST,
@@ -400,6 +434,7 @@ struct PageInfo {
   // while doing chunked reads, persist the value from the page index here.
   int32_t str_bytes_from_index;
   decode_kernel_mask kernel_mask;
+  level_prepass_family prepass_family{level_prepass_family::NONE};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -446,6 +446,7 @@ struct PageInfo {
   // True when the GENERAL/BYTE_STREAM_SPLIT flat consumer is selected by the
   // temporary dual-path level-prepass selector.
   bool legacy_flat_prepass_enabled{};
+  bool delta_flat_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1078,7 +1079,8 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          int level_type_size,
                          cudf::device_span<bool const> page_mask,
                          kernel_error::pointer error_code,
-                         cuda::stream_ref stream);
+                         cuda::stream_ref stream,
+                         bool use_flat_prepass = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_BYTE_ARRAY column data stored in the pages
@@ -1104,7 +1106,8 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              cudf::device_span<bool const> page_mask,
                              cudf::device_span<size_t> initial_str_offsets,
                              kernel_error::pointer error_code,
-                             cuda::stream_ref stream);
+                             cuda::stream_ref stream,
+                             bool use_flat_prepass = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_LENGTH_BYTE_ARRAY column data stored in the pages
@@ -1130,7 +1133,8 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     cudf::device_span<bool const> page_mask,
                                     cudf::device_span<size_t> initial_str_offsets,
                                     kernel_error::pointer error_code,
-                                    cuda::stream_ref stream);
+                                    cuda::stream_ref stream,
+                                    bool use_flat_prepass = false);
 
 /**
  * @brief Launches pre-processing kernel to fill string offsets for non-dictionary columns

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -333,6 +333,13 @@ constexpr uint32_t GENERIC_LIST_LEVEL_PREPASS_MASK =
         decode_kernel_mask::STRING_DICT_LIST,
         decode_kernel_mask::STRING_STREAM_SPLIT_LIST);
 
+/** @brief GENERAL and BYTE_STREAM_SPLIT list pages covered by the list prepass. */
+constexpr uint32_t LEGACY_LIST_LEVEL_PREPASS_MASK =
+  BitOr(decode_kernel_mask::GENERAL, decode_kernel_mask::BYTE_STREAM_SPLIT);
+
+constexpr uint32_t LIST_LEVEL_PREPASS_MASK =
+  BitOr(GENERIC_LIST_LEVEL_PREPASS_MASK, LEGACY_LIST_LEVEL_PREPASS_MASK);
+
 /**
  * @brief Nesting information specifically needed by the decode and preprocessing
  * kernels.
@@ -507,6 +514,7 @@ struct PageInfo {
   int32_t list_prepass_input_value_count{};
   int32_t list_prepass_input_row_count{};
   bool generic_list_prepass_enabled{};
+  bool legacy_list_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1079,7 +1087,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
                       bool use_flat_prepass   = false,
-                      bool use_nested_prepass = false);
+                      bool use_nested_prepass = false,
+                      bool use_list_prepass   = false);
 
 /**
  * @brief Launches kernel for reading the BYTE_STREAM_SPLIT column data stored in the pages
@@ -1105,7 +1114,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             kernel_error::pointer error_code,
                             cuda::stream_ref stream,
                             bool use_flat_prepass   = false,
-                            bool use_nested_prepass = false);
+                            bool use_nested_prepass = false,
+                            bool use_list_prepass   = false);
 
 /**
  * @brief Writes the final offsets to the corresponding list and string buffer end addresses in a

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -337,6 +337,11 @@ constexpr uint32_t GENERIC_LIST_LEVEL_PREPASS_MASK =
 constexpr uint32_t LEGACY_LIST_LEVEL_PREPASS_MASK =
   BitOr(decode_kernel_mask::GENERAL, decode_kernel_mask::BYTE_STREAM_SPLIT);
 
+/** @brief Delta list decoder masks covered by the opt-in list prepass. */
+constexpr uint32_t DELTA_LIST_LEVEL_PREPASS_MASK = BitOr(decode_kernel_mask::DELTA_BINARY,
+                                                         decode_kernel_mask::DELTA_BYTE_ARRAY,
+                                                         decode_kernel_mask::DELTA_LENGTH_BA);
+
 constexpr uint32_t LIST_LEVEL_PREPASS_MASK =
   BitOr(GENERIC_LIST_LEVEL_PREPASS_MASK, LEGACY_LIST_LEVEL_PREPASS_MASK);
 
@@ -493,6 +498,7 @@ struct PageInfo {
   bool legacy_flat_prepass_enabled{};
   bool delta_flat_prepass_enabled{};
   bool delta_nested_prepass_enabled{};
+  bool delta_list_prepass_enabled{};
 
   // Temporary page-global state for the opt-in generic non-list nested
   // prepass. A null nesting pointer denotes legacy nested dispatch.
@@ -1153,7 +1159,8 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          kernel_error::pointer error_code,
                          cuda::stream_ref stream,
                          bool use_flat_prepass   = false,
-                         bool use_nested_prepass = false);
+                         bool use_nested_prepass = false,
+                         bool use_list_prepass   = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_BYTE_ARRAY column data stored in the pages
@@ -1181,7 +1188,8 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              kernel_error::pointer error_code,
                              cuda::stream_ref stream,
                              bool use_flat_prepass   = false,
-                             bool use_nested_prepass = false);
+                             bool use_nested_prepass = false,
+                             bool use_list_prepass   = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_LENGTH_BYTE_ARRAY column data stored in the pages
@@ -1209,7 +1217,8 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     kernel_error::pointer error_code,
                                     cuda::stream_ref stream,
                                     bool use_flat_prepass   = false,
-                                    bool use_nested_prepass = false);
+                                    bool use_nested_prepass = false,
+                                    bool use_list_prepass   = false);
 
 /**
  * @brief Launches pre-processing kernel to fill string offsets for non-dictionary columns

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -323,6 +323,16 @@ constexpr uint32_t NESTED_GENERIC_LEVEL_PREPASS_MASK =
 constexpr uint32_t NESTED_LEGACY_LEVEL_PREPASS_MASK =
   BitOr(decode_kernel_mask::GENERAL, decode_kernel_mask::BYTE_STREAM_SPLIT);
 
+/** @brief Generic list decoder masks covered by the opt-in list prepass. */
+constexpr uint32_t GENERIC_LIST_LEVEL_PREPASS_MASK =
+  BitOr(decode_kernel_mask::FIXED_WIDTH_NO_DICT_LIST,
+        decode_kernel_mask::FIXED_WIDTH_DICT_LIST,
+        decode_kernel_mask::BYTE_STREAM_SPLIT_FIXED_WIDTH_LIST,
+        decode_kernel_mask::BOOLEAN_LIST,
+        decode_kernel_mask::STRING_LIST,
+        decode_kernel_mask::STRING_DICT_LIST,
+        decode_kernel_mask::STRING_STREAM_SPLIT_LIST);
+
 /**
  * @brief Nesting information specifically needed by the decode and preprocessing
  * kernels.
@@ -487,6 +497,16 @@ struct PageInfo {
   int32_t nested_prepass_input_row_count{};
   bool nested_prepass_enabled{};
   bool legacy_nested_prepass_enabled{};
+
+  // Temporary page-global state for the opt-in generic list prepass.
+  // The map preserves the legacy valid-rank-to-output-position contract,
+  // including rows suppressed by a nullable ancestor of a required leaf.
+  uint32_t* list_prepass_nz_idx{};
+  PageNestingPrepassState* list_prepass_nesting{};
+  int32_t list_prepass_nz_count{-1};
+  int32_t list_prepass_input_value_count{};
+  int32_t list_prepass_input_row_count{};
+  bool generic_list_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1246,6 +1266,15 @@ void precompute_nested_level_state(cudf::detail::hostdevice_span<PageInfo> pages
                                    int level_type_size,
                                    cuda::stream_ref stream);
 
+/** @brief Publish opt-in generic list level state. */
+void precompute_list_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                 cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                 cudf::device_span<bool const> page_mask,
+                                 size_t min_row,
+                                 size_t num_rows,
+                                 int level_type_size,
+                                 cuda::stream_ref stream);
+
 /**
  * @brief Fills output offset entries for pruned string and list pages
  *
@@ -1295,7 +1324,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
                       bool use_flat_prepass   = false,
-                      bool use_nested_prepass = false);
+                      bool use_nested_prepass = false,
+                      bool use_list_prepass   = false);
 
 /**
  * @brief Launches kernel for initializing encoder row group fragments

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -309,6 +309,16 @@ constexpr uint32_t STRINGS_MASK = BitOr(decode_kernel_mask::DELTA_BYTE_ARRAY,
                                         decode_kernel_mask::DELTA_LENGTH_BA,
                                         STRINGS_MASK_NON_DELTA);
 
+/** @brief Generic non-list nested decoder masks covered by the nested prepass. */
+constexpr uint32_t NESTED_GENERIC_LEVEL_PREPASS_MASK =
+  BitOr(decode_kernel_mask::FIXED_WIDTH_NO_DICT_NESTED,
+        decode_kernel_mask::FIXED_WIDTH_DICT_NESTED,
+        decode_kernel_mask::BYTE_STREAM_SPLIT_FIXED_WIDTH_NESTED,
+        decode_kernel_mask::BOOLEAN_NESTED,
+        decode_kernel_mask::STRING_NESTED,
+        decode_kernel_mask::STRING_DICT_NESTED,
+        decode_kernel_mask::STRING_STREAM_SPLIT_NESTED);
+
 /**
  * @brief Nesting information specifically needed by the decode and preprocessing
  * kernels.
@@ -337,6 +347,20 @@ struct PageNestingDecodeInfo {
   uint8_t* data_out;
   uint8_t* string_out;
   bitmask_type* valid_map;
+};
+
+/**
+ * @brief Decode-local nesting counters published by the nested level prepass.
+ *
+ * The prepass does not own setup pointers or schema metadata.  A selected
+ * value decoder still obtains those from `setup_local_page_info`; it restores
+ * only these counters before consuming the page-global valid-rank map.
+ */
+struct PageNestingPrepassState {
+  int32_t null_count;
+  int32_t valid_map_offset;
+  int32_t valid_count;
+  int32_t value_count;
 };
 
 // Use up to 512 bytes of shared memory as a cache for nesting information.
@@ -447,6 +471,16 @@ struct PageInfo {
   // temporary dual-path level-prepass selector.
   bool legacy_flat_prepass_enabled{};
   bool delta_flat_prepass_enabled{};
+
+  // Temporary page-global state for the opt-in generic non-list nested
+  // prepass. A null nesting pointer denotes legacy nested dispatch.
+  uint32_t* nested_prepass_nz_idx{};
+  PageNestingPrepassState* nested_prepass_nesting{};
+  int32_t nested_prepass_prefix_valid_count{-1};
+  int32_t nested_prepass_nz_count{-1};
+  int32_t nested_prepass_input_value_count{};
+  int32_t nested_prepass_input_row_count{};
+  bool nested_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1192,6 +1226,15 @@ void precompute_flat_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
                                  int level_type_size,
                                  cuda::stream_ref stream);
 
+/** @brief Publish opt-in generic non-list nested level state. */
+void precompute_nested_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                   cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                   cudf::device_span<bool const> page_mask,
+                                   size_t min_row,
+                                   size_t num_rows,
+                                   int level_type_size,
+                                   cuda::stream_ref stream);
+
 /**
  * @brief Fills output offset entries for pruned string and list pages
  *
@@ -1240,7 +1283,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<size_t const> page_string_offset_indices,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
-                      bool use_flat_prepass = false);
+                      bool use_flat_prepass   = false,
+                      bool use_nested_prepass = false);
 
 /**
  * @brief Launches kernel for initializing encoder row group fragments

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -443,6 +443,9 @@ struct PageInfo {
   int32_t flat_prepass_prefix_valid_count{-1};
   int32_t flat_prepass_null_count{};
   bool flat_prepass_enabled{};
+  // True when the GENERAL/BYTE_STREAM_SPLIT flat consumer is selected by the
+  // temporary dual-path level-prepass selector.
+  bool legacy_flat_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1013,7 +1016,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       int level_type_size,
                       cudf::device_span<bool const> page_mask,
                       kernel_error::pointer error_code,
-                      cuda::stream_ref stream);
+                      cuda::stream_ref stream,
+                      bool use_flat_prepass = false);
 
 /**
  * @brief Launches kernel for reading the BYTE_STREAM_SPLIT column data stored in the pages
@@ -1037,7 +1041,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             int level_type_size,
                             cudf::device_span<bool const> page_mask,
                             kernel_error::pointer error_code,
-                            cuda::stream_ref stream);
+                            cuda::stream_ref stream,
+                            bool use_flat_prepass = false);
 
 /**
  * @brief Writes the final offsets to the corresponding list and string buffer end addresses in a

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -475,6 +475,7 @@ struct PageInfo {
   // temporary dual-path level-prepass selector.
   bool legacy_flat_prepass_enabled{};
   bool delta_flat_prepass_enabled{};
+  bool delta_nested_prepass_enabled{};
 
   // Temporary page-global state for the opt-in generic non-list nested
   // prepass. A null nesting pointer denotes legacy nested dispatch.
@@ -1121,7 +1122,8 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          cudf::device_span<bool const> page_mask,
                          kernel_error::pointer error_code,
                          cuda::stream_ref stream,
-                         bool use_flat_prepass = false);
+                         bool use_flat_prepass   = false,
+                         bool use_nested_prepass = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_BYTE_ARRAY column data stored in the pages
@@ -1148,7 +1150,8 @@ void decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
                              cudf::device_span<size_t> initial_str_offsets,
                              kernel_error::pointer error_code,
                              cuda::stream_ref stream,
-                             bool use_flat_prepass = false);
+                             bool use_flat_prepass   = false,
+                             bool use_nested_prepass = false);
 
 /**
  * @brief Launches kernel for reading the DELTA_LENGTH_BYTE_ARRAY column data stored in the pages
@@ -1175,7 +1178,8 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
                                     cudf::device_span<size_t> initial_str_offsets,
                                     kernel_error::pointer error_code,
                                     cuda::stream_ref stream,
-                                    bool use_flat_prepass = false);
+                                    bool use_flat_prepass   = false,
+                                    bool use_nested_prepass = false);
 
 /**
  * @brief Launches pre-processing kernel to fill string offsets for non-dictionary columns

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -436,6 +436,14 @@ struct PageInfo {
   decode_kernel_mask kernel_mask;
   level_prepass_family prepass_family{level_prepass_family::NONE};
 
+  // Temporary page-global state for the opt-in generic flat level prepass.
+  // A null map denotes either legacy dispatch or the required-column identity path.
+  uint32_t* flat_prepass_nz_idx{};
+  int32_t flat_prepass_nz_count{-1};
+  int32_t flat_prepass_prefix_valid_count{-1};
+  int32_t flat_prepass_null_count{};
+  bool flat_prepass_enabled{};
+
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
   uint8_t flags;              // PAGEINFO_FLAGS_XXX
@@ -1166,6 +1174,15 @@ void preprocess_levels(cudf::detail::hostdevice_span<PageInfo> pages,
                        int level_type_size,
                        cuda::stream_ref stream);
 
+/** @brief Publish opt-in generic-flat validity and rank state from decoded levels. */
+void precompute_flat_level_state(cudf::detail::hostdevice_span<PageInfo> pages,
+                                 cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                 cudf::device_span<bool const> page_mask,
+                                 size_t min_row,
+                                 size_t num_rows,
+                                 int level_type_size,
+                                 cuda::stream_ref stream);
+
 /**
  * @brief Fills output offset entries for pruned string and list pages
  *
@@ -1213,7 +1230,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<size_t> initial_str_offsets,
                       cudf::device_span<size_t const> page_string_offset_indices,
                       kernel_error::pointer error_code,
-                      cuda::stream_ref stream);
+                      cuda::stream_ref stream,
+                      bool use_flat_prepass = false);
 
 /**
  * @brief Launches kernel for initializing encoder row group fragments

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -319,6 +319,10 @@ constexpr uint32_t NESTED_GENERIC_LEVEL_PREPASS_MASK =
         decode_kernel_mask::STRING_DICT_NESTED,
         decode_kernel_mask::STRING_STREAM_SPLIT_NESTED);
 
+/** @brief Legacy page-data decoder masks covered by the nested prepass. */
+constexpr uint32_t NESTED_LEGACY_LEVEL_PREPASS_MASK =
+  BitOr(decode_kernel_mask::GENERAL, decode_kernel_mask::BYTE_STREAM_SPLIT);
+
 /**
  * @brief Nesting information specifically needed by the decode and preprocessing
  * kernels.
@@ -481,6 +485,7 @@ struct PageInfo {
   int32_t nested_prepass_input_value_count{};
   int32_t nested_prepass_input_row_count{};
   bool nested_prepass_enabled{};
+  bool legacy_nested_prepass_enabled{};
 
   bool is_num_rows_adjusted;  // Flag to indicate if the number of rows of this page have been
                               // adjusted to compensate for the list row size estimates.
@@ -1052,7 +1057,8 @@ void decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                       cudf::device_span<bool const> page_mask,
                       kernel_error::pointer error_code,
                       cuda::stream_ref stream,
-                      bool use_flat_prepass = false);
+                      bool use_flat_prepass   = false,
+                      bool use_nested_prepass = false);
 
 /**
  * @brief Launches kernel for reading the BYTE_STREAM_SPLIT column data stored in the pages
@@ -1077,7 +1083,8 @@ void decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
                             cudf::device_span<bool const> page_mask,
                             kernel_error::pointer error_code,
                             cuda::stream_ref stream,
-                            bool use_flat_prepass = false);
+                            bool use_flat_prepass   = false,
+                            bool use_nested_prepass = false);
 
 /**
  * @brief Writes the final offsets to the corresponding list and string buffer end addresses in a

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -229,6 +229,15 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                 level_type_size,
                                 _stream);
   }
+  if ((_level_prepass_mode & level_prepass_generic_nested) != 0) {
+    precompute_nested_level_state(subpass.pages,
+                                  pass.chunks,
+                                  subpass_page_mask_span(),
+                                  skip_rows,
+                                  num_rows,
+                                  level_type_size,
+                                  _stream);
+  }
 
   // get the number of streams we need from the pool and tell them to wait on the H2D copies
   int const nkernels = std::bitset<32>(kernel_mask).count();
@@ -247,6 +256,16 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
       decoder_mask == decode_kernel_mask::DICT_INT32;
     bool const use_flat_prepass =
       flat_generic_mask && (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const nested_generic_mask =
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT_NESTED ||
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_DICT_NESTED ||
+      decoder_mask == decode_kernel_mask::BYTE_STREAM_SPLIT_FIXED_WIDTH_NESTED ||
+      decoder_mask == decode_kernel_mask::BOOLEAN_NESTED ||
+      decoder_mask == decode_kernel_mask::STRING_NESTED ||
+      decoder_mask == decode_kernel_mask::STRING_DICT_NESTED ||
+      decoder_mask == decode_kernel_mask::STRING_STREAM_SPLIT_NESTED;
+    bool const use_nested_prepass =
+      nested_generic_mask && (_level_prepass_mode & level_prepass_generic_nested) != 0;
     detail::decode_page_data(subpass.pages,
                              pass.chunks,
                              num_rows,
@@ -258,7 +277,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              subpass.page_string_offset_indices,
                              error_code.data(),
                              streams[s_idx++],
-                             use_flat_prepass);
+                             use_flat_prepass,
+                             use_nested_prepass);
   };
 
   // launch string decoder for plain encoded flat columns

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -229,7 +229,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                 level_type_size,
                                 _stream);
   }
-  if ((_level_prepass_mode & (level_prepass_generic_nested | level_prepass_legacy_nested)) != 0) {
+  if ((_level_prepass_mode & (level_prepass_generic_nested | level_prepass_legacy_nested |
+                              level_prepass_delta_nested)) != 0) {
     precompute_nested_level_state(subpass.pages,
                                   pass.chunks,
                                   subpass_page_mask_span(),
@@ -342,7 +343,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                             initial_str_offsets,
                             error_code.data(),
                             streams[s_idx++],
-                            (_level_prepass_mode & level_prepass_delta_flat) != 0);
+                            (_level_prepass_mode & level_prepass_delta_flat) != 0,
+                            (_level_prepass_mode & level_prepass_delta_nested) != 0);
   }
 
   // launch delta length byte array decoder
@@ -356,7 +358,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                    initial_str_offsets,
                                    error_code.data(),
                                    streams[s_idx++],
-                                   (_level_prepass_mode & level_prepass_delta_flat) != 0);
+                                   (_level_prepass_mode & level_prepass_delta_flat) != 0,
+                                   (_level_prepass_mode & level_prepass_delta_nested) != 0);
   }
 
   // launch delta binary decoder
@@ -369,7 +372,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                         subpass_page_mask_span(),
                         error_code.data(),
                         streams[s_idx++],
-                        (_level_prepass_mode & level_prepass_delta_flat) != 0);
+                        (_level_prepass_mode & level_prepass_delta_flat) != 0,
+                        (_level_prepass_mode & level_prepass_delta_nested) != 0);
   }
 
   // launch byte stream split decoder

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -236,8 +236,16 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   int s_idx = 0;
 
   auto decode_data = [&](decode_kernel_mask decoder_mask) {
-    bool const use_flat_prepass = decoder_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT &&
-                                  (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const flat_generic_mask =
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT ||
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_DICT ||
+      decoder_mask == decode_kernel_mask::BYTE_STREAM_SPLIT_FIXED_WIDTH_FLAT ||
+      decoder_mask == decode_kernel_mask::BOOLEAN || decoder_mask == decode_kernel_mask::STRING ||
+      decoder_mask == decode_kernel_mask::STRING_DICT ||
+      decoder_mask == decode_kernel_mask::STRING_STREAM_SPLIT ||
+      decoder_mask == decode_kernel_mask::DICT_INT32;
+    bool const use_flat_prepass =
+      flat_generic_mask && (_level_prepass_mode & level_prepass_generic_flat) != 0;
     detail::decode_page_data(subpass.pages,
                              pass.chunks,
                              num_rows,

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -239,7 +239,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                   level_type_size,
                                   _stream);
   }
-  if ((_level_prepass_mode & level_prepass_generic_list) != 0) {
+  if ((_level_prepass_mode & (level_prepass_generic_list | level_prepass_legacy_list)) != 0) {
     precompute_list_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),
@@ -422,7 +422,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                            error_code.data(),
                            streams[s_idx++],
                            (_level_prepass_mode & level_prepass_legacy_flat) != 0,
-                           (_level_prepass_mode & level_prepass_legacy_nested) != 0);
+                           (_level_prepass_mode & level_prepass_legacy_nested) != 0,
+                           (_level_prepass_mode & level_prepass_legacy_list) != 0);
   }
 
   // launch fixed width type decoder
@@ -481,7 +482,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              error_code.data(),
                              streams[s_idx++],
                              (_level_prepass_mode & level_prepass_legacy_flat) != 0,
-                             (_level_prepass_mode & level_prepass_legacy_nested) != 0);
+                             (_level_prepass_mode & level_prepass_legacy_nested) != 0,
+                             (_level_prepass_mode & level_prepass_legacy_list) != 0);
   }
 
   // synchronize the streams

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -229,7 +229,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                 level_type_size,
                                 _stream);
   }
-  if ((_level_prepass_mode & level_prepass_generic_nested) != 0) {
+  if ((_level_prepass_mode & (level_prepass_generic_nested | level_prepass_legacy_nested)) != 0) {
     precompute_nested_level_state(subpass.pages,
                                   pass.chunks,
                                   subpass_page_mask_span(),
@@ -397,7 +397,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                            subpass_page_mask_span(),
                            error_code.data(),
                            streams[s_idx++],
-                           (_level_prepass_mode & level_prepass_legacy_flat) != 0);
+                           (_level_prepass_mode & level_prepass_legacy_flat) != 0,
+                           (_level_prepass_mode & level_prepass_legacy_nested) != 0);
   }
 
   // launch fixed width type decoder
@@ -455,7 +456,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              subpass_page_mask_span(),
                              error_code.data(),
                              streams[s_idx++],
-                             (_level_prepass_mode & level_prepass_legacy_flat) != 0);
+                             (_level_prepass_mode & level_prepass_legacy_flat) != 0,
+                             (_level_prepass_mode & level_prepass_legacy_nested) != 0);
   }
 
   // synchronize the streams

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -219,7 +219,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   // create this before we fork streams
   kernel_error error_code(_stream);
 
-  if ((_level_prepass_mode & level_prepass_generic_flat) != 0) {
+  if ((_level_prepass_mode & (level_prepass_generic_flat | level_prepass_legacy_flat)) != 0) {
     precompute_flat_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),
@@ -372,7 +372,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                            level_type_size,
                            subpass_page_mask_span(),
                            error_code.data(),
-                           streams[s_idx++]);
+                           streams[s_idx++],
+                           (_level_prepass_mode & level_prepass_legacy_flat) != 0);
   }
 
   // launch fixed width type decoder
@@ -429,7 +430,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              level_type_size,
                              subpass_page_mask_span(),
                              error_code.data(),
-                             streams[s_idx++]);
+                             streams[s_idx++],
+                             (_level_prepass_mode & level_prepass_legacy_flat) != 0);
   }
 
   // synchronize the streams

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -239,6 +239,15 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                   level_type_size,
                                   _stream);
   }
+  if ((_level_prepass_mode & level_prepass_generic_list) != 0) {
+    precompute_list_level_state(subpass.pages,
+                                pass.chunks,
+                                subpass_page_mask_span(),
+                                skip_rows,
+                                num_rows,
+                                level_type_size,
+                                _stream);
+  }
 
   // get the number of streams we need from the pool and tell them to wait on the H2D copies
   int const nkernels = std::bitset<32>(kernel_mask).count();
@@ -267,6 +276,16 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
       decoder_mask == decode_kernel_mask::STRING_STREAM_SPLIT_NESTED;
     bool const use_nested_prepass =
       nested_generic_mask && (_level_prepass_mode & level_prepass_generic_nested) != 0;
+    bool const list_generic_mask =
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT_LIST ||
+      decoder_mask == decode_kernel_mask::FIXED_WIDTH_DICT_LIST ||
+      decoder_mask == decode_kernel_mask::BYTE_STREAM_SPLIT_FIXED_WIDTH_LIST ||
+      decoder_mask == decode_kernel_mask::BOOLEAN_LIST ||
+      decoder_mask == decode_kernel_mask::STRING_LIST ||
+      decoder_mask == decode_kernel_mask::STRING_DICT_LIST ||
+      decoder_mask == decode_kernel_mask::STRING_STREAM_SPLIT_LIST;
+    bool const use_list_prepass =
+      list_generic_mask && (_level_prepass_mode & level_prepass_generic_list) != 0;
     detail::decode_page_data(subpass.pages,
                              pass.chunks,
                              num_rows,
@@ -279,7 +298,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              error_code.data(),
                              streams[s_idx++],
                              use_flat_prepass,
-                             use_nested_prepass);
+                             use_nested_prepass,
+                             use_list_prepass);
   };
 
   // launch string decoder for plain encoded flat columns

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -41,7 +41,9 @@ uint32_t level_prepass_mode_from_environment()
 {
   constexpr char const* name = "LIBCUDF_PARQUET_LEVEL_PREPASS";
   auto const* value          = std::getenv(name);
-  if (value == nullptr || *value == '\0') { return 0; }
+  // Keep an explicit zero as the temporary rollback mode, but use the
+  // validated page-global prepass for normal reads.
+  if (value == nullptr || *value == '\0') { return level_prepass_all; }
 
   errno           = 0;
   char* end       = nullptr;

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -239,7 +239,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                   level_type_size,
                                   _stream);
   }
-  if ((_level_prepass_mode & (level_prepass_generic_list | level_prepass_legacy_list)) != 0) {
+  if ((_level_prepass_mode &
+       (level_prepass_generic_list | level_prepass_legacy_list | level_prepass_delta_list)) != 0) {
     precompute_list_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),
@@ -364,7 +365,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                             error_code.data(),
                             streams[s_idx++],
                             (_level_prepass_mode & level_prepass_delta_flat) != 0,
-                            (_level_prepass_mode & level_prepass_delta_nested) != 0);
+                            (_level_prepass_mode & level_prepass_delta_nested) != 0,
+                            (_level_prepass_mode & level_prepass_delta_list) != 0);
   }
 
   // launch delta length byte array decoder
@@ -379,7 +381,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                    error_code.data(),
                                    streams[s_idx++],
                                    (_level_prepass_mode & level_prepass_delta_flat) != 0,
-                                   (_level_prepass_mode & level_prepass_delta_nested) != 0);
+                                   (_level_prepass_mode & level_prepass_delta_nested) != 0,
+                                   (_level_prepass_mode & level_prepass_delta_list) != 0);
   }
 
   // launch delta binary decoder
@@ -393,7 +396,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                         error_code.data(),
                         streams[s_idx++],
                         (_level_prepass_mode & level_prepass_delta_flat) != 0,
-                        (_level_prepass_mode & level_prepass_delta_nested) != 0);
+                        (_level_prepass_mode & level_prepass_delta_nested) != 0,
+                        (_level_prepass_mode & level_prepass_delta_list) != 0);
   }
 
   // launch byte stream split decoder

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -219,8 +219,23 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   // create this before we fork streams
   kernel_error error_code(_stream);
 
-  if ((_level_prepass_mode &
-       (level_prepass_generic_flat | level_prepass_legacy_flat | level_prepass_delta_flat)) != 0) {
+  auto const has_selected_flat_prepass =
+    std::any_of(subpass.pages.host_begin(), subpass.pages.host_end(), [](PageInfo const& page) {
+      return page.flat_prepass_enabled || page.legacy_flat_prepass_enabled ||
+             page.delta_flat_prepass_enabled;
+    });
+  auto const has_selected_nested_prepass =
+    std::any_of(subpass.pages.host_begin(), subpass.pages.host_end(), [](PageInfo const& page) {
+      return page.nested_prepass_enabled || page.legacy_nested_prepass_enabled ||
+             page.delta_nested_prepass_enabled;
+    });
+  auto const has_selected_list_prepass =
+    std::any_of(subpass.pages.host_begin(), subpass.pages.host_end(), [](PageInfo const& page) {
+      return page.generic_list_prepass_enabled || page.legacy_list_prepass_enabled ||
+             page.delta_list_prepass_enabled;
+    });
+
+  if (has_selected_flat_prepass) {
     precompute_flat_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),
@@ -229,8 +244,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                 level_type_size,
                                 _stream);
   }
-  if ((_level_prepass_mode & (level_prepass_generic_nested | level_prepass_legacy_nested |
-                              level_prepass_delta_nested)) != 0) {
+  if (has_selected_nested_prepass) {
     precompute_nested_level_state(subpass.pages,
                                   pass.chunks,
                                   subpass_page_mask_span(),
@@ -239,8 +253,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                   level_type_size,
                                   _stream);
   }
-  if ((_level_prepass_mode &
-       (level_prepass_generic_list | level_prepass_legacy_list | level_prepass_delta_list)) != 0) {
+  if (has_selected_list_prepass) {
     precompute_list_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -28,12 +28,31 @@
 #include <cuda/std/tuple>
 
 #include <bitset>
+#include <cerrno>
+#include <cstdlib>
 #include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <utility>
 
 namespace cudf::io::parquet::detail {
+
+uint32_t level_prepass_mode_from_environment()
+{
+  constexpr char const* name = "LIBCUDF_PARQUET_LEVEL_PREPASS";
+  auto const* value          = std::getenv(name);
+  if (value == nullptr || *value == '\0') { return 0; }
+
+  errno           = 0;
+  char* end       = nullptr;
+  auto const base = value[0] == '0' && (value[1] == 'x' || value[1] == 'X') ? 16 : 10;
+  auto parsed     = std::strtoul(value, &end, base);
+  if (errno != 0 || end == value || *end != '\0' || parsed > level_prepass_all) {
+    CUDF_LOG_WARN("Ignoring invalid %s=%s; using legacy Parquet level decode", name, value);
+    return 0;
+  }
+  return static_cast<uint32_t>(parsed);
+}
 
 void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_rows)
 {
@@ -538,6 +557,14 @@ reader_impl::reader_impl(std::size_t chunk_read_limit,
     _output_chunk_read_limit{chunk_read_limit},
     _input_pass_read_limit{pass_read_limit}
 {
+  _level_prepass_mode = level_prepass_mode_from_environment();
+  if (_level_prepass_mode != 0) {
+    CUDF_LOG_INFO(
+      "LIBCUDF_PARQUET_LEVEL_PREPASS resolved to 0x%x; no prepass consumer family "
+      "is enabled in this build",
+      _level_prepass_mode);
+  }
+
   // The direct parquet-dict → DICTIONARY32 transcode fast path only supports single-pass,
   // non-chunked reads.
   if (_options.output_dict_columns and (chunk_read_limit != 0 or pass_read_limit != 0)) {

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -219,7 +219,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   // create this before we fork streams
   kernel_error error_code(_stream);
 
-  if ((_level_prepass_mode & (level_prepass_generic_flat | level_prepass_legacy_flat)) != 0) {
+  if ((_level_prepass_mode &
+       (level_prepass_generic_flat | level_prepass_legacy_flat | level_prepass_delta_flat)) != 0) {
     precompute_flat_level_state(subpass.pages,
                                 pass.chunks,
                                 subpass_page_mask_span(),
@@ -320,7 +321,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                             subpass_page_mask_span(),
                             initial_str_offsets,
                             error_code.data(),
-                            streams[s_idx++]);
+                            streams[s_idx++],
+                            (_level_prepass_mode & level_prepass_delta_flat) != 0);
   }
 
   // launch delta length byte array decoder
@@ -333,7 +335,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                                    subpass_page_mask_span(),
                                    initial_str_offsets,
                                    error_code.data(),
-                                   streams[s_idx++]);
+                                   streams[s_idx++],
+                                   (_level_prepass_mode & level_prepass_delta_flat) != 0);
   }
 
   // launch delta binary decoder
@@ -345,7 +348,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                         level_type_size,
                         subpass_page_mask_span(),
                         error_code.data(),
-                        streams[s_idx++]);
+                        streams[s_idx++],
+                        (_level_prepass_mode & level_prepass_delta_flat) != 0);
   }
 
   // launch byte stream split decoder

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -219,6 +219,16 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   // create this before we fork streams
   kernel_error error_code(_stream);
 
+  if ((_level_prepass_mode & level_prepass_generic_flat) != 0) {
+    precompute_flat_level_state(subpass.pages,
+                                pass.chunks,
+                                subpass_page_mask_span(),
+                                skip_rows,
+                                num_rows,
+                                level_type_size,
+                                _stream);
+  }
+
   // get the number of streams we need from the pool and tell them to wait on the H2D copies
   int const nkernels = std::bitset<32>(kernel_mask).count();
   auto streams       = cudf::detail::fork_streams(_stream, nkernels);
@@ -226,6 +236,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   int s_idx = 0;
 
   auto decode_data = [&](decode_kernel_mask decoder_mask) {
+    bool const use_flat_prepass = decoder_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT &&
+                                  (_level_prepass_mode & level_prepass_generic_flat) != 0;
     detail::decode_page_data(subpass.pages,
                              pass.chunks,
                              num_rows,
@@ -236,7 +248,8 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
                              initial_str_offsets,
                              subpass.page_string_offset_indices,
                              error_code.data(),
-                             streams[s_idx++]);
+                             streams[s_idx++],
+                             use_flat_prepass);
   };
 
   // launch string decoder for plain encoded flat columns

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -602,6 +602,11 @@ class reader_impl {
   // Per-input-column flag indicating whether that column was selected for direct
   // Parquet-dict → DICTIONARY32 transcode.
   std::vector<bool> _dict_transcode_eligible;
+
+  // Snapshot of the internal LIBCUDF_PARQUET_LEVEL_PREPASS selector. This is
+  // fixed for the reader lifetime so every pass and output chunk agrees on
+  // which (future) prepass consumer families may be selected.
+  uint32_t _level_prepass_mode{0};
 };
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/reader_impl_chunking.hpp
+++ b/cpp/src/io/parquet/reader_impl_chunking.hpp
@@ -81,6 +81,7 @@ struct subpass_intermediate_data {
   subpass_intermediate_data(cuda::stream_ref stream)
     : decomp_page_data(0, stream),
       level_decode_data(0, stream),
+      flat_prepass_data(0, stream),
       page_buf(0, stream),
       page_src_index{0, stream},
       page_string_offset_indices(0, stream),
@@ -94,6 +95,7 @@ struct subpass_intermediate_data {
   rmm::device_buffer decomp_page_data;
 
   rmm::device_buffer level_decode_data;
+  rmm::device_buffer flat_prepass_data;
   cudf::detail::hostdevice_span<PageInfo> pages{};
 
   cudf::detail::hostdevice_vector<PageInfo> page_buf;

--- a/cpp/src/io/parquet/reader_impl_chunking.hpp
+++ b/cpp/src/io/parquet/reader_impl_chunking.hpp
@@ -83,6 +83,7 @@ struct subpass_intermediate_data {
       level_decode_data(0, stream),
       flat_prepass_data(0, stream),
       nested_prepass_data(0, stream),
+      list_prepass_data(0, stream),
       page_buf(0, stream),
       page_src_index{0, stream},
       page_string_offset_indices(0, stream),
@@ -98,6 +99,7 @@ struct subpass_intermediate_data {
   rmm::device_buffer level_decode_data;
   rmm::device_buffer flat_prepass_data;
   rmm::device_buffer nested_prepass_data;
+  rmm::device_buffer list_prepass_data;
   cudf::detail::hostdevice_span<PageInfo> pages{};
 
   cudf::detail::hostdevice_vector<PageInfo> page_buf;

--- a/cpp/src/io/parquet/reader_impl_chunking.hpp
+++ b/cpp/src/io/parquet/reader_impl_chunking.hpp
@@ -82,6 +82,7 @@ struct subpass_intermediate_data {
     : decomp_page_data(0, stream),
       level_decode_data(0, stream),
       flat_prepass_data(0, stream),
+      nested_prepass_data(0, stream),
       page_buf(0, stream),
       page_src_index{0, stream},
       page_string_offset_indices(0, stream),
@@ -96,6 +97,7 @@ struct subpass_intermediate_data {
 
   rmm::device_buffer level_decode_data;
   rmm::device_buffer flat_prepass_data;
+  rmm::device_buffer nested_prepass_data;
   cudf::detail::hostdevice_span<PageInfo> pages{};
 
   cudf::detail::hostdevice_vector<PageInfo> page_buf;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -389,18 +389,23 @@ void reader_impl::allocate_level_decode_space()
   // allocation.
   size_t flat_prepass_size = 0;
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page          = pages[idx];
-    auto const& chunk   = pass.chunks[page.chunk_idx];
-    bool const enabled  = (_level_prepass_mode & level_prepass_generic_flat) != 0;
-    bool const optional = chunk.max_level[level_type::DEFINITION] != 0;
+    auto& page                 = pages[idx];
+    auto const& chunk          = pass.chunks[page.chunk_idx];
+    bool const generic_enabled = (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const legacy_enabled  = (_level_prepass_mode & level_prepass_legacy_flat) != 0;
+    bool const optional        = chunk.max_level[level_type::DEFINITION] != 0;
     bool const selected_generic_flat =
-      enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT;
+      generic_enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT;
+    bool const selected_legacy_flat =
+      legacy_enabled && page.prepass_family == level_prepass_family::LEGACY_FLAT;
+    bool const selected_flat             = selected_generic_flat || selected_legacy_flat;
     page.flat_prepass_nz_idx             = nullptr;
-    page.flat_prepass_nz_count           = selected_generic_flat ? -2 : -1;
+    page.flat_prepass_nz_count           = selected_flat ? -2 : -1;
     page.flat_prepass_prefix_valid_count = -1;
     page.flat_prepass_null_count         = 0;
     page.flat_prepass_enabled            = selected_generic_flat;
-    if (selected_generic_flat && optional) {
+    page.legacy_flat_prepass_enabled     = selected_legacy_flat;
+    if (selected_flat && optional) {
       flat_prepass_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
     }
   }
@@ -408,11 +413,13 @@ void reader_impl::allocate_level_decode_space()
     rmm::device_buffer(flat_prepass_size, _stream, cudf::get_current_device_resource_ref());
   auto* flat_prepass_ptr = static_cast<uint32_t*>(subpass.flat_prepass_data.data());
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page                       = pages[idx];
-    auto const& chunk                = pass.chunks[page.chunk_idx];
-    bool const selected_generic_flat = (_level_prepass_mode & level_prepass_generic_flat) != 0 &&
-                                       page.prepass_family == level_prepass_family::GENERIC_FLAT;
-    if (selected_generic_flat && chunk.max_level[level_type::DEFINITION] != 0) {
+    auto& page               = pages[idx];
+    auto const& chunk        = pass.chunks[page.chunk_idx];
+    bool const selected_flat = (((_level_prepass_mode & level_prepass_generic_flat) != 0 &&
+                                 page.prepass_family == level_prepass_family::GENERIC_FLAT) ||
+                                ((_level_prepass_mode & level_prepass_legacy_flat) != 0 &&
+                                 page.prepass_family == level_prepass_family::LEGACY_FLAT));
+    if (selected_flat && chunk.max_level[level_type::DEFINITION] != 0) {
       page.flat_prepass_nz_idx = flat_prepass_ptr;
       flat_prepass_ptr += page.num_input_values;
     }

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <new>
 #include <numeric>
 #include <utility>
 #include <vector>
@@ -487,6 +488,74 @@ void reader_impl::allocate_level_decode_space()
       }
       page.nested_prepass_nesting = nested_nesting_ptr;
       nested_nesting_ptr += page.nesting_info_size;
+    }
+  }
+
+  // The generic-list prepass owns per-depth counters, offsets, and the
+  // legacy valid-rank-to-output map. The latter is required even for a
+  // required leaf when an optional ancestor suppresses leaf values.
+  // Leave every unselected list page on the legacy level walker.
+  size_t list_prepass_map_size     = 0;
+  size_t list_prepass_nesting_size = 0;
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page          = pages[idx];
+    auto const& chunk   = pass.chunks[page.chunk_idx];
+    bool const selected = (_level_prepass_mode & level_prepass_generic_list) != 0 &&
+                          page.prepass_family == level_prepass_family::GENERIC_LIST &&
+                          chunk.max_level[level_type::REPETITION] > 0;
+    page.list_prepass_nz_idx            = nullptr;
+    page.list_prepass_nesting           = nullptr;
+    page.list_prepass_nz_count          = -1;
+    page.list_prepass_input_value_count = 0;
+    page.list_prepass_input_row_count   = 0;
+    page.generic_list_prepass_enabled   = selected;
+    if (selected) {
+      list_prepass_map_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
+      list_prepass_nesting_size +=
+        static_cast<size_t>(page.nesting_info_size) * sizeof(PageNestingPrepassState);
+    }
+  }
+  auto disable_generic_list_prepass = [&] {
+    list_prepass_map_size     = 0;
+    list_prepass_nesting_size = 0;
+    for (size_t idx = 0; idx < num_pages; ++idx) {
+      pages[idx].generic_list_prepass_enabled = false;
+    }
+  };
+
+  // The dense compatibility map must stay live alongside the output chunk.
+  // Bound its per-subpass footprint so a selected experimental path cannot
+  // crowd out a large, otherwise valid list output allocation.
+  constexpr size_t max_list_prepass_map_bytes{size_t{1} << 30};
+  if (list_prepass_map_size > max_list_prepass_map_bytes) { disable_generic_list_prepass(); }
+
+  auto const list_prepass_size = list_prepass_map_size + list_prepass_nesting_size;
+  try {
+    subpass.list_prepass_data =
+      rmm::device_buffer(list_prepass_size, _stream, cudf::get_current_device_resource_ref());
+  } catch (std::bad_alloc const&) {
+    // A list map is deliberately dense so that it preserves the legacy
+    // valid-rank-to-output-position contract for required leaves below an
+    // optional ancestor.  It can therefore be much larger than the output
+    // itself for a single exceptionally large page.  The selector is an
+    // opt-in compatibility path: leave this subpass on the existing list
+    // walker if its temporary map cannot be accommodated, rather than making
+    // a selected read fail solely because of prepass scratch space.
+    disable_generic_list_prepass();
+    subpass.list_prepass_data =
+      rmm::device_buffer(0, _stream, cudf::get_current_device_resource_ref());
+  }
+  auto* list_prepass_bytes = static_cast<uint8_t*>(subpass.list_prepass_data.data());
+  auto* list_map_ptr       = reinterpret_cast<uint32_t*>(list_prepass_bytes);
+  auto* list_prepass_ptr   = reinterpret_cast<PageNestingPrepassState*>(
+    list_prepass_bytes == nullptr ? nullptr : list_prepass_bytes + list_prepass_map_size);
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page = pages[idx];
+    if (page.generic_list_prepass_enabled) {
+      page.list_prepass_nz_idx = list_map_ptr;
+      list_map_ptr += page.num_input_values;
+      page.list_prepass_nesting = list_prepass_ptr;
+      list_prepass_ptr += page.nesting_info_size;
     }
   }
 }

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -498,17 +498,21 @@ void reader_impl::allocate_level_decode_space()
   size_t list_prepass_map_size     = 0;
   size_t list_prepass_nesting_size = 0;
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page          = pages[idx];
-    auto const& chunk   = pass.chunks[page.chunk_idx];
-    bool const selected = (_level_prepass_mode & level_prepass_generic_list) != 0 &&
-                          page.prepass_family == level_prepass_family::GENERIC_LIST &&
-                          chunk.max_level[level_type::REPETITION] > 0;
+    auto& page                  = pages[idx];
+    auto const& chunk           = pass.chunks[page.chunk_idx];
+    bool const selected_generic = (_level_prepass_mode & level_prepass_generic_list) != 0 &&
+                                  page.prepass_family == level_prepass_family::GENERIC_LIST;
+    bool const selected_legacy = (_level_prepass_mode & level_prepass_legacy_list) != 0 &&
+                                 page.prepass_family == level_prepass_family::LEGACY_LIST;
+    bool const selected =
+      (selected_generic || selected_legacy) && chunk.max_level[level_type::REPETITION] > 0;
     page.list_prepass_nz_idx            = nullptr;
     page.list_prepass_nesting           = nullptr;
     page.list_prepass_nz_count          = -1;
     page.list_prepass_input_value_count = 0;
     page.list_prepass_input_row_count   = 0;
-    page.generic_list_prepass_enabled   = selected;
+    page.generic_list_prepass_enabled   = selected_generic;
+    page.legacy_list_prepass_enabled    = selected_legacy;
     if (selected) {
       list_prepass_map_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
       list_prepass_nesting_size +=
@@ -520,6 +524,7 @@ void reader_impl::allocate_level_decode_space()
     list_prepass_nesting_size = 0;
     for (size_t idx = 0; idx < num_pages; ++idx) {
       pages[idx].generic_list_prepass_enabled = false;
+      pages[idx].legacy_list_prepass_enabled  = false;
     }
   };
 
@@ -551,7 +556,7 @@ void reader_impl::allocate_level_decode_space()
     list_prepass_bytes == nullptr ? nullptr : list_prepass_bytes + list_prepass_map_size);
   for (size_t idx = 0; idx < num_pages; ++idx) {
     auto& page = pages[idx];
-    if (page.generic_list_prepass_enabled) {
+    if (page.generic_list_prepass_enabled || page.legacy_list_prepass_enabled) {
       page.list_prepass_nz_idx = list_map_ptr;
       list_map_ptr += page.num_input_values;
       page.list_prepass_nesting = list_prepass_ptr;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -385,18 +385,16 @@ void reader_impl::allocate_level_decode_space()
       std::max(def_level_sizes[idx], rep_level_sizes[idx]) / pass.level_type_size;
   }
 
-  // Flat strings retain the legacy path until their string-size preprocessing
-  // can consume the same published state. Required pages publish an identity
-  // contract and therefore need no map allocation.
+  // Required pages publish an identity contract and therefore need no map
+  // allocation.
   size_t flat_prepass_size = 0;
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page                       = pages[idx];
-    auto const& chunk                = pass.chunks[page.chunk_idx];
-    bool const enabled               = (_level_prepass_mode & level_prepass_generic_flat) != 0;
-    bool const optional              = chunk.max_level[level_type::DEFINITION] != 0;
-    bool const selected_generic_flat = enabled &&
-                                       page.prepass_family == level_prepass_family::GENERIC_FLAT &&
-                                       BitAnd(page.kernel_mask, STRINGS_MASK) == 0;
+    auto& page          = pages[idx];
+    auto const& chunk   = pass.chunks[page.chunk_idx];
+    bool const enabled  = (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const optional = chunk.max_level[level_type::DEFINITION] != 0;
+    bool const selected_generic_flat =
+      enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT;
     page.flat_prepass_nz_idx             = nullptr;
     page.flat_prepass_nz_count           = selected_generic_flat ? -2 : -1;
     page.flat_prepass_prefix_valid_count = -1;
@@ -413,8 +411,7 @@ void reader_impl::allocate_level_decode_space()
     auto& page                       = pages[idx];
     auto const& chunk                = pass.chunks[page.chunk_idx];
     bool const selected_generic_flat = (_level_prepass_mode & level_prepass_generic_flat) != 0 &&
-                                       page.prepass_family == level_prepass_family::GENERIC_FLAT &&
-                                       BitAnd(page.kernel_mask, STRINGS_MASK) == 0;
+                                       page.prepass_family == level_prepass_family::GENERIC_FLAT;
     if (selected_generic_flat && chunk.max_level[level_type::DEFINITION] != 0) {
       page.flat_prepass_nz_idx = flat_prepass_ptr;
       flat_prepass_ptr += page.num_input_values;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -331,6 +331,10 @@ void reader_impl::allocate_level_decode_space()
   // Loop over pages to compute sizes
   size_t total_memory_size = 0;
   for (size_t idx = 0; idx < num_pages; idx++) {
+    auto& p           = pages[idx];
+    auto const& chunk = pass.chunks[p.chunk_idx];
+    p.prepass_family  = classify_prepass_family(p, chunk);
+
     // Skip pages that are masked out - no need to allocate level decode space for them
     auto const page_mask = subpass_page_mask_span();
     if (!page_mask.is_empty() && !page_mask[idx]) {
@@ -338,9 +342,6 @@ void reader_impl::allocate_level_decode_space()
       rep_level_sizes[idx] = 0;
       continue;
     }
-
-    auto const& p     = pages[idx];
-    auto const& chunk = pass.chunks[p.chunk_idx];
 
     compute_page_level_decode_sizes(p,
                                     chunk,
@@ -382,6 +383,41 @@ void reader_impl::allocate_level_decode_space()
                  "Repetition level size is not a multiple of the level type size");
     pages[idx].num_decoded_level_values =
       std::max(def_level_sizes[idx], rep_level_sizes[idx]) / pass.level_type_size;
+  }
+
+  // PR2 only enables the generic flat, plain fixed-width family. Required
+  // pages publish an identity contract and therefore need no map allocation.
+  size_t flat_prepass_size = 0;
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page                      = pages[idx];
+    auto const& chunk               = pass.chunks[page.chunk_idx];
+    bool const enabled              = (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const optional             = chunk.max_level[level_type::DEFINITION] != 0;
+    bool const is_plain_fixed_width = page.kernel_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT;
+    bool const selected_generic_flat =
+      enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT && is_plain_fixed_width;
+    page.flat_prepass_nz_idx             = nullptr;
+    page.flat_prepass_nz_count           = selected_generic_flat ? -2 : -1;
+    page.flat_prepass_prefix_valid_count = -1;
+    page.flat_prepass_null_count         = 0;
+    page.flat_prepass_enabled            = selected_generic_flat;
+    if (selected_generic_flat && optional) {
+      flat_prepass_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
+    }
+  }
+  subpass.flat_prepass_data =
+    rmm::device_buffer(flat_prepass_size, _stream, cudf::get_current_device_resource_ref());
+  auto* flat_prepass_ptr = static_cast<uint32_t*>(subpass.flat_prepass_data.data());
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page                       = pages[idx];
+    auto const& chunk                = pass.chunks[page.chunk_idx];
+    bool const selected_generic_flat = (_level_prepass_mode & level_prepass_generic_flat) != 0 &&
+                                       page.prepass_family == level_prepass_family::GENERIC_FLAT &&
+                                       page.kernel_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT;
+    if (selected_generic_flat && chunk.max_level[level_type::DEFINITION] != 0) {
+      page.flat_prepass_nz_idx = flat_prepass_ptr;
+      flat_prepass_ptr += page.num_input_values;
+    }
   }
 }
 
@@ -762,10 +798,6 @@ void reader_impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_lim
 
   // figure out which kernels to run
   subpass.kernel_mask = get_aggregated_decode_kernel_mask(subpass.pages, _stream);
-  for (size_t page_idx = 0; page_idx < subpass.pages.size(); ++page_idx) {
-    auto& page          = subpass.pages[page_idx];
-    page.prepass_family = classify_prepass_family(page, pass.chunks[page.chunk_idx]);
-  }
 
   // Decode definition and repetition levels for all subpass pages
   // so they're available to compute_page_sizes and decode kernels.

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -385,17 +385,18 @@ void reader_impl::allocate_level_decode_space()
       std::max(def_level_sizes[idx], rep_level_sizes[idx]) / pass.level_type_size;
   }
 
-  // PR2 only enables the generic flat, plain fixed-width family. Required
-  // pages publish an identity contract and therefore need no map allocation.
+  // Flat strings retain the legacy path until their string-size preprocessing
+  // can consume the same published state. Required pages publish an identity
+  // contract and therefore need no map allocation.
   size_t flat_prepass_size = 0;
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page                      = pages[idx];
-    auto const& chunk               = pass.chunks[page.chunk_idx];
-    bool const enabled              = (_level_prepass_mode & level_prepass_generic_flat) != 0;
-    bool const optional             = chunk.max_level[level_type::DEFINITION] != 0;
-    bool const is_plain_fixed_width = page.kernel_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT;
-    bool const selected_generic_flat =
-      enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT && is_plain_fixed_width;
+    auto& page                       = pages[idx];
+    auto const& chunk                = pass.chunks[page.chunk_idx];
+    bool const enabled               = (_level_prepass_mode & level_prepass_generic_flat) != 0;
+    bool const optional              = chunk.max_level[level_type::DEFINITION] != 0;
+    bool const selected_generic_flat = enabled &&
+                                       page.prepass_family == level_prepass_family::GENERIC_FLAT &&
+                                       BitAnd(page.kernel_mask, STRINGS_MASK) == 0;
     page.flat_prepass_nz_idx             = nullptr;
     page.flat_prepass_nz_count           = selected_generic_flat ? -2 : -1;
     page.flat_prepass_prefix_valid_count = -1;
@@ -413,7 +414,7 @@ void reader_impl::allocate_level_decode_space()
     auto const& chunk                = pass.chunks[page.chunk_idx];
     bool const selected_generic_flat = (_level_prepass_mode & level_prepass_generic_flat) != 0 &&
                                        page.prepass_family == level_prepass_family::GENERIC_FLAT &&
-                                       page.kernel_mask == decode_kernel_mask::FIXED_WIDTH_NO_DICT;
+                                       BitAnd(page.kernel_mask, STRINGS_MASK) == 0;
     if (selected_generic_flat && chunk.max_level[level_type::DEFINITION] != 0) {
       page.flat_prepass_nz_idx = flat_prepass_ptr;
       flat_prepass_ptr += page.num_input_values;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -393,18 +393,22 @@ void reader_impl::allocate_level_decode_space()
     auto const& chunk          = pass.chunks[page.chunk_idx];
     bool const generic_enabled = (_level_prepass_mode & level_prepass_generic_flat) != 0;
     bool const legacy_enabled  = (_level_prepass_mode & level_prepass_legacy_flat) != 0;
+    bool const delta_enabled   = (_level_prepass_mode & level_prepass_delta_flat) != 0;
     bool const optional        = chunk.max_level[level_type::DEFINITION] != 0;
     bool const selected_generic_flat =
       generic_enabled && page.prepass_family == level_prepass_family::GENERIC_FLAT;
     bool const selected_legacy_flat =
       legacy_enabled && page.prepass_family == level_prepass_family::LEGACY_FLAT;
-    bool const selected_flat             = selected_generic_flat || selected_legacy_flat;
-    page.flat_prepass_nz_idx             = nullptr;
+    bool const selected_delta_flat =
+      delta_enabled && page.prepass_family == level_prepass_family::DELTA_FLAT;
+    bool const selected_flat = selected_generic_flat || selected_legacy_flat || selected_delta_flat;
+    page.flat_prepass_nz_idx = nullptr;
     page.flat_prepass_nz_count           = selected_flat ? -2 : -1;
     page.flat_prepass_prefix_valid_count = -1;
     page.flat_prepass_null_count         = 0;
     page.flat_prepass_enabled            = selected_generic_flat;
     page.legacy_flat_prepass_enabled     = selected_legacy_flat;
+    page.delta_flat_prepass_enabled      = selected_delta_flat;
     if (selected_flat && optional) {
       flat_prepass_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
     }
@@ -418,7 +422,9 @@ void reader_impl::allocate_level_decode_space()
     bool const selected_flat = (((_level_prepass_mode & level_prepass_generic_flat) != 0 &&
                                  page.prepass_family == level_prepass_family::GENERIC_FLAT) ||
                                 ((_level_prepass_mode & level_prepass_legacy_flat) != 0 &&
-                                 page.prepass_family == level_prepass_family::LEGACY_FLAT));
+                                 page.prepass_family == level_prepass_family::LEGACY_FLAT) ||
+                                ((_level_prepass_mode & level_prepass_delta_flat) != 0 &&
+                                 page.prepass_family == level_prepass_family::DELTA_FLAT));
     if (selected_flat && chunk.max_level[level_type::DEFINITION] != 0) {
       page.flat_prepass_nz_idx = flat_prepass_ptr;
       flat_prepass_ptr += page.num_input_values;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -41,6 +41,38 @@
 namespace cudf::io::parquet::detail {
 
 namespace {
+
+[[nodiscard]] level_prepass_family classify_prepass_family(PageInfo const& page,
+                                                           ColumnChunkDesc const& chunk)
+{
+  bool const is_list   = chunk.max_level[level_type::REPETITION] > 0;
+  bool const is_nested = !is_list && chunk.max_nesting_depth > 1;
+  bool const is_delta  = BitAnd(page.kernel_mask,
+                               BitOr(decode_kernel_mask::DELTA_BINARY,
+                                     decode_kernel_mask::DELTA_BYTE_ARRAY,
+                                     decode_kernel_mask::DELTA_LENGTH_BA)) != 0;
+  bool const is_legacy =
+    BitAnd(page.kernel_mask,
+           BitOr(decode_kernel_mask::GENERAL, decode_kernel_mask::BYTE_STREAM_SPLIT)) != 0;
+
+  if (is_list) {
+    return is_delta    ? level_prepass_family::DELTA_LIST
+           : is_legacy ? level_prepass_family::LEGACY_LIST
+                       : level_prepass_family::GENERIC_LIST;
+  }
+  if (is_nested) {
+    return is_delta    ? level_prepass_family::DELTA_NESTED
+           : is_legacy ? level_prepass_family::LEGACY_NESTED
+                       : level_prepass_family::GENERIC_NESTED;
+  }
+  return is_delta    ? level_prepass_family::DELTA_FLAT
+         : is_legacy ? level_prepass_family::LEGACY_FLAT
+                     : level_prepass_family::GENERIC_FLAT;
+}
+
+}  // namespace
+
+namespace {
 // Tests the passed in logical type for a FIXED_LENGTH_BYTE_ARRAY column to see if it should
 // be treated as a string. Currently the only logical type that has special handling is DECIMAL.
 // Other valid types in the future would be UUID (still treated as string) and FLOAT16 (which
@@ -730,6 +762,10 @@ void reader_impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_lim
 
   // figure out which kernels to run
   subpass.kernel_mask = get_aggregated_decode_kernel_mask(subpass.pages, _stream);
+  for (size_t page_idx = 0; page_idx < subpass.pages.size(); ++page_idx) {
+    auto& page          = subpass.pages[page_idx];
+    page.prepass_family = classify_prepass_family(page, pass.chunks[page.chunk_idx]);
+  }
 
   // Decode definition and repetition levels for all subpass pages
   // so they're available to compute_page_sizes and decode kernels.

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -430,6 +430,55 @@ void reader_impl::allocate_level_decode_space()
       flat_prepass_ptr += page.num_input_values;
     }
   }
+
+  // Non-list generic nested pages publish their per-depth decode counters and
+  // a dense valid-rank-to-output-position map.  Keep this allocation wholly
+  // separate from flat staging: the selected nested consumer needs the map
+  // through value decoding, while unselected pages retain untouched legacy
+  // nesting state.
+  size_t nested_prepass_map_size     = 0;
+  size_t nested_prepass_nesting_size = 0;
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page                 = pages[idx];
+    auto const& chunk          = pass.chunks[page.chunk_idx];
+    bool const selected_nested = (_level_prepass_mode & level_prepass_generic_nested) != 0 &&
+                                 page.prepass_family == level_prepass_family::GENERIC_NESTED;
+    page.nested_prepass_nz_idx             = nullptr;
+    page.nested_prepass_nesting            = nullptr;
+    page.nested_prepass_prefix_valid_count = -1;
+    page.nested_prepass_nz_count           = -1;
+    page.nested_prepass_input_value_count  = 0;
+    page.nested_prepass_input_row_count    = 0;
+    page.nested_prepass_enabled            = selected_nested;
+    if (selected_nested) {
+      // Required nested leaves have an identity valid-rank mapping. They
+      // still publish per-depth state, but do not retain a redundant map.
+      if (chunk.max_level[level_type::DEFINITION] != 0) {
+        nested_prepass_map_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
+      }
+      nested_prepass_nesting_size +=
+        static_cast<size_t>(page.nesting_info_size) * sizeof(PageNestingPrepassState);
+    }
+  }
+  auto const nested_prepass_size = nested_prepass_map_size + nested_prepass_nesting_size;
+  subpass.nested_prepass_data =
+    rmm::device_buffer(nested_prepass_size, _stream, cudf::get_current_device_resource_ref());
+  auto* nested_prepass_ptr = static_cast<uint8_t*>(subpass.nested_prepass_data.data());
+  auto* nested_map_ptr     = reinterpret_cast<uint32_t*>(nested_prepass_ptr);
+  auto* nested_nesting_ptr = reinterpret_cast<PageNestingPrepassState*>(
+    nested_prepass_ptr == nullptr ? nullptr : nested_prepass_ptr + nested_prepass_map_size);
+  for (size_t idx = 0; idx < num_pages; ++idx) {
+    auto& page = pages[idx];
+    if (page.nested_prepass_enabled) {
+      auto const& chunk = pass.chunks[page.chunk_idx];
+      if (chunk.max_level[level_type::DEFINITION] != 0) {
+        page.nested_prepass_nz_idx = nested_map_ptr;
+        nested_map_ptr += page.num_input_values;
+      }
+      page.nested_prepass_nesting = nested_nesting_ptr;
+      nested_nesting_ptr += page.nesting_info_size;
+    }
+  }
 }
 
 namespace {

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -504,8 +504,10 @@ void reader_impl::allocate_level_decode_space()
                                   page.prepass_family == level_prepass_family::GENERIC_LIST;
     bool const selected_legacy = (_level_prepass_mode & level_prepass_legacy_list) != 0 &&
                                  page.prepass_family == level_prepass_family::LEGACY_LIST;
-    bool const selected =
-      (selected_generic || selected_legacy) && chunk.max_level[level_type::REPETITION] > 0;
+    bool const selected_delta = (_level_prepass_mode & level_prepass_delta_list) != 0 &&
+                                page.prepass_family == level_prepass_family::DELTA_LIST;
+    bool const selected = (selected_generic || selected_legacy || selected_delta) &&
+                          chunk.max_level[level_type::REPETITION] > 0;
     page.list_prepass_nz_idx            = nullptr;
     page.list_prepass_nesting           = nullptr;
     page.list_prepass_nz_count          = -1;
@@ -513,6 +515,7 @@ void reader_impl::allocate_level_decode_space()
     page.list_prepass_input_row_count   = 0;
     page.generic_list_prepass_enabled   = selected_generic;
     page.legacy_list_prepass_enabled    = selected_legacy;
+    page.delta_list_prepass_enabled     = selected_delta;
     if (selected) {
       list_prepass_map_size += static_cast<size_t>(page.num_input_values) * sizeof(uint32_t);
       list_prepass_nesting_size +=
@@ -525,6 +528,7 @@ void reader_impl::allocate_level_decode_space()
     for (size_t idx = 0; idx < num_pages; ++idx) {
       pages[idx].generic_list_prepass_enabled = false;
       pages[idx].legacy_list_prepass_enabled  = false;
+      pages[idx].delta_list_prepass_enabled   = false;
     }
   };
 
@@ -556,7 +560,8 @@ void reader_impl::allocate_level_decode_space()
     list_prepass_bytes == nullptr ? nullptr : list_prepass_bytes + list_prepass_map_size);
   for (size_t idx = 0; idx < num_pages; ++idx) {
     auto& page = pages[idx];
-    if (page.generic_list_prepass_enabled || page.legacy_list_prepass_enabled) {
+    if (page.generic_list_prepass_enabled || page.legacy_list_prepass_enabled ||
+        page.delta_list_prepass_enabled) {
       page.list_prepass_nz_idx = list_map_ptr;
       list_map_ptr += page.num_input_values;
       page.list_prepass_nesting = list_prepass_ptr;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -439,17 +439,22 @@ void reader_impl::allocate_level_decode_space()
   size_t nested_prepass_map_size     = 0;
   size_t nested_prepass_nesting_size = 0;
   for (size_t idx = 0; idx < num_pages; ++idx) {
-    auto& page                 = pages[idx];
-    auto const& chunk          = pass.chunks[page.chunk_idx];
-    bool const selected_nested = (_level_prepass_mode & level_prepass_generic_nested) != 0 &&
-                                 page.prepass_family == level_prepass_family::GENERIC_NESTED;
+    auto& page        = pages[idx];
+    auto const& chunk = pass.chunks[page.chunk_idx];
+    bool const selected_generic_nested =
+      (_level_prepass_mode & level_prepass_generic_nested) != 0 &&
+      page.prepass_family == level_prepass_family::GENERIC_NESTED;
+    bool const selected_legacy_nested = (_level_prepass_mode & level_prepass_legacy_nested) != 0 &&
+                                        page.prepass_family == level_prepass_family::LEGACY_NESTED;
+    bool const selected_nested             = selected_generic_nested || selected_legacy_nested;
     page.nested_prepass_nz_idx             = nullptr;
     page.nested_prepass_nesting            = nullptr;
     page.nested_prepass_prefix_valid_count = -1;
     page.nested_prepass_nz_count           = -1;
     page.nested_prepass_input_value_count  = 0;
     page.nested_prepass_input_row_count    = 0;
-    page.nested_prepass_enabled            = selected_nested;
+    page.nested_prepass_enabled            = selected_generic_nested;
+    page.legacy_nested_prepass_enabled     = selected_legacy_nested;
     if (selected_nested) {
       // Required nested leaves have an identity valid-rank mapping. They
       // still publish per-depth state, but do not retain a redundant map.
@@ -469,7 +474,7 @@ void reader_impl::allocate_level_decode_space()
     nested_prepass_ptr == nullptr ? nullptr : nested_prepass_ptr + nested_prepass_map_size);
   for (size_t idx = 0; idx < num_pages; ++idx) {
     auto& page = pages[idx];
-    if (page.nested_prepass_enabled) {
+    if (page.nested_prepass_enabled || page.legacy_nested_prepass_enabled) {
       auto const& chunk = pass.chunks[page.chunk_idx];
       if (chunk.max_level[level_type::DEFINITION] != 0) {
         page.nested_prepass_nz_idx = nested_map_ptr;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -446,7 +446,10 @@ void reader_impl::allocate_level_decode_space()
       page.prepass_family == level_prepass_family::GENERIC_NESTED;
     bool const selected_legacy_nested = (_level_prepass_mode & level_prepass_legacy_nested) != 0 &&
                                         page.prepass_family == level_prepass_family::LEGACY_NESTED;
-    bool const selected_nested             = selected_generic_nested || selected_legacy_nested;
+    bool const selected_delta_nested = (_level_prepass_mode & level_prepass_delta_nested) != 0 &&
+                                       page.prepass_family == level_prepass_family::DELTA_NESTED;
+    bool const selected_nested =
+      selected_generic_nested || selected_legacy_nested || selected_delta_nested;
     page.nested_prepass_nz_idx             = nullptr;
     page.nested_prepass_nesting            = nullptr;
     page.nested_prepass_prefix_valid_count = -1;
@@ -455,6 +458,7 @@ void reader_impl::allocate_level_decode_space()
     page.nested_prepass_input_row_count    = 0;
     page.nested_prepass_enabled            = selected_generic_nested;
     page.legacy_nested_prepass_enabled     = selected_legacy_nested;
+    page.delta_nested_prepass_enabled      = selected_delta_nested;
     if (selected_nested) {
       // Required nested leaves have an identity valid-rank mapping. They
       // still publish per-depth state, but do not retain a redundant map.
@@ -474,7 +478,8 @@ void reader_impl::allocate_level_decode_space()
     nested_prepass_ptr == nullptr ? nullptr : nested_prepass_ptr + nested_prepass_map_size);
   for (size_t idx = 0; idx < num_pages; ++idx) {
     auto& page = pages[idx];
-    if (page.nested_prepass_enabled || page.legacy_nested_prepass_enabled) {
+    if (page.nested_prepass_enabled || page.legacy_nested_prepass_enabled ||
+        page.delta_nested_prepass_enabled) {
       auto const& chunk = pass.chunks[page.chunk_idx];
       if (chunk.max_level[level_type::DEFINITION] != 0) {
         page.nested_prepass_nz_idx = nested_map_ptr;

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -44,6 +44,29 @@
 
 using ParquetDecompressionTest = DecompressionTest<ParquetReaderTest>;
 
+TEST_F(ParquetReaderTest, LevelPrepassSelectorParsesInternalBitmask)
+{
+  using cudf::io::parquet::detail::level_prepass_mode_from_environment;
+
+  EXPECT_EQ(level_prepass_mode_from_environment(), 0);
+  {
+    tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "0x101"};
+    EXPECT_EQ(level_prepass_mode_from_environment(), 0x101);
+  }
+  {
+    tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "511"};
+    EXPECT_EQ(level_prepass_mode_from_environment(), 0x1ff);
+  }
+  {
+    tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "0x200"};
+    EXPECT_EQ(level_prepass_mode_from_environment(), 0);
+  }
+  {
+    tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "invalid"};
+    EXPECT_EQ(level_prepass_mode_from_environment(), 0);
+  }
+}
+
 TEST_F(ParquetReaderTest, UserBounds)
 {
   // trying to read more rows than there are should result in

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -48,7 +48,10 @@ TEST_F(ParquetReaderTest, LevelPrepassSelectorParsesInternalBitmask)
 {
   using cudf::io::parquet::detail::level_prepass_mode_from_environment;
 
-  EXPECT_EQ(level_prepass_mode_from_environment(), 0);
+  {
+    tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "0"};
+    EXPECT_EQ(level_prepass_mode_from_environment(), 0);
+  }
   {
     tmp_env_var const selector{"LIBCUDF_PARQUET_LEVEL_PREPASS", "0x101"};
     EXPECT_EQ(level_prepass_mode_from_environment(), 0x101);


### PR DESCRIPTION
## Summary

Rebuilds the Parquet level-prepass experiment as a linear, opt-in dual-path series.

- Adds the internal `LIBCUDF_PARQUET_LEVEL_PREPASS` selector, snapshotted per read.
- Keeps legacy and prepass consumers separately compiled and selected host-side.
- Migrates generic, GENERAL/BSS, and delta decoders across flat, nested, and list pages.
- Enables the prepass by default (`0x1ff`) while retaining `0` as a rollback mode.
- Includes the nested page-local rank correction.

## Validation

- `PARQUET_TEST` passed in default-prepass and legacy-selector modes (544 passing; one expected skip).
- Targeted nested specialized-path test passed under compute-sanitizer memcheck.
- Matched Parquet NVBench coverage was collected.
- PDS-H SF1000 Q1-Q22 was run in both modes. Q21 is allocation-limited in both modes and is excluded from timing comparisons.

## Follow-up

This draft intentionally retains the selector and legacy paths. Their removal is a later PR after default-on has landed and completed a release-cycle soak.