### PR TITLE
Add Java/JNI applyNullMask to ColumnView

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -630,6 +630,24 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(result);
   }
 
+  /**
+   * Returns a copy of this column with each row set to null wherever the corresponding row
+   * in booleanMask is false or null, leaving the other rows as they already are (including
+   * any that were already null).
+   * <p>
+   * This is a convenience over {@code ifElse}, which otherwise needs a null scalar of this
+   * column's type constructed just to null out the false rows.
+   * @param booleanMask a BOOL8 column with the same row count as this column
+   * @return a new column with this column's values, nulled out where booleanMask is not true
+   */
+  public final ColumnVector applyNullMask(ColumnView booleanMask) {
+    if (!booleanMask.getType().equals(DType.BOOL8)) {
+      throw new IllegalArgumentException("Mask column must be of type BOOL8, found " +
+          booleanMask.getType());
+    }
+    return new ColumnVector(applyNullMask(getNativeView(), booleanMask.getNativeView()));
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Slice/Split and Concatenate
   /////////////////////////////////////////////////////////////////////////////
@@ -5127,6 +5145,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   private static native long ifElseSV(long predVec, long trueScalar, long falseVec) throws CudfException;
 
   private static native long ifElseSS(long predVec, long trueScalar, long falseScalar) throws CudfException;
+
+  private static native long applyNullMask(long baseHandle, long boolMaskHandle) throws CudfException;
 
   private static native long reduce(long viewHandle, long aggregation, int dtype, int scale) throws CudfException;
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -645,6 +645,10 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
       throw new IllegalArgumentException("Mask column must be of type BOOL8, found " +
           booleanMask.getType());
     }
