### PR TITLE
CI: Use isolated build for all wheel packages

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -52,6 +52,7 @@ RAPIDS_BUILD_ARGS=(
   --wheel
   --outdir dist
   --verbose
+  # A fixed location keeps isolated-build include paths stable for sccache.
   --env-dir "/tmp/${package_name}-wheel-build-env"
   --dependency-constraints-txt "${PIP_CONSTRAINT}"
 )

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -42,12 +42,17 @@ sccache --stop-server 2>/dev/null || true
 
 rapids-logger "Building '${package_name}' wheel"
 
+build_env_dir="/tmp/${package_name}-wheel-build-env"
+# `build` preserves this environment after a failed build for debugging. CI
+# retries must start with an empty directory, as required by `--env-dir`.
+rm -rf "${build_env_dir}"
+
 RAPIDS_BUILD_ARGS=(
   --wheel
   --outdir dist
   --verbose
   # A fixed location keeps isolated-build include paths stable for sccache.
-  --env-dir "/tmp/${package_name}-wheel-build-env"
+  --env-dir "${build_env_dir}"
   --dependency-constraints-txt "${PIP_CONSTRAINT}"
 )
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -31,7 +31,7 @@ source rapids-init-pip
 # outer CI environment so that the build dependencies remain isolated.
 rapids-pip-retry install \
   --disable-pip-version-check \
-  'build>=1.5'
+  'build>=1.5.1'
 
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}-${RAPIDS_CONDA_ARCH}-cuda${RAPIDS_CUDA_VERSION%%.*}-wheel-preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -27,6 +27,12 @@ source rapids-configure-sccache
 source rapids-datetime-string
 source rapids-init-pip
 
+# `build` is the frontend that creates the isolated environment. Keep it in the
+# outer CI environment so that the build dependencies remain isolated.
+rapids-pip-retry install \
+  --disable-pip-version-check \
+  'build>=1.5'
+
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}-${RAPIDS_CONDA_ARCH}-cuda${RAPIDS_CUDA_VERSION%%.*}-wheel-preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 
@@ -42,33 +48,25 @@ sccache --stop-server 2>/dev/null || true
 
 rapids-logger "Building '${package_name}' wheel"
 
-RAPIDS_PIP_WHEEL_ARGS=(
-  -w dist
-  -v
-  --no-deps
-  --disable-pip-version-check
+RAPIDS_BUILD_ARGS=(
+  --wheel
+  --outdir dist
+  --verbose
+  --env-dir "/tmp/${package_name}-wheel-build-env"
+  --dependency-constraints-txt "${PIP_CONSTRAINT}"
 )
 
 # Add py-api setting for stable ABI builds
 if [[ "${stable_abi}" == "true" ]] && [[ -n "${RAPIDS_PY_API:-}" ]]; then
-  RAPIDS_PIP_WHEEL_ARGS+=(--config-settings="skbuild.wheel.py-api=${RAPIDS_PY_API}")
+  RAPIDS_BUILD_ARGS+=(--config-setting="skbuild.wheel.py-api=${RAPIDS_PY_API}")
 fi
 
-# Only use --build-constraint when build isolation is enabled.
-#
-# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
-# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
-# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
-    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
-fi
-
-# unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
-# results in an error from 'pip wheel' when set and --build-constraint is also passed
+# `build` receives the same generated constraints explicitly. Unset the
+# environment variable so it does not constrain the frontend installation.
 unset PIP_CONSTRAINT
 
-rapids-telemetry-record build-${package_name}.log rapids-pip-retry wheel \
-    "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
+rapids-telemetry-record build-${package_name}.log python -m build \
+    "${RAPIDS_BUILD_ARGS[@]}" \
     .
 
 rapids-telemetry-record sccache-stats-${package_name}.txt sccache --show-adv-stats

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -27,12 +27,6 @@ source rapids-configure-sccache
 source rapids-datetime-string
 source rapids-init-pip
 
-# `build` is the frontend that creates the isolated environment. Keep it in the
-# outer CI environment so that the build dependencies remain isolated.
-rapids-pip-retry install \
-  --disable-pip-version-check \
-  'build>=1.5.1'
-
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}-${RAPIDS_CONDA_ARCH}-cuda${RAPIDS_CUDA_VERSION%%.*}-wheel-preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 

--- a/ci/build_wheel_cudf.sh
+++ b/ci/build_wheel_cudf.sh
@@ -16,7 +16,8 @@ LIBCUDF_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_c
 PYLIBCUDF_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python pylibcudf cudf --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
-# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
+# 'pip install', 'pip download', etc. calls (except the isolated wheel build,
+# which is handled separately by ci/build_wheel.sh)
 echo "libcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUDF_WHEELHOUSE}"/libcudf_*.whl)" >> "${PIP_CONSTRAINT}"
 echo "pylibcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${PYLIBCUDF_WHEELHOUSE}"/pylibcudf_*.whl)" >> "${PIP_CONSTRAINT}"
 

--- a/ci/build_wheel_cudf_streaming.sh
+++ b/ci/build_wheel_cudf_streaming.sh
@@ -36,10 +36,6 @@ rapids-pip-retry install \
     --prefer-binary \
     -r /tmp/requirements-build.txt
 
-# build with '--no-build-isolation', for better sccache hit rate
-# 0 really means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-export PIP_NO_BUILD_ISOLATION=0
-
 # TODO: move this variable into `ci-wheel`
 # Format Python limited API version string
 RAPIDS_PY_API="cp${RAPIDS_PY_VERSION//./}"

--- a/ci/build_wheel_cudf_streaming.sh
+++ b/ci/build_wheel_cudf_streaming.sh
@@ -41,6 +41,7 @@ rapids-pip-retry install \
 RAPIDS_PY_API="cp${RAPIDS_PY_VERSION//./}"
 export RAPIDS_PY_API
 
+# The shared helper performs the isolated wheel build and configures sccache.
 ./ci/build_wheel.sh "${package_name}" "${package_dir}" --stable 2>&1 | tee cudf-streaming-wheel-build-output.log
 
 rapids-logger "Checking for Cython performance warnings"

--- a/ci/build_wheel_libcudf.sh
+++ b/ci/build_wheel_libcudf.sh
@@ -24,10 +24,6 @@ rapids-pip-retry install \
     --prefer-binary \
     -r /tmp/requirements-build.txt
 
-# build with '--no-build-isolation', for better sccache hit rate
-# 0 really means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-export PIP_NO_BUILD_ISOLATION=0
-
 export SKBUILD_CMAKE_ARGS="-DUSE_NVCOMP_RUNTIME_WHEEL=ON"
 ./ci/build_wheel.sh "${package_name}" "${package_dir}"
 

--- a/ci/build_wheel_libcudf_streaming.sh
+++ b/ci/build_wheel_libcudf_streaming.sh
@@ -32,10 +32,6 @@ rapids-pip-retry install \
     --prefer-binary \
     -r /tmp/requirements-build.txt
 
-# build with '--no-build-isolation', for better sccache hit rate
-# 0 really means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
-export PIP_NO_BUILD_ISOLATION=0
-
 ./ci/build_wheel.sh "${package_name}" "${package_dir}"
 
 # repair wheels and write to the location that artifact-uploading code expects to find them

--- a/ci/build_wheel_pylibcudf.sh
+++ b/ci/build_wheel_pylibcudf.sh
@@ -14,7 +14,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # then ensures 'pylibcudf' wheel builds always use the 'libcudf' just built in the same CI run.
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
-# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
+# 'pip install', 'pip download', etc. calls (except the isolated wheel build,
+# which is handled separately by ci/build_wheel.sh)
 LIBCUDF_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libcudf cudf --cuda "$RAPIDS_CUDA_VERSION")")
 echo "libcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUDF_WHEELHOUSE}"/libcudf_*.whl)" >> "${PIP_CONSTRAINT}"
 


### PR DESCRIPTION
## Description

Replace `pip wheel` with isolated `python -m build --wheel` in the shared wheel-build helper used by every wheel build job: libcudf, libcudf-streaming, pylibcudf, cudf, cudf-streaming, dask-cudf, and cudf-polars.

`build>=1.5.1` is supplied by the `ci-wheel` image ([rapidsai/ci-imgs#462](https://github.com/rapidsai/ci-imgs/pull/462)), so no package installation is repeated in each job. Each package uses a deterministic `--env-dir`, explicit generated dependency constraints, package/architecture/CUDA-specific preprocessor-cache prefixes, and sccache telemetry.

## Validation

- Shell syntax, diff checks, and commit hooks passed.
- All wheel-build matrices completed successfully in workflow 33927693284.
- A warmed libcudf run recorded 671 sccache hits, including 647 preprocessor-cache hits, zero cache misses, and a 100% cache-hit rate.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.