### PR TITLE
Work around CUDA 12.9 scan corruption on Blackwell

### DIFF
--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -894,6 +894,11 @@ struct split_key_functor {
   int operator() __device__(int buf_index) const { return buf_index / num_src_bufs; }
 };
 
+struct wide_split_key_functor {
+  int const num_src_bufs;
+  int operator() __device__(std::ptrdiff_t buf_index) const { return buf_index / num_src_bufs; }
+};
+
 /**
  * @brief Writes values to the dst_offset field of the dst_buf_info struct
  */
@@ -1314,8 +1319,12 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
 
   // compute start offset for each output buffer for each split
   {
-    auto const keys = cudf::detail::make_counting_transform_iterator(
-      0, split_key_functor{static_cast<int>(num_src_bufs)});
+    // Work around a CUDA 12.9 ptxas scan-by-key miscompilation on SM120. Both the counting iterator
+    // and the functor argument must use ptrdiff_t.
+    // https://github.com/NVIDIA/cccl/issues/11167
+    auto const keys = cuda::transform_iterator(
+      cuda::counting_iterator<std::ptrdiff_t>{0},
+      wide_split_key_functor{static_cast<int>(num_src_bufs)});
     auto values =
       cudf::detail::make_counting_transform_iterator(0, buf_size_functor{d_dst_buf_info});
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1322,9 +1322,9 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
     // Work around a CUDA 12.9 ptxas scan-by-key miscompilation on SM120. Both the counting iterator
     // and the functor argument must use ptrdiff_t.
     // https://github.com/NVIDIA/cccl/issues/11167
-    auto const keys = cuda::transform_iterator(
-      cuda::counting_iterator<std::ptrdiff_t>{0},
-      wide_split_key_functor{static_cast<int>(num_src_bufs)});
+    auto const keys =
+      cuda::transform_iterator(cuda::counting_iterator<std::ptrdiff_t>{0},
+                               wide_split_key_functor{static_cast<int>(num_src_bufs)});
     auto values =
       cudf::detail::make_counting_transform_iterator(0, buf_size_functor{d_dst_buf_info});
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -894,10 +894,12 @@ struct split_key_functor {
   int operator() __device__(int buf_index) const { return buf_index / num_src_bufs; }
 };
 
+#if CUDART_VERSION < 13000
 struct wide_split_key_functor {
   int const num_src_bufs;
   int operator() __device__(std::ptrdiff_t buf_index) const { return buf_index / num_src_bufs; }
 };
+#endif  // CUDART_VERSION < 13000
 
 /**
  * @brief Writes values to the dst_offset field of the dst_buf_info struct
@@ -1319,12 +1321,17 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
 
   // compute start offset for each output buffer for each split
   {
+#if CUDART_VERSION < 13000
     // Work around a CUDA 12.9 ptxas scan-by-key miscompilation on SM120. Both the counting iterator
     // and the functor argument must use ptrdiff_t.
     // https://github.com/NVIDIA/cccl/issues/11167
     auto const keys =
       cuda::transform_iterator(cuda::counting_iterator<std::ptrdiff_t>{0},
                                wide_split_key_functor{static_cast<int>(num_src_bufs)});
+#else
+    auto const keys = cudf::detail::make_counting_transform_iterator(
+      0, split_key_functor{static_cast<int>(num_src_bufs)});
+#endif  // CUDART_VERSION < 13000
     auto values =
       cudf::detail::make_counting_transform_iterator(0, buf_size_functor{d_dst_buf_info});
 

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cuh
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cuh
@@ -13,6 +13,7 @@
 #include <cuda/stream>
 #include <thrust/logical.h>
 
+#include <cstddef>
 #include <future>
 #include <span>
 #include <vector>
@@ -476,7 +477,13 @@ struct page_to_string_size {
  */
 struct set_str_offset_fn {
   PageInfo* p;
-  __device__ constexpr void operator()(size_type i, size_t value) const { p[i].str_offset = value; }
+  // Work around a CUDA 12.9 ptxas scan-by-key miscompilation on SM120 by using a pointer-width
+  // tabulate output index.
+  // https://github.com/NVIDIA/cccl/issues/11167
+  __device__ constexpr void operator()(std::ptrdiff_t i, size_t value) const
+  {
+    p[i].str_offset = value;
+  }
 };
 
 /**

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cuh
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cuh
@@ -477,10 +477,14 @@ struct page_to_string_size {
  */
 struct set_str_offset_fn {
   PageInfo* p;
+#if CUDART_VERSION < 13000
   // Work around a CUDA 12.9 ptxas scan-by-key miscompilation on SM120 by using a pointer-width
   // tabulate output index.
   // https://github.com/NVIDIA/cccl/issues/11167
   __device__ constexpr void operator()(std::ptrdiff_t i, size_t value) const
+#else
+  __device__ constexpr void operator()(size_type i, size_t value) const
+#endif  // CUDART_VERSION < 13000
   {
     p[i].str_offset = value;
   }

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1732,6 +1732,40 @@ TEST_F(ContiguousSplitUntypedTest, ValidityEdgeCase)
   }
 }
 
