### PR TITLE
Skip another test that fails due to a polars bug

### DIFF
--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -357,7 +357,8 @@ def test_groupby_max_min_by_literal_column_value_unsupported(
 
 
 @pytest.mark.skipif(
-    POLARS_VERSION_LT_138, reason="polars 1.38.0 introduced max_by and min_by"
+    POLARS_VERSION_LT_139,
+    reason="polars 1.38.0 introduced max_by and min_by, but has a bug with literals (fixed in 1.39)",
 )
 @pytest.mark.parametrize("agg", ["max_by", "min_by"])
 def test_groupby_max_min_by_scalar_value(engine: pl.GPUEngine, agg: str) -> None:


### PR DESCRIPTION
## Description

In #23969 we skipped some tests in Polars 1.39, since it has bugs. However, we didn't catch them all. Address that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
