### PR TITLE
[FEA] Remove precompiled header directory specifications

### DIFF
--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -300,7 +300,6 @@ rtcx::blob compile_fragment(char const* name,
   auto& bundle = ctx.jit_bundle();
 
   auto include_dirs = bundle.get_include_directories();
-  auto pch_dir      = ctx.get_jit_pch_dir();
 
   auto nvrtc_version = ctx.nvrtc_version().value();
 
@@ -333,7 +332,6 @@ rtcx::blob compile_fragment(char const* name,
 
   if (use_pch) {
     options.emplace_back("--pch");
-    options.emplace_back(std::format("--pch-dir={}", pch_dir));
 
     if (cfg.jit_verbose) {
       options.emplace_back("--pch-verbose=true");

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -76,7 +76,6 @@ void context::initialize_jit()
   // make sure the required directories exist
   std::filesystem::create_directories(_config.rtcx_cache_dir);
   std::filesystem::create_directories(_config.jit_bundle_dir);
-  std::filesystem::create_directories(_config.jit_pch_dir);
   std::filesystem::create_directories(_config.jit_tmp_dir);
 
   _nvrtc_version     = rtcx::nvrtc_version();
@@ -116,8 +115,6 @@ bool context::dump_codegen() const { return _config.dump_codegen; }
 bool context::use_jit() const { return _config.use_jit; }
 
 context_config const& context::config() const { return _config; }
-
-std::string const& context::get_jit_pch_dir() const { return _config.jit_pch_dir; }
 
 context::device_properties const& context::get_device_properties() const
 {
@@ -229,7 +226,6 @@ context make_context(detail::init_flags flags)
   auto const cache_dir      = get_cudf_kernel_cache_dir();
   auto const jit_bundle_dir = cache_dir / "bundle";
   auto const rtcx_cache_dir = cache_dir / "rtcx_cache";
-  auto const jit_pch_dir    = cache_dir / "pch";
   auto const jit_tmp_dir    = cache_dir / "tmp";
 
   flags = flags | (preload_nvcomp ? detail::init_flags::LOAD_NVCOMP : detail::init_flags::NONE);
@@ -245,7 +241,6 @@ context make_context(detail::init_flags flags)
                      .dump_jit_time_profile      = dump_jit_time_profile,
                      .rtcx_cache_dir             = rtcx_cache_dir,
                      .jit_bundle_dir             = jit_bundle_dir,
-                     .jit_pch_dir                = jit_pch_dir,
                      .jit_tmp_dir                = jit_tmp_dir,
                      .kernel_cache_limit_process = kernel_cache_limit_process};
 

--- a/cpp/src/runtime/context.hpp
+++ b/cpp/src/runtime/context.hpp
@@ -35,7 +35,6 @@ struct [[nodiscard]] context_config {
   bool dump_jit_time_profile : 1      = false;
   std::string rtcx_cache_dir          = {};
   std::string jit_bundle_dir          = {};
-  std::string jit_pch_dir             = {};
   std::string jit_tmp_dir             = {};
   uint32_t kernel_cache_limit_process = 0;
 };
@@ -83,8 +82,6 @@ class context {
   [[nodiscard]] bool use_jit() const;
 
   [[nodiscard]] context_config const& config() const;
-
-  [[nodiscard]] std::string const& get_jit_pch_dir() const;
 
   [[nodiscard]] device_properties const& get_device_properties() const;
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow-up to #22812 
Removes manual  PCH cache directory specification for LTO fragment compilation. 
It was already removed for the pure CUDA-only path.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