+TEST_F(ContiguousSplitUntypedTest, ManyBuffersPreserveValidity)
+{
+  // 172 nullable columns plus one non-nullable column produce 345 source buffers. Ten output
+  // partitions therefore produce a 3450-item scan that crosses the tile boundary implicated in
+  // https://github.com/NVIDIA/cccl/issues/11167. The value column is positioned after that boundary
+  // in the final partition so that corrupted offsets change its final validity bit.
+  constexpr cudf::size_type column_count = 173;
+  constexpr cudf::size_type value_column = 25;
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.reserve(column_count);
+  columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
+                      {0, 0, 0, 0}, {true, true, true, false})
+                      .release());
+  columns.push_back(cudf::test::fixed_width_column_wrapper<int32_t>{0, 0, 0, 0}.release());
+  for (cudf::size_type column_index = 2; column_index < column_count; ++column_index) {
+    if (column_index == value_column) {
+      columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
+                          {0, 0, 0, -1}, {false, false, false, true})
+                          .release());
+    } else {
+      columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
+                          {0, 0, 0, 0}, {false, false, false, false})
+                          .release());
+    }
+  }
+
+  cudf::table const input{std::move(columns)};
+  auto const result = cudf::contiguous_split(input, std::vector<cudf::size_type>(9, 0));
+
+  ASSERT_EQ(result.size(), 10);
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input, result.back().table);
+}
+
 // This test requires about 25GB of device memory when used with the arena allocator
 TEST_F(ContiguousSplitUntypedTest, DISABLED_VeryLargeColumnTest)
 {

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1743,19 +1743,19 @@ TEST_F(ContiguousSplitUntypedTest, ManyBuffersPreserveValidity)
 
   std::vector<std::unique_ptr<cudf::column>> columns;
   columns.reserve(column_count);
-  columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
-                      {0, 0, 0, 0}, {true, true, true, false})
-                      .release());
+  columns.push_back(
+    cudf::test::fixed_width_column_wrapper<int64_t>({0, 0, 0, 0}, {true, true, true, false})
+      .release());
   columns.push_back(cudf::test::fixed_width_column_wrapper<int32_t>{0, 0, 0, 0}.release());
   for (cudf::size_type column_index = 2; column_index < column_count; ++column_index) {
     if (column_index == value_column) {
-      columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
-                          {0, 0, 0, -1}, {false, false, false, true})
-                          .release());
+      columns.push_back(
+        cudf::test::fixed_width_column_wrapper<int64_t>({0, 0, 0, -1}, {false, false, false, true})
+          .release());
     } else {
-      columns.push_back(cudf::test::fixed_width_column_wrapper<int64_t>(
-                          {0, 0, 0, 0}, {false, false, false, false})
-                          .release());
+      columns.push_back(
+        cudf::test::fixed_width_column_wrapper<int64_t>({0, 0, 0, 0}, {false, false, false, false})
+          .release());
     }
   }
 

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -39,10 +39,44 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 
 using ParquetDecompressionTest = DecompressionTest<ParquetReaderTest>;
+
+TEST_F(ParquetReaderTest, ManyTinyStringPages)
+{
+  // This creates enough pages to cross the scan-by-key tile boundary implicated in
+  // https://github.com/NVIDIA/cccl/issues/11167.
+  constexpr cudf::size_type num_rows    = 1000;
+  constexpr cudf::size_type num_columns = 4;
+
+  std::vector<std::string> values;
+  values.reserve(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    values.push_back(std::to_string(i) + std::string(static_cast<std::size_t>(i % 12), 'a'));
+  }
+  cudf::test::strings_column_wrapper strings(values.begin(), values.end());
+  cudf::table_view const input{std::vector<cudf::column_view>(num_columns, strings)};
+
+  auto const filepath = temp_env->get_temp_filepath("ManyTinyStringPages.parquet");
+  auto const write_options =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, input)
+      .compression(cudf::io::compression_type::NONE)
+      .dictionary_policy(cudf::io::dictionary_policy::NEVER)
+      .row_group_size_rows(num_rows)
+      .max_page_size_rows(1)
+      .max_page_fragment_size(1)
+      .build();
+  cudf::io::write_parquet(write_options);
+
+  auto const read_options =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath}).build();
+  auto const result = cudf::io::read_parquet(read_options);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input, result.tbl->view());
+}
 
 TEST_F(ParquetReaderTest, UserBounds)
 {


### PR DESCRIPTION
## Description

Work around two manifestations of a CUDA 12.9 ptxas miscompilation in device scans on Blackwell (SM120), tracked in [NVIDIA/cccl#11167](https://github.com/NVIDIA/cccl/issues/11167):

- Use a `cuda::counting_iterator<std::ptrdiff_t>` and a pointer-width transform argument for the `contiguous_split` scan-by-key keys.
- Use a pointer-width callback index for the Parquet string-page offset scan's `cuda::tabulate_output_iterator`.

Add focused regressions for both affected cuDF paths. The public cudf-spark investigation that led to these reductions is documented in [NVIDIA/cudf-spark#15872](https://github.com/NVIDIA/cudf-spark/issues/15872#issuecomment-5527329473).

Testing used CUDA 12.9.86 on an RTX PRO 4500 Blackwell (SM120), with `CMAKE_CUDA_ARCHITECTURES=native` and build parallelism 64.

Negative controls without the corresponding workaround reproduced both failures:

- `ContiguousSplitUntypedTest.ManyBuffersPreserveValidity`: expected the final `int64` value `-1`, but received NULL.
- `ParquetReaderTest.ManyTinyStringPages`: read-back string corruption.

With the workarounds:

- Both focused regressions passed 50 consecutive iterations.
- `COPYING_TEST`: 4,112 passed; 6 disabled.
- `PARQUET_TEST`: 548 passed; 1 pre-existing skip; 4 disabled.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes (no public API or behavior change).