+    if (booleanMask.getRowCount() != getRowCount()) {
+      throw new IllegalArgumentException("Mask column row count (" + booleanMask.getRowCount() +
+          ") does not match this column's row count (" + getRowCount() + ")");
+    }
     return new ColumnVector(applyNullMask(getNativeView(), booleanMask.getNativeView()));
   }
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -303,6 +303,33 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseSS(
   JNI_CATCH(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_applyNullMask(JNIEnv* env,
+                                                                     jclass,
+                                                                     jlong j_col,
+                                                                     jlong j_bool_mask)
+{
+  JNI_NULL_CHECK(env, j_col, "column is null", 0);
+  JNI_NULL_CHECK(env, j_bool_mask, "mask column is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const col_view  = reinterpret_cast<cudf::column_view*>(j_col);
+    auto const mask_view = reinterpret_cast<cudf::column_view*>(j_bool_mask);
+
+    auto [bool_mask, bool_null_count] = cudf::bools_to_mask(*mask_view);
+    auto copy                         = std::make_unique<cudf::column>(*col_view);
+    auto result                       = cudf::structs::detail::superimpose_and_sanitize_nulls(
+      static_cast<cudf::bitmask_type const*>(bool_mask->data()),
+      bool_null_count,
+      std::move(copy),
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref());
+
+    return release_as_jlong(result);
+  }
+  JNI_CATCH(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getElement(JNIEnv* env,
                                                                   jclass,
                                                                   jlong from,

--- a/java/src/test/java/ai/rapids/cudf/IfElseTest.java
+++ b/java/src/test/java/ai/rapids/cudf/IfElseTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2020, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -1165,6 +1165,33 @@ public class IfElseTest extends CudfTestBase {
          Scalar trueScalar = Scalar.fromByte((byte) 1);
          Scalar falseScalar = Scalar.fromString("hey")) {
       assertThrows(CudfException.class, () -> pred.ifElse(trueScalar, falseScalar));
+    }
+  }
+
+  @Test
+  void testApplyNullMask() {
+    try (ColumnVector input = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
+         ColumnVector mask = ColumnVector.fromBoxedBooleans(true, false, true, null, false, true);
+         ColumnVector result = input.applyNullMask(mask);
+         ColumnVector expected = ColumnVector.fromBoxedInts(0, null, 1, null, null, null)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void testApplyNullMaskAllTrueIsValuePreserving() {
+    try (ColumnVector input = ColumnVector.fromBoxedInts(0, 100, null, 2);
+         ColumnVector mask = ColumnVector.fromBoxedBooleans(true, true, true, true);
+         ColumnVector result = input.applyNullMask(mask)) {
+      assertColumnsAreEqual(input, result);
+    }
+  }
+
+  @Test
+  void testApplyNullMaskRejectsNonBooleanMask() {
+    try (ColumnVector input = ColumnVector.fromBoxedInts(0, 100, 1, 2);
+         ColumnVector mask = ColumnVector.fromBoxedInts(1, 0, 1, 0)) {
+      assertThrows(IllegalArgumentException.class, () -> input.applyNullMask(mask));
     }
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/IfElseTest.java
+++ b/java/src/test/java/ai/rapids/cudf/IfElseTest.java
@@ -12,10 +12,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IfElseTest extends CudfTestBase {
   private static Stream<Arguments> createBooleanVVParams() {
@@ -1200,6 +1204,65 @@ public class IfElseTest extends CudfTestBase {
     try (ColumnVector input = ColumnVector.fromBoxedInts(0, 100, 1, 2);
          ColumnVector mask = ColumnVector.fromBoxedBooleans(true, false, true)) {
       assertThrows(IllegalArgumentException.class, () -> input.applyNullMask(mask));
+    }
+  }
+
+  @Test
+  void testApplyNullMaskPropagatesToStructChildren() {
+    try (ColumnVector c0 = ColumnVector.fromInts(1, 2, 3, 4, 5);
+         ColumnVector c1 = ColumnVector.fromInts(10, 20, 30, 40, 50);
+         ColumnVector struct = ColumnVector.makeStruct(c0, c1);
+         ColumnVector mask = ColumnVector.fromBoxedBooleans(true, true, false, null, true);
+         ColumnVector result = struct.applyNullMask(mask);
+         HostColumnVector hostResult = result.copyToHost()) {
+      assertEquals(2, hostResult.getNullCount(), "parent null count");
+      assertFalse(hostResult.isNull(0));
+      assertFalse(hostResult.isNull(1));
+      assertTrue(hostResult.isNull(2));
+      assertTrue(hostResult.isNull(3));
+      assertFalse(hostResult.isNull(4));
+
+      // Each child should have the same null mask as the parent.
+      assertEquals(2, hostResult.getNumChildren());
+      for (int i = 0; i < hostResult.getNumChildren(); i++) {
+        HostColumnVectorCore child = hostResult.getChildColumnView(i);
+        assertEquals(2, child.getNullCount(), "child " + i + " null count");
+        assertTrue(child.isNull(2), "child " + i + " row 2");
+        assertTrue(child.isNull(3), "child " + i + " row 3");
+      }
+    }
+  }
+
+  @Test
+  void testApplyNullMaskPurgesListOffsetsOfMaskedRows() {
+    HostColumnVector.DataType intType  = new HostColumnVector.BasicType(true, DType.INT32);
+    HostColumnVector.DataType listType = new HostColumnVector.ListType(true, intType);
+    try (ColumnVector list = ColumnVector.fromLists(listType,
+             Arrays.asList(1, 2),
+             Arrays.asList(3, 4, 5),
+             Arrays.asList(6),  // will be masked null.
+             Arrays.asList(7, 8, 9, 10),  // will be masked null.
+             Arrays.asList(11));
+         ColumnVector mask = ColumnVector.fromBoxedBooleans(true, true, false, null, true);
+         ColumnVector result = list.applyNullMask(mask);
+         HostColumnVector hostResult = result.copyToHost()) {
+      assertEquals(2, hostResult.getNullCount(), "parent null count");
+      assertTrue(hostResult.isNull(2));
+      assertTrue(hostResult.isNull(3));
+
+      // Rows 2 and 3 collapse so the inner INT should have only 6 elements.
+      assertEquals(1, hostResult.getNumChildren());
+      HostColumnVectorCore intChild = hostResult.getChildColumnView(0);
+      assertEquals(6, intChild.getRowCount(), "purged inner row count");
+      int[] expectedInner = {1, 2, 3, 4, 5, 11};
+      for (int i = 0; i < expectedInner.length; i++) {
+        assertEquals(expectedInner[i], intChild.getInt(i), "inner " + i);
+      }
+      HostMemoryBuffer offsets = hostResult.getOffsets();
+      int[] expectedOffsets = {0, 2, 5, 5, 5, 6};
+      for (int i = 0; i < expectedOffsets.length; i++) {
+        assertEquals(expectedOffsets[i], offsets.getInt(i * 4L), "offset " + i);
+      }
     }
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/IfElseTest.java
+++ b/java/src/test/java/ai/rapids/cudf/IfElseTest.java
@@ -1194,4 +1194,12 @@ public class IfElseTest extends CudfTestBase {
       assertThrows(IllegalArgumentException.class, () -> input.applyNullMask(mask));
     }
   }
+
+  @Test
+  void testApplyNullMaskRejectsRowCountMismatch() {
+    try (ColumnVector input = ColumnVector.fromBoxedInts(0, 100, 1, 2);
+         ColumnVector mask = ColumnVector.fromBoxedBooleans(true, false, true)) {
+      assertThrows(IllegalArgumentException.class, () -> input.applyNullMask(mask));
+    }
+  }
 }


### PR DESCRIPTION
## Description

Adds `ColumnView.applyNullMask(ColumnView booleanMask)`, a Java/JNI function
that returns a copy of a column with each row nulled out wherever the
corresponding row in a BOOL8 mask column is false or null, leaving already-null
rows as they are.

Closes #16764. Currently this needs `copy_if_else` with a null scalar built
just to null out the false rows, which is what the issue asks to avoid.

Implementation follows the approach `ttnghia` outlines in the issue thread:
`cudf::bools_to_mask` to turn the boolean values into a bitmask, then
`cudf::structs::detail::superimpose_and_sanitize_nulls` (not a raw
`set_null_mask`) so nested (list/struct) columns get the mask pushed down to
their descendants and non-empty nulls sanitized correctly, same as the
existing `bitwiseMergeAndSetValidity` JNI function already does for its own
merge case.

## Testing

Could not build the native library locally (no CUDA toolchain/GPU build
environment available here), so the C++ side is unverified by an actual
run - flagging that plainly. What was verified:

- `java/src/main` and `java/src/test` compiled together with `javac` against
  the Maven-resolved dependency classpath (`mvn dependency:build-classpath`),
  zero errors.
- `pre-commit run clang-format` passes clean on the new C++ function.
- Added `IfElseTest.testApplyNullMask`, `testApplyNullMaskAllTrueIsValuePreserving`,
  and `testApplyNullMaskRejectsNonBooleanMask` covering the masking behavior,
  the value-preserving no-op case, and the type check - not run against the
  native library for the reason above, but exercise the same semantics the
  existing `IfElseTest` suite already checks this way.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
