### PR TITLE
Skip length-1 max/min_by tests with polars<1.39

### DIFF
--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -18,6 +18,7 @@ from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_138,
+    POLARS_VERSION_LT_139,
 )
 
 
@@ -234,6 +235,11 @@ def test_max_min_by_scalar_value(engine: pl.GPUEngine, expr: str) -> None:
             q.collect(engine=engine)
 
 
+SKIP_IF_POLARS_VERSION_LT_139 = pytest.mark.skipif(
+    POLARS_VERSION_LT_139, reason="polars bug in single-value max_by and min_by."
+)
+
+
 @pytest.mark.skipif(
     POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
 )
@@ -263,9 +269,15 @@ def test_max_min_by_scalar_value(engine: pl.GPUEngine, expr: str) -> None:
         ([], [], [], pl.Int64),
         ([], [], [], pl.Float64),
         ([1, 2, 3], [10, 20, 30], [None, None, None], pl.Float64),
-        ([1], [10], [3.0], pl.Float64),
-        ([1], [10], [None], pl.Float64),
-        ([1], [10], [float("nan")], pl.Float64),
+        pytest.param(
+            [1], [10], [3.0], pl.Float64, marks=[SKIP_IF_POLARS_VERSION_LT_139]
+        ),
+        pytest.param(
+            [1], [10], [None], pl.Float64, marks=[SKIP_IF_POLARS_VERSION_LT_139]
+        ),
+        pytest.param(
+            [1], [10], [float("nan")], pl.Float64, marks=[SKIP_IF_POLARS_VERSION_LT_139]
+        ),
         (
             [1, 1, 1, 2, 2, 2],
             [10, 20, 30, 40, 50, 60],


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cudf/actions/runs/33724423730/job/100550196587 is a failure in our nightly runs in the max_by / min_by tests. polars incorrectly returns null for length-1 groups.

This was reported in https://github.com/pola-rs/polars/issues/26548 and fixed in polars 1.39. cudf-polars doesn't reproduce the polars bug, so the test fails.

I've skipped those cases for polars<1.39.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
