### PR TITLE
Adopt CUDA stream compatibility accessors

### DIFF
--- a/cpp/include/cudf/detail/utilities/default_stream.hpp
+++ b/cpp/include/cudf/detail/utilities/default_stream.hpp
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace CUDF_EXPORT cudf {
 

--- a/cpp/include/cudf/join/streaming_hash_join.hpp
+++ b/cpp/include/cudf/join/streaming_hash_join.hpp
@@ -14,7 +14,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>

--- a/cpp/include/cudf/utilities/default_stream.hpp
+++ b/cpp/include/cudf/utilities/default_stream.hpp
@@ -7,7 +7,7 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 /**
  * @file

--- a/cpp/libcudf_streaming/src/bloom_filter.cpp
+++ b/cpp/libcudf_streaming/src/bloom_filter.cpp
@@ -118,7 +118,7 @@ rapidsmpf::streaming::Actor bloom_filter::apply(
   auto storage = (co_await bloom_filter->receive()).release<rmm::device_buffer>();
   RAPIDSMPF_EXPECTS((co_await bloom_filter->receive()).empty(),
                     "Bloom filter channel contained more than one message");
-  auto stream = cuda::stream_ref{storage.stream().value()};
+  auto stream = cuda::stream_ref{storage.stream().get()};
   rapidsmpf::CudaEvent event;
   auto filter = cudf_streaming::detail::device_bloom_filter(filter_size_, seed_, storage.data());
   auto meta   = co_await ch_in->receive_metadata();

--- a/cpp/src/io/parquet/synthetic_column_helpers.hpp
+++ b/cpp/src/io/parquet/synthetic_column_helpers.hpp
@@ -12,7 +12,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/src/join/streaming_hash_join.cu
+++ b/cpp/src/join/streaming_hash_join.cu
@@ -32,7 +32,7 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <atomic>

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -15,7 +15,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <atomic>

--- a/cpp/tests/join/streaming_hash_join_tests.cpp
+++ b/cpp/tests/join/streaming_hash_join_tests.cpp
@@ -28,7 +28,7 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <algorithm>
 #include <atomic>

--- a/cpp/tests/scalar/scalar_test.cpp
+++ b/cpp/tests/scalar/scalar_test.cpp
@@ -138,7 +138,7 @@ TEST_F(ScalarTest, AsyncStringConstructionOwnsHostSource)
       auto* ptr = upstream.allocate(stream, bytes, cuda::mr::default_cuda_malloc_alignment);
       if (allocations++ == 1) {
         CUDF_CUDA_TRY(cudaLaunchHostFunc(
-          stream.value(), [](void* data) { static_cast<host_func_gate*>(data)->wait(); }, &gate));
+          stream.get(), [](void* data) { static_cast<host_func_gate*>(data)->wait(); }, &gate));
       }
       return ptr;
     },

--- a/java/src/main/native/include/maps_column_view.hpp
+++ b/java/src/main/native/include/maps_column_view.hpp
@@ -10,7 +10,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 

--- a/java/src/main/native/src/ColumnViewJni.hpp
+++ b/java/src/main/native/src/ColumnViewJni.hpp
@@ -9,7 +9,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf::jni {
 

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -27,7 +27,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <sys/mman.h>

--- a/java/src/main/native/src/aggregation128_utils.hpp
+++ b/java/src/main/native/src/aggregation128_utils.hpp
@@ -9,7 +9,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <memory>
 

--- a/java/src/main/native/src/check_nvcomp_output_sizes.hpp
+++ b/java/src/main/native/src/check_nvcomp_output_sizes.hpp
@@ -7,7 +7,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 namespace cudf {
 namespace java {

--- a/python/cudf_streaming/cudf_streaming/partition_utils.pyx
+++ b/python/cudf_streaming/cudf_streaming/partition_utils.pyx
@@ -119,7 +119,7 @@ cpdef size_t partition_and_pack_cost(
     --------
     cudf_streaming.partition_utils.partition_and_pack
     """
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef table_view tbl = table.view()
     cdef size_t ret
@@ -177,7 +177,7 @@ cpdef object partition_and_pack(
     pylibcudf.contiguous_split.pack
     cudf_streaming.partition_utils.split_and_pack
     """
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef vector[size_type] _columns_to_hash = tuple(columns_to_hash)
     cdef unordered_map[uint32_t, cpp_PackedData] _ret
@@ -244,7 +244,7 @@ cpdef size_t split_and_pack_cost(
     --------
     cudf_streaming.partition_utils.split_and_pack
     """
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef table_view tbl = table.view()
     cdef size_t ret
@@ -299,7 +299,7 @@ cpdef object split_and_pack(
     pylibcudf.copying.split
     cudf_streaming.partition_utils.partition_and_pack
     """
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef vector[size_type] _splits = tuple(splits)
     cdef unordered_map[uint32_t, cpp_PackedData] _ret
@@ -463,7 +463,7 @@ cpdef object unpack_and_concat(
     cudf_streaming.partition_utils.unpack_and_concat_cost
     cudf_streaming.partition_utils.partition_and_pack
     """
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef vector[cpp_PackedData] _partitions = _partitions_py_to_cpp(partitions)
     cdef unique_ptr[cpp_table] _ret
@@ -550,7 +550,7 @@ cpdef object packed_data_from_cudf_packed_columns(
     """
     if packed_columns is None or stream is None or br is None:
         raise TypeError("Arguments must not be None")
-    cdef stream_ref _stream = stream_ref(stream.view().value())
+    cdef stream_ref _stream = stream_ref(stream.view().get())
     cdef cpp_BufferResource* _br = br.ptr()
     cdef PackedData ret = PackedData.__new__(PackedData)
     with nogil:

--- a/python/cudf_streaming/cudf_streaming/table_chunk.pyx
+++ b/python/cudf_streaming/cudf_streaming/table_chunk.pyx
@@ -183,7 +183,7 @@ cdef class TableChunk:
         persists even when the chunk is transferred through Channels.
 
         """
-        cdef stream_ref _stream = stream_ref(stream.view().value())
+        cdef stream_ref _stream = stream_ref(stream.view().get())
         cdef cpp_table_view view = table.view()
         return TableChunk.from_handle(
             cpp_from_table_view_with_owner(

--- a/python/pylibcudf/pylibcudf/binaryop.pyx
+++ b/python/pylibcudf/pylibcudf/binaryop.pyx
@@ -68,7 +68,7 @@ cpdef Column binary_operation(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_lhs_column
     cdef column_view c_rhs_column
 

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -119,7 +119,7 @@ cdef class _OwnerWithCAI:
             # Cast to Python integers before multiplying to avoid overflow.
             size = int(cv.size()) * int(cpp_size_of(cv.type()))
         elif cv.type().id() == type_id.STRING:
-            size = strings_column_view(cv).chars_size((<Stream>stream).view().value())
+            size = strings_column_view(cv).chars_size((<Stream>stream).view().get())
 
         obj.cai = {
             "shape": (size,),
@@ -474,7 +474,7 @@ cdef class Column:
         cdef unique_ptr[arrow_column] c_result
 
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
 
         if hasattr(obj, "__arrow_c_device_array__"):
@@ -855,7 +855,7 @@ cdef class Column:
         cdef const cpp_scalar* c_scalar = slr.get()
         cdef unique_ptr[cpp_column] c_result
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             c_result = make_column_from_scalar(
@@ -890,7 +890,7 @@ cdef class Column:
         cdef column_view cv = self.view()
         cdef unique_ptr[cpp_scalar] result
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
 
         with nogil:
@@ -922,7 +922,7 @@ cdef class Column:
             An all-null column of `size` rows and type matching `like`.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         cdef Scalar slr = Scalar.empty_like(like, _stream, mr)
         cdef unique_ptr[cpp_column] c_result
@@ -1306,7 +1306,7 @@ cdef class Column:
             and self.child(0).type().id() == type_id.INT64
         )
         cdef Stream _stream = _get_stream(None)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef ArrowArray* raw_host_array_ptr = NULL
         c_self = self.view()
         with nogil:
@@ -1436,7 +1436,7 @@ cdef class Column:
         """Create a copy of the column."""
         cdef unique_ptr[cpp_column] c_result
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
 
         mr = _get_memory_resource(mr)
         cdef column_view c_self = self.view()
@@ -1497,7 +1497,7 @@ cdef class Column:
     def _to_host_array(self, object stream: CudaStreamLike):
         cdef ArrowArray* raw_host_array_ptr
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
 
         cdef column_view c_self = self.view()
         with nogil:
@@ -1581,7 +1581,7 @@ cdef class ListsColumnView:
         """
         cdef Stream _stream = _get_stream(stream)
 
-        cdef column_view c_child = self.view().get_sliced_child(_stream.view().value())
+        cdef column_view c_child = self.view().get_sliced_child(_stream.view().get())
         return Column.from_column_view(c_child, self._column.child(1))
 
 
@@ -1621,7 +1621,7 @@ cdef class StructsColumnView:
         """
         cdef Stream _stream = _get_stream(stream)
 
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef column_view c_child = self.view().get_sliced_child(index, _cs)
         return Column.from_column_view(c_child, self._column.child(index))
 

--- a/python/pylibcudf/pylibcudf/column_factories.pyx
+++ b/python/pylibcudf/pylibcudf/column_factories.pyx
@@ -108,7 +108,7 @@ cpdef Column make_numeric_column(
     else:
         raise TypeError("Invalid mask argument")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -143,7 +143,7 @@ cpdef Column make_fixed_point_column(
     else:
         raise TypeError("Invalid mask argument")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -179,7 +179,7 @@ cpdef Column make_timestamp_column(
     else:
         raise TypeError("Invalid mask argument")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -215,7 +215,7 @@ cpdef Column make_duration_column(
     else:
         raise TypeError("Invalid mask argument")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -251,7 +251,7 @@ cpdef Column make_fixed_width_column(
     else:
         raise TypeError("Invalid mask argument")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/concatenate.pyx
+++ b/python/pylibcudf/pylibcudf/concatenate.pyx
@@ -52,7 +52,7 @@ cpdef concatenate(
     cdef vector[column_view] c_columns
     cdef vector[table_view] c_tables
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef unique_ptr[column] c_col_result

--- a/python/pylibcudf/pylibcudf/contiguous_split.pyx
+++ b/python/pylibcudf/pylibcudf/contiguous_split.pyx
@@ -193,7 +193,7 @@ cdef class ChunkedPack:
         cdef Stream _stream = _get_stream(stream)
         temp_mr = _get_memory_resource(temp_mr)
         cdef unique_ptr[chunked_pack] obj = chunked_pack.create(
-            input.view(), user_buffer_size, _stream.view().value(), temp_mr.get_mr()
+            input.view(), user_buffer_size, _stream.view().get(), temp_mr.get_mr()
         )
 
         cdef ChunkedPack out = ChunkedPack.__new__(ChunkedPack)
@@ -299,7 +299,7 @@ cdef class ChunkedPack:
             )
         )
         cdef Stream py_stream = self.stream
-        cdef cudaStream_t stream = py_stream.view().value()
+        cdef cudaStream_t stream = py_stream.view().get()
         with nogil:
             while dereference(self.c_obj).has_next():
                 size = dereference(self.c_obj).next(d_span)
@@ -354,7 +354,7 @@ cpdef PackedColumns pack(Table input, object stream: CudaStreamLike | None = Non
     """
     cdef unique_ptr[packed_columns] pack
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     mr = _get_memory_resource(mr)
     cdef table_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/copying.pyx
+++ b/python/pylibcudf/pylibcudf/copying.pyx
@@ -101,7 +101,7 @@ cpdef Table gather(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -165,7 +165,7 @@ cpdef Table scatter(
     cdef unique_ptr[table] c_result
     cdef vector[reference_wrapper[const scalar]] source_scalars
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef table_view c_source_table
     cdef column_view c_scatter_map
     cdef table_view c_target_table
@@ -269,7 +269,7 @@ cpdef Column allocate_like(
     cdef unique_ptr[column] c_result
     cdef size_type c_size = size if size is not None else input_column.size()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input_column = input_column.view()
@@ -328,7 +328,7 @@ cpdef Column copy_range_in_place(
 
     cdef mutable_column_view target_view = target_column.mutable_view()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     cdef column_view c_input_column = input_column.view()
     with nogil:
@@ -386,7 +386,7 @@ cpdef Column copy_range(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input_column = input_column.view()
@@ -441,7 +441,7 @@ cpdef Column shift(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -480,7 +480,7 @@ cpdef ColumnOrTable reverse(
     cdef unique_ptr[table] c_tbl_result
     cdef unique_ptr[column] c_col_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_input_column
     cdef table_view c_input_table
 
@@ -533,7 +533,7 @@ cpdef list[ColumnOrTable] slice(
     cdef vector[table_view] c_tbl_result
     cdef int i
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     cdef column_view c_input_column
     cdef table_view c_input_table
@@ -586,7 +586,7 @@ cpdef list[ColumnOrTable] split(
     cdef vector[table_view] c_tbl_result
     cdef int i
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     cdef column_view c_input_column
     cdef table_view c_input_table
@@ -651,7 +651,7 @@ cpdef Column copy_if_else(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_lhs_column
     cdef column_view c_rhs_column
     cdef column_view c_boolean_mask
@@ -749,7 +749,7 @@ cpdef Table boolean_mask_scatter(
     cdef unique_ptr[table] result
     cdef vector[reference_wrapper[const scalar]] source_scalars
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef table_view c_input_table
     cdef table_view c_target
     cdef column_view c_boolean_mask
@@ -815,7 +815,7 @@ cpdef Scalar get_element(
     """
     cdef unique_ptr[scalar] c_output
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input_column = input_column.view()

--- a/python/pylibcudf/pylibcudf/datetime.pyx
+++ b/python/pylibcudf/pylibcudf/datetime.pyx
@@ -80,7 +80,7 @@ cpdef Column extract_datetime_component(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -118,7 +118,7 @@ cpdef Column ceil_datetimes(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -154,7 +154,7 @@ cpdef Column floor_datetimes(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -190,7 +190,7 @@ cpdef Column round_datetimes(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -234,7 +234,7 @@ cpdef Column add_calendrical_months(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     c_input = input.view()
@@ -275,7 +275,7 @@ cpdef Column day_of_year(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -307,7 +307,7 @@ cpdef Column is_leap_year(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -339,7 +339,7 @@ cpdef Column last_day_of_month(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -371,7 +371,7 @@ cpdef Column extract_quarter(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -402,7 +402,7 @@ cpdef Column days_in_month(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/experimental/_join_streams.pyx
+++ b/python/pylibcudf/pylibcudf/experimental/_join_streams.pyx
@@ -50,12 +50,12 @@ cpdef void join_streams(
     >>> # ... continue work on join_stream ...
     """
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef vector[cudaStream_t] c_streams
 
     c_streams.reserve(len(streams))
     for s in streams:
-        c_streams.push_back((<Stream>_get_stream(s)).view().value())
+        c_streams.push_back((<Stream>_get_stream(s)).view().get())
 
     with nogil:
         cpp_stream_pool.join_streams(

--- a/python/pylibcudf/pylibcudf/filling.pyx
+++ b/python/pylibcudf/pylibcudf/filling.pyx
@@ -78,7 +78,7 @@ cpdef Column fill(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_destination = destination.view()
@@ -124,7 +124,7 @@ cpdef void fill_in_place(
     """
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     cdef mutable_column_view c_destination = destination.mutable_view()
     with nogil:
@@ -170,7 +170,7 @@ cpdef Column sequence(
     cdef size_type c_size = size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -217,7 +217,7 @@ cpdef Table repeat(
     cdef unique_ptr[table] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef table_view c_input_table
     cdef column_view c_count_column
 
@@ -277,7 +277,7 @@ cpdef Column calendrical_month_sequence(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/groupby.pyx
+++ b/python/pylibcudf/pylibcudf/groupby.pyx
@@ -204,7 +204,7 @@ cdef class GroupBy:
 
         cdef pair[unique_ptr[table], vector[aggregation_result]] c_res
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         # TODO: Need to capture C++ exceptions indicating that an invalid type was used.
         # We rely on libcudf to tell us this rather than checking the types beforehand
@@ -248,7 +248,7 @@ cdef class GroupBy:
 
         cdef pair[unique_ptr[table], vector[aggregation_result]] c_res
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             c_res = dereference(self.c_obj).scan(
@@ -295,7 +295,7 @@ cdef class GroupBy:
         cdef vector[size_type] c_offset = offset
         cdef pair[unique_ptr[table], unique_ptr[table]] c_res
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         c_values = values.view()
         with nogil:
@@ -340,7 +340,7 @@ cdef class GroupBy:
         cdef pair[unique_ptr[table], unique_ptr[table]] c_res
         cdef vector[replace_policy] c_replace_policies = replace_policies
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         cdef table_view c_value = value.view()
         with nogil:
@@ -385,7 +385,7 @@ cdef class GroupBy:
         mr = _get_memory_resource(mr)
         if values:
             c_groups = dereference(self.c_obj).get_groups(
-                values.view(), _stream.view().value(), mr.get_mr()
+                values.view(), _stream.view().get(), mr.get_mr()
             )
             return (
                 c_groups.offsets,
@@ -395,7 +395,7 @@ cdef class GroupBy:
         else:
             # c_groups.values is nullptr - call get_groups with empty table view
             c_groups = dereference(self.c_obj).get_groups(
-                empty_view, _stream.view().value(), mr.get_mr()
+                empty_view, _stream.view().get(), mr.get_mr()
             )
             return (
                 c_groups.offsets,

--- a/python/pylibcudf/pylibcudf/hashing.pyx
+++ b/python/pylibcudf/pylibcudf/hashing.pyx
@@ -72,7 +72,7 @@ cpdef Column murmurhash3_x86_32(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -112,7 +112,7 @@ cpdef Table murmurhash3_x64_128(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -153,7 +153,7 @@ cpdef Column xxhash_32(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -194,7 +194,7 @@ cpdef Column xxhash_64(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -235,7 +235,7 @@ cpdef Column md5(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -267,7 +267,7 @@ cpdef Column sha1(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -300,7 +300,7 @@ cpdef Column sha224(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -333,7 +333,7 @@ cpdef Column sha256(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -366,7 +366,7 @@ cpdef Column sha384(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -399,7 +399,7 @@ cpdef Column sha512(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -70,7 +70,7 @@ cpdef Table from_dlpack(
         raise ValueError("PyCapsule object contained a NULL pointer")
     PyCapsule_SetName(managed_tensor, "used_dltensor")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     # Note: A copy is always performed when converting the dlpack
@@ -118,7 +118,7 @@ cpdef object to_dlpack(Table input, object stream: CudaStreamLike | None = None,
             )
     cdef DLManagedTensor *dlpack_tensor
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     c_input = input.view()

--- a/python/pylibcudf/pylibcudf/io/avro.pyx
+++ b/python/pylibcudf/pylibcudf/io/avro.pyx
@@ -180,7 +180,7 @@ cpdef TableWithMetadata read_avro(
         Device memory resource used to allocate the returned table's device memory.
     """
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     mr = _get_memory_resource(mr)
     with nogil:
         c_result = move(cpp_read_avro(options.c_obj, _cs, mr.get_mr()))

--- a/python/pylibcudf/pylibcudf/io/csv.pyx
+++ b/python/pylibcudf/pylibcudf/io/csv.pyx
@@ -699,7 +699,7 @@ cpdef TableWithMetadata read_csv(
     """
     cdef table_with_metadata c_result
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     mr = _get_memory_resource(mr)
     with nogil:
         c_result = move(cpp_read_csv(options.c_obj, _cs, mr.get_mr()))
@@ -964,7 +964,7 @@ cpdef void write_csv(
         CUDA stream used for device memory operations and kernel launches
     """
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     with nogil:
         cpp_write_csv(move(options.c_obj), _cs)
 

--- a/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyx
+++ b/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyx
@@ -359,7 +359,7 @@ cdef class HybridScanReader:
                     indices_vec.data(), indices_vec.size()
                 ),
                 options.c_obj,
-                _stream.view().value()
+                _stream.view().get()
             ))
         return list(filtered)
 
@@ -464,7 +464,7 @@ cdef class HybridScanReader:
                 ),
                 std_span[const_size_type](indices_vec.data(), indices_vec.size()),
                 options.c_obj,
-                _stream.view().value()
+                _stream.view().get()
             ))
         return list(filtered)
 
@@ -508,7 +508,7 @@ cdef class HybridScanReader:
                 ),
                 std_span[const_size_type](indices_vec.data(), indices_vec.size()),
                 options.c_obj,
-                _stream.view().value()
+                _stream.view().get()
             ))
         return list(filtered)
 
@@ -541,7 +541,7 @@ cdef class HybridScanReader:
         with nogil:
             c_result = move(self.c_obj.get()[0].build_all_true_row_mask(
                 std_span[const_size_type](indices_vec.data(), indices_vec.size()),
-                _stream.view().value(),
+                _stream.view().get(),
                 mr.get_mr()
             ))
         return Column.from_libcudf(move(c_result), _stream, mr)
@@ -579,7 +579,7 @@ cdef class HybridScanReader:
             c_result = move(self.c_obj.get()[0].build_row_mask_with_page_index_stats(
                 std_span[const_size_type](indices_vec.data(), indices_vec.size()),
                 options.c_obj,
-                _stream.view().value(),
+                _stream.view().get(),
                 mr.get_mr()
             ))
         return Column.from_libcudf(move(c_result), _stream, mr)
@@ -665,7 +665,7 @@ cdef class HybridScanReader:
                 mask_view,
                 mask_data_pages,
                 options.c_obj,
-                _stream.view().value(),
+                _stream.view().get(),
                 mr.get_mr()
             ))
         return TableWithMetadata.from_libcudf(c_result, _stream, mr)
@@ -751,7 +751,7 @@ cdef class HybridScanReader:
                 mask_view,
                 mask_data_pages,
                 options.c_obj,
-                _stream.view().value(),
+                _stream.view().get(),
                 mr.get_mr()
             ))
         return TableWithMetadata.from_libcudf(c_result, _stream, mr)
@@ -827,7 +827,7 @@ cdef class HybridScanReader:
                     <const_device_span_const_uint8_t*>spans_vec.data(), spans_vec.size()
                 ),
                 options.c_obj,
-                _stream.view().value(),
+                _stream.view().get(),
                 mr.get_mr()
             ))
         return TableWithMetadata.from_libcudf(c_result, _stream, mr)
@@ -890,7 +890,7 @@ cdef class HybridScanReader:
                     <const_device_span_const_uint8_t*>spans_vec.data(), spans_vec.size()
                 ),
                 options.c_obj,
-                self._stream.view().value(),
+                self._stream.view().get(),
                 self.mr.get_mr()
             )
 
@@ -980,7 +980,7 @@ cdef class HybridScanReader:
                     <const_device_span_const_uint8_t*>spans_vec.data(), spans_vec.size()
                 ),
                 options.c_obj,
-                self._stream.view().value(),
+                self._stream.view().get(),
                 self.mr.get_mr()
             )
 

--- a/python/pylibcudf/pylibcudf/io/json.pyx
+++ b/python/pylibcudf/pylibcudf/io/json.pyx
@@ -749,7 +749,7 @@ cpdef tuple[list[Column], list[str], dict] chunked_read_json(
     child_names = None
     i = 0
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     mr = _get_memory_resource(mr)
     while True:
         options.enable_lines(True)
@@ -812,7 +812,7 @@ cpdef TableWithMetadata read_json(
     """
     cdef table_with_metadata c_result
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     mr = _get_memory_resource(mr)
     with nogil:
         c_result = move(cpp_read_json(options.c_obj, _cs, mr.get_mr()))
@@ -869,7 +869,7 @@ cpdef TableWithMetadata read_json_from_string_column(
     cdef column_contents c_contents
     cdef table_with_metadata c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     # Join the string column into a single string
@@ -1126,7 +1126,7 @@ cpdef void write_json(JsonWriterOptions options, object stream: CudaStreamLike |
     None
     """
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     with nogil:
         cpp_write_json(options.c_obj, _cs)
 

--- a/python/pylibcudf/pylibcudf/io/orc.pyx
+++ b/python/pylibcudf/pylibcudf/io/orc.pyx
@@ -474,7 +474,7 @@ cpdef TableWithMetadata read_orc(
     """
     cdef table_with_metadata c_result
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     mr = _get_memory_resource(mr)
     with nogil:
         c_result = move(cpp_read_orc(options.c_obj, _cs, mr.get_mr()))
@@ -503,7 +503,7 @@ cpdef ParsedOrcStatistics read_parsed_orc_statistics(
     """
     cdef Stream s = _get_stream(stream)
     cdef parsed_orc_statistics parsed
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     with nogil:
         parsed = cpp_read_parsed_orc_statistics(source_info.c_obj, _cs)
     return ParsedOrcStatistics.from_libcudf(parsed)
@@ -702,7 +702,7 @@ cpdef void write_orc(OrcWriterOptions options, object stream: CudaStreamLike | N
     None
     """
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     with nogil:
         cpp_write_orc(move(options.c_obj), _cs)
 
@@ -759,7 +759,7 @@ cdef class OrcChunkedWriter:
             OrcChunkedWriter
         )
         cdef Stream s = _get_stream(stream)
-        cdef cudaStream_t _cs = s.view().value()
+        cdef cudaStream_t _cs = s.view().get()
         orc_writer.c_obj.reset(new orc_chunked_writer(options.c_obj, _cs))
         return orc_writer
 

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -668,7 +668,7 @@ cdef class ChunkedParquetReader:
         cdef vector[unique_ptr[datasource]] sources
         cdef vector[cpp_FileMetaData] c_metadatas
         cdef vector[cpp_FileMetaData*] metadata_ptrs
-        cdef cudaStream_t stream_view = self._stream.view().value()
+        cdef cudaStream_t stream_view = self._stream.view().get()
         cdef size_t i
         if parquet_metadatas is None:
             with nogil:
@@ -771,7 +771,7 @@ cpdef TableWithMetadata read_parquet(
         provided, footers are read from the sources internally.
     """
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     cdef vector[unique_ptr[datasource]] sources
     cdef vector[cpp_FileMetaData] c_metadatas
     cdef vector[cpp_FileMetaData*] metadata_ptrs
@@ -879,7 +879,7 @@ cdef class ChunkedParquetWriter:
             ChunkedParquetWriter
         )
         cdef Stream s = _get_stream(stream)
-        cdef cudaStream_t _cs = s.view().value()
+        cdef cudaStream_t _cs = s.view().get()
         parquet_writer.c_obj.reset(
             new cpp_chunked_parquet_writer(options.c_obj, _cs)
         )
@@ -1486,7 +1486,7 @@ cpdef memoryview write_parquet(ParquetWriterOptions options, object stream: Cuda
     """
     cdef unique_ptr[vector[uint8_t]] c_result
     cdef Stream s = _get_stream(stream)
-    cdef cudaStream_t _cs = s.view().value()
+    cdef cudaStream_t _cs = s.view().get()
     with nogil:
         c_result = cpp_write_parquet(move(options.c_obj), _cs)
 

--- a/python/pylibcudf/pylibcudf/io/parquet_io_utils.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_io_utils.pyx
@@ -104,7 +104,7 @@ cpdef list fetch_byte_ranges_to_device(
             dereference(sources[0]),
             host_span[const_byte_range_info](ranges_vec.data(), ranges_vec.size()),
             policy,
-            _stream.view().value(),
+            _stream.view().get(),
             _mr.get_mr(),
         )
 

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -843,7 +843,7 @@ cpdef Table read_parquet_column_chunk_bounds(
     cdef object metadata_obj
     cdef object column_name
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     for metadata_obj in file_metadatas:

--- a/python/pylibcudf/pylibcudf/io/text.pyx
+++ b/python/pylibcudf/pylibcudf/io/text.pyx
@@ -230,7 +230,7 @@ cpdef Column multibyte_split(
     cdef unique_ptr[data_chunk_source] c_source = move(source.c_source)
     cdef string c_delimiter = delimiter.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if options is None:

--- a/python/pylibcudf/pylibcudf/io/timezone.pyx
+++ b/python/pylibcudf/pylibcudf/io/timezone.pyx
@@ -48,7 +48,7 @@ cpdef Table make_timezone_transition_table(
     cdef string c_tzdir = tzif_dir.encode()
     cdef string c_tzname = timezone_name.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/join.pyx
+++ b/python/pylibcudf/pylibcudf/join.pyx
@@ -93,7 +93,7 @@ cpdef tuple[Column, Column] inner_join(
     cdef cpp_join.gather_map_pair_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -141,7 +141,7 @@ cpdef tuple[Column, Column] left_join(
     cdef cpp_join.gather_map_pair_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -189,7 +189,7 @@ cpdef tuple[Column, Column] full_join(
     cdef cpp_join.gather_map_pair_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -236,7 +236,7 @@ cpdef Column left_semi_join(
     cdef cpp_join.gather_map_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef unique_ptr[cpp_join.filtered_join] join_obj
@@ -287,7 +287,7 @@ cpdef Column left_anti_join(
     cdef cpp_join.gather_map_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef unique_ptr[cpp_join.filtered_join] join_obj
@@ -336,7 +336,7 @@ cpdef Table cross_join(
     cdef unique_ptr[table] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -378,7 +378,7 @@ cpdef tuple[Column, Column] conditional_inner_join(
     cdef optional[size_t] output_size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -428,7 +428,7 @@ cpdef tuple[Column, Column] conditional_left_join(
     cdef optional[size_t] output_size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -477,7 +477,7 @@ cpdef tuple[Column, Column] conditional_full_join(
     cdef cpp_join.gather_map_pair_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -525,7 +525,7 @@ cpdef Column conditional_left_semi_join(
     cdef optional[size_t] output_size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -571,7 +571,7 @@ cpdef Column conditional_left_anti_join(
     cdef optional[size_t] output_size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left = left.view()
@@ -627,7 +627,7 @@ cpdef tuple[Column, Column] mixed_inner_join(
     cdef cpp_join.output_size_data_type empty_optional
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -691,7 +691,7 @@ cpdef tuple[Column, Column] mixed_left_join(
     cdef cpp_join.output_size_data_type empty_optional
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -755,7 +755,7 @@ cpdef tuple[Column, Column] mixed_full_join(
     cdef cpp_join.output_size_data_type empty_optional
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -817,7 +817,7 @@ cpdef Column mixed_left_semi_join(
     cdef cpp_join.gather_map_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -875,7 +875,7 @@ cpdef Column mixed_left_anti_join(
     cdef cpp_join.gather_map_type c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_left_keys = left_keys.view()
@@ -932,7 +932,7 @@ cdef class FilteredJoin:
             CUDA stream used for device memory operations and kernel launches.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
 
         cdef table_view c_right = right.view()
         with nogil:
@@ -974,7 +974,7 @@ cdef class FilteredJoin:
         cdef cpp_join.gather_map_type c_result
 
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
 
         cdef table_view c_left = left.view()
@@ -1015,7 +1015,7 @@ cdef class FilteredJoin:
         cdef cpp_join.gather_map_type c_result
 
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
 
         cdef table_view c_left = left.view()

--- a/python/pylibcudf/pylibcudf/json.pyx
+++ b/python/pylibcudf/pylibcudf/json.pyx
@@ -164,7 +164,7 @@ cpdef Column get_json_object(
 
     cdef cpp_json.get_json_object_options c_options = options.options
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     c_col = col.view()

--- a/python/pylibcudf/pylibcudf/labeling.pyx
+++ b/python/pylibcudf/pylibcudf/labeling.pyx
@@ -61,7 +61,7 @@ cpdef Column label_bins(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/detail/utilities/stream_pool.pxd
@@ -12,7 +12,7 @@ cdef extern from * nogil:
     """
     #include <cudf/detail/utilities/stream_pool.hpp>
     #include <cudf/utilities/span.hpp>
-    #include <cuda/stream_ref>
+    #include <cuda/stream>
     #include <vector>
 
     namespace {

--- a/python/pylibcudf/pylibcudf/lists.pyx
+++ b/python/pylibcudf/pylibcudf/lists.pyx
@@ -119,7 +119,7 @@ cpdef Table explode_outer(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -155,7 +155,7 @@ cpdef Column concatenate_rows(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -192,7 +192,7 @@ cpdef Column concatenate_list_elements(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -238,7 +238,7 @@ cpdef Column contains(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef lists_column_view c_list_view
     cdef column_view c_search_key_column
 
@@ -289,7 +289,7 @@ cpdef Column contains_nulls(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -336,7 +336,7 @@ cpdef Column index_of(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_search_key_column
 
     mr = _get_memory_resource(mr)
@@ -382,7 +382,7 @@ cpdef Column reverse(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -431,7 +431,7 @@ cpdef Column segmented_gather(
     cdef ListsColumnView list_view2 = gather_map_list.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view1 = list_view1.view()
@@ -473,7 +473,7 @@ cpdef Column extract_list_element(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_index_column
 
     mr = _get_memory_resource(mr)
@@ -518,7 +518,7 @@ cpdef Column count_elements(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -557,7 +557,7 @@ cpdef Column sequences(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef column_view c_starts
     cdef column_view c_steps
     cdef column_view c_sizes
@@ -619,7 +619,7 @@ cpdef Column sort_lists(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -677,7 +677,7 @@ cpdef Column difference_distinct(
     cdef ListsColumnView rhs_view = rhs.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_lhs_view = lhs_view.view()
@@ -727,7 +727,7 @@ cpdef Column have_overlap(
     cdef ListsColumnView rhs_view = rhs.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_lhs_view = lhs_view.view()
@@ -777,7 +777,7 @@ cpdef Column intersect_distinct(
     cdef ListsColumnView rhs_view = rhs.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_lhs_view = lhs_view.view()
@@ -828,7 +828,7 @@ cpdef Column union_distinct(
     cdef ListsColumnView rhs_view = rhs.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_lhs_view = lhs_view.view()
@@ -874,7 +874,7 @@ cpdef Column apply_retention_mask(
     cdef ListsColumnView mask_view = retention_mask.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -931,7 +931,7 @@ cpdef Column apply_deletion_mask(
     cdef ListsColumnView mask_view = deletion_mask.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()
@@ -975,7 +975,7 @@ cpdef Column distinct(
     cdef ListsColumnView list_view = input.list_view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef lists_column_view c_list_view = list_view.view()

--- a/python/pylibcudf/pylibcudf/merge.pyx
+++ b/python/pylibcudf/pylibcudf/merge.pyx
@@ -66,7 +66,7 @@ cpdef Table merge (
 
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/null_mask.pyx
+++ b/python/pylibcudf/pylibcudf/null_mask.pyx
@@ -72,7 +72,7 @@ cpdef DeviceBuffer copy_bitmask(
     """
     cdef device_buffer db
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_col = col.view()
@@ -119,7 +119,7 @@ cpdef DeviceBuffer copy_bitmask_from_bitmask(
         )
     cdef device_buffer db
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef uintptr_t ptr = bitmask.ptr
 
@@ -188,7 +188,7 @@ cpdef DeviceBuffer create_null_mask(
     """
     cdef device_buffer db
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -223,7 +223,7 @@ cpdef tuple[DeviceBuffer, int] bitmask_and(
     cdef Table c_table = Table(columns)
     cdef pair[device_buffer, size_type] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = c_table.view()
@@ -261,7 +261,7 @@ cpdef tuple[DeviceBuffer, int] bitmask_or(
     cdef Table c_table = Table(columns)
     cdef pair[device_buffer, size_type] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = c_table.view()
@@ -304,7 +304,7 @@ cpdef size_type null_count(
         )
     cdef uintptr_t ptr = bitmask.ptr
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     with nogil:
         return cpp_null_mask.null_count(
             <bitmask_type*>ptr,
@@ -347,7 +347,7 @@ cpdef size_type index_of_first_set_bit(
         )
     cdef uintptr_t ptr = bitmask.ptr
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     with nogil:
         return cpp_null_mask.index_of_first_set_bit(
             <bitmask_type*>ptr,

--- a/python/pylibcudf/pylibcudf/nvtext/byte_pair_encode.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/byte_pair_encode.pyx
@@ -40,7 +40,7 @@ cdef class BPEMergePairs:
     ):
         cdef column_view c_pairs = merge_pairs.view()
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             self.c_obj = move(
@@ -79,12 +79,12 @@ cpdef Column byte_pair_encoding(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if separator is None:
         separator = Scalar.from_libcudf(
-            cpp_make_string_scalar(" ".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar(" ".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/deduplicate.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/deduplicate.pyx
@@ -73,7 +73,7 @@ cpdef Column build_suffix_array(
     """
     cdef cpp_suffix_array_type c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -118,7 +118,7 @@ cpdef Column resolve_duplicates(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -171,7 +171,7 @@ cpdef Column resolve_duplicates_pair(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input1 = input1.view()

--- a/python/pylibcudf/pylibcudf/nvtext/edit_distance.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/edit_distance.pyx
@@ -51,7 +51,7 @@ cpdef Column edit_distance(
     cdef column_view c_targets = targets.view()
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/nvtext/generate_ngrams.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/generate_ngrams.pyx
@@ -62,7 +62,7 @@ cpdef Column generate_ngrams(
     cdef const string_scalar* c_separator = <const string_scalar*>separator.c_obj.get()
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -104,7 +104,7 @@ cpdef Column generate_character_ngrams(
     cdef column_view c_strings = input.view()
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -148,7 +148,7 @@ cpdef Column hash_character_ngrams(
     cdef column_view c_strings = input.view()
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/nvtext/jaccard.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/jaccard.pyx
@@ -55,7 +55,7 @@ cpdef Column jaccard_index(
     cdef column_view c_input2 = input2.view()
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:

--- a/python/pylibcudf/pylibcudf/nvtext/minhash.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/minhash.pyx
@@ -65,7 +65,7 @@ cpdef Column minhash(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -121,7 +121,7 @@ cpdef Column minhash64(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -178,7 +178,7 @@ cpdef Column minhash_ngrams(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -235,7 +235,7 @@ cpdef Column minhash64_ngrams(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/ngrams_tokenize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/ngrams_tokenize.pyx
@@ -59,7 +59,7 @@ cpdef Column ngrams_tokenize(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/normalize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/normalize.pyx
@@ -38,7 +38,7 @@ cdef class CharacterNormalizer:
     ):
         cdef column_view c_tokens = tokens.view()
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             self.c_obj = move(
@@ -75,7 +75,7 @@ cpdef Column normalize_spaces(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -114,7 +114,7 @@ cpdef Column normalize_characters(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/replace.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/replace.pyx
@@ -62,11 +62,11 @@ cpdef Column replace_tokens(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
     cdef column_view c_input = input.view()
     cdef column_view c_targets = targets.view()
@@ -118,15 +118,15 @@ cpdef Column filter_tokens(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
     if replacement is None:
         replacement = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/stemmer.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/stemmer.pyx
@@ -62,7 +62,7 @@ cpdef Column is_letter(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -104,7 +104,7 @@ cpdef Column porter_stemmer_measure(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/tokenize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/tokenize.pyx
@@ -49,7 +49,7 @@ cdef class TokenizeVocabulary:
     def __cinit__(self, Column vocab, object stream: CudaStreamLike | None = None, DeviceMemoryResource mr=None):
         cdef column_view c_vocab = vocab.view()
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             self.c_obj = move(cpp_load_vocabulary(c_vocab, _cs, mr.get_mr()))
@@ -84,12 +84,12 @@ cpdef Column tokenize_scalar(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef column_view c_input = input.view()
@@ -128,7 +128,7 @@ cpdef Column tokenize_column(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -171,12 +171,12 @@ cpdef Column count_tokens_scalar(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef column_view c_input = input.view()
@@ -215,7 +215,7 @@ cpdef Column count_tokens_column(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -253,7 +253,7 @@ cpdef Column character_tokenize(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -292,12 +292,12 @@ cpdef Column detokenize(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if separator is None:
         separator = Scalar.from_libcudf(
-            cpp_make_string_scalar(" ".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar(" ".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef column_view c_input = input.view()
@@ -347,7 +347,7 @@ cpdef Column tokenize_with_vocabulary(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/unicode_normalize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/unicode_normalize.pyx
@@ -60,7 +60,7 @@ cdef class UnicodeNormalizer:
     ):
         cdef table_view c_data = unicode_data.view()
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef DeviceMemoryResource _mr = _get_memory_resource(mr)
         with nogil:
             self.c_obj = move(
@@ -103,7 +103,7 @@ cpdef Column normalize_unicode(
         raise TypeError("normalizer must not be None")
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef DeviceMemoryResource _mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/nvtext/wordpiece_tokenize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/wordpiece_tokenize.pyx
@@ -39,7 +39,7 @@ cdef class WordPieceVocabulary:
     ):
         cdef column_view c_vocab = vocab.view()
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         with nogil:
             self.c_obj = move(cpp_load_wordpiece_vocabulary(
@@ -80,7 +80,7 @@ cpdef Column wordpiece_tokenize(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/partitioning.pyx
+++ b/python/pylibcudf/pylibcudf/partitioning.pyx
@@ -70,7 +70,7 @@ cpdef tuple[Table, list] hash_partition(
     cdef int c_num_partitions = num_partitions
     cdef vector[libcudf_types.size_type] columns_to_hash
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef table_view c_input = input.view()
     cdef table_view c_keys
@@ -137,7 +137,7 @@ cpdef tuple[Table, list] partition(
     cdef int c_num_partitions = num_partitions
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = t.view()
@@ -190,7 +190,7 @@ cpdef tuple[Table, list] round_robin_partition(
     cdef int c_start_partition = start_partition
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/quantiles.pyx
+++ b/python/pylibcudf/pylibcudf/quantiles.pyx
@@ -82,7 +82,7 @@ cpdef Column quantile(
         ordered_indices_view = ordered_indices.view()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -167,7 +167,7 @@ cpdef Table quantiles(
         null_precedence_vec = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/reduce.pyx
+++ b/python/pylibcudf/pylibcudf/reduce.pyx
@@ -90,7 +90,7 @@ cpdef Scalar reduce(
     cdef const scalar* c_init_ptr
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if init is not None:
@@ -147,7 +147,7 @@ cpdef Column scan(
     cdef const scan_aggregation *c_agg = agg.view_underlying_as_scan()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_col = col.view()
@@ -192,7 +192,7 @@ cpdef tuple[Scalar, Scalar] minmax(
     cdef Scalar max_scalar
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_col = col.view()
@@ -258,7 +258,7 @@ cpdef size_type unique_count(
 
     with nogil:
         return cpp_unique_count.unique_count(
-            c_source, null_handling, nan_handling, _stream.view().value()
+            c_source, null_handling, nan_handling, _stream.view().get()
         )
 
 
@@ -293,7 +293,7 @@ cpdef size_type distinct_count(
 
     with nogil:
         return cpp_distinct_count.distinct_count(
-            c_source, null_handling, nan_handling, _stream.view().value()
+            c_source, null_handling, nan_handling, _stream.view().get()
         )
 
 
@@ -327,7 +327,7 @@ cpdef size_type unique_count_table(
 
     with nogil:
         return cpp_unique_count.unique_count(
-            c_source, nulls_equal, _stream.view().value()
+            c_source, nulls_equal, _stream.view().get()
         )
 
 
@@ -361,7 +361,7 @@ cpdef size_type distinct_count_table(
 
     with nogil:
         return cpp_distinct_count.distinct_count(
-            c_source, nulls_equal, _stream.view().value()
+            c_source, nulls_equal, _stream.view().get()
         )
 
 
@@ -394,7 +394,7 @@ cdef class ApproxDistinctCount:
         DeviceMemoryResource mr=None,
     ):
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef DeviceMemoryResource _mr = _get_memory_resource(mr)
         cdef table_view c_input = input.view()
         cdef any_resource[device_accessible] c_mr = any_resource[device_accessible](
@@ -418,7 +418,7 @@ cdef class ApproxDistinctCount:
             CUDA stream on which to perform the operation.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef table_view c_input = input.view()
         with nogil:
             dereference(self.c_obj).add(c_input, _cs)
@@ -438,7 +438,7 @@ cdef class ApproxDistinctCount:
             CUDA stream on which to perform the operation.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         with nogil:
             dereference(self.c_obj).merge(dereference(other.c_obj), _cs)
 
@@ -456,7 +456,7 @@ cdef class ApproxDistinctCount:
             The approximate number of distinct rows.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef size_t result
         with nogil:
             result = dereference(self.c_obj).estimate(_cs)

--- a/python/pylibcudf/pylibcudf/replace.pyx
+++ b/python/pylibcudf/pylibcudf/replace.pyx
@@ -78,7 +78,7 @@ cpdef Column replace_nulls(
     cdef column_view c_replacement
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source_column = source_column.view()
@@ -163,7 +163,7 @@ cpdef Column find_and_replace_all(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source_column = source_column.view()
@@ -223,7 +223,7 @@ cpdef Column clamp(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source_column = source_column.view()
@@ -279,7 +279,7 @@ cpdef Column normalize_nans_and_zeros(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source_column = source_column.view()

--- a/python/pylibcudf/pylibcudf/reshape.pyx
+++ b/python/pylibcudf/pylibcudf/reshape.pyx
@@ -62,7 +62,7 @@ cpdef Column interleave_columns(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -102,7 +102,7 @@ cpdef Table tile(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -140,7 +140,7 @@ cpdef void table_to_array(
             "Size exceeds the size_t limit."
         )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
 
     cdef device_span[byte] span = device_span[byte](
         <byte*> ptr, size

--- a/python/pylibcudf/pylibcudf/rolling.pyx
+++ b/python/pylibcudf/pylibcudf/rolling.pyx
@@ -172,7 +172,7 @@ cpdef Table grouped_range_rolling_window(
         crequests.push_back(move((<RollingRequest?>req).view()))
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_group_keys = group_keys.view()
@@ -235,7 +235,7 @@ cpdef Column rolling_window(
     cdef const rolling_aggregation *c_agg = agg.view_underlying_as_rolling()
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source = source.view()
@@ -325,7 +325,7 @@ cpdef tuple[Column, Column] make_range_windows(
     cdef pair[unique_ptr[column], unique_ptr[column]] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_group_keys = group_keys.view()

--- a/python/pylibcudf/pylibcudf/round.pyx
+++ b/python/pylibcudf/pylibcudf/round.pyx
@@ -65,7 +65,7 @@ cpdef Column round(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source = source.view()
@@ -115,7 +115,7 @@ cpdef Column round_decimal(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_source = source.view()

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -163,7 +163,7 @@ cdef class Scalar:
     cpdef bool is_valid(self, object stream: CudaStreamLike | None = None):
         """True if the scalar is valid, false if not"""
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         return self.get().is_valid(_cs)
 
     def to_arrow(
@@ -187,7 +187,7 @@ cdef class Scalar:
         # Note that metadata for scalars is primarily important for preserving
         # information on nested types since names are otherwise irrelevant.
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         return Column.from_scalar(self, 1, _stream).to_arrow(metadata=metadata)[0]
 
     @staticmethod
@@ -234,7 +234,7 @@ cdef class Scalar:
         New empty (null) scalar of the given type.
         """
         cdef Stream _stream = <Stream>stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         return Scalar.from_libcudf(
             move(make_empty_scalar_like(column.view(), _cs, mr.get_mr()))
         )
@@ -281,7 +281,7 @@ cdef class Scalar:
             New pylibcudf.Scalar
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         return _from_py(py_val, dtype, _stream, mr)
 
@@ -310,7 +310,7 @@ cdef class Scalar:
             New pylibcudf.Scalar
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
         return _from_numpy(np_val, _stream, mr)
 
@@ -331,7 +331,7 @@ cdef class Scalar:
             A Python scalar associated with the type of the Scalar.
         """
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         if not self.is_valid(stream):
             return None
 
@@ -395,7 +395,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef DataType c_dtype
     if dtype is None:
         raise ValueError("Must specify a dtype for a None value.")
@@ -424,7 +424,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef unique_ptr[scalar] c_obj
     cdef DataType c_dtype
     if dtype is None:
@@ -454,7 +454,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef unique_ptr[scalar] c_obj
     cdef DataType c_dtype
     cdef duration_ns c_duration_ns
@@ -618,7 +618,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     if dtype is None:
         dtype = DataType(type_id.BOOL8)
     elif dtype.id() != type_id.BOOL8:
@@ -641,7 +641,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     if dtype is None:
         dtype = DataType(type_id.STRING)
     elif dtype.id() != type_id.STRING:
@@ -660,7 +660,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef unique_ptr[scalar] c_obj
     cdef duration_us c_duration_us
     cdef duration_ns c_duration_ns
@@ -739,7 +739,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef unique_ptr[scalar] c_obj
     cdef duration_us c_duration_us
     cdef duration_ns c_duration_ns
@@ -836,7 +836,7 @@ def _(
     py_val, dtype: DataType | None, stream: Stream, mr: DeviceMemoryResource
 ):
     cdef Stream _stream = stream
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     scale = py_val.as_tuple().exponent
     # 38 for the max precision of DECIMAL128
     with decimal.localcontext(prec=38):
@@ -878,7 +878,7 @@ if np is not None:
     @_from_numpy.register(np.bool_)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef DataType dtype = DataType(type_id.BOOL8)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -891,7 +891,7 @@ if np is not None:
     @_from_numpy.register(np.str_)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef DataType dtype = DataType(type_id.STRING)
         cdef unique_ptr[scalar] c_obj = make_string_scalar(
             np_val.item().encode(),
@@ -904,7 +904,7 @@ if np is not None:
     @_from_numpy.register(np.int8)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.INT8)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -916,7 +916,7 @@ if np is not None:
     @_from_numpy.register(np.int16)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.INT16)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -928,7 +928,7 @@ if np is not None:
     @_from_numpy.register(np.int32)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.INT32)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -940,7 +940,7 @@ if np is not None:
     @_from_numpy.register(np.int64)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.INT64)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -952,7 +952,7 @@ if np is not None:
     @_from_numpy.register(np.uint8)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.UINT8)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -964,7 +964,7 @@ if np is not None:
     @_from_numpy.register(np.uint16)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.UINT16)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -976,7 +976,7 @@ if np is not None:
     @_from_numpy.register(np.uint32)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.UINT32)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -988,7 +988,7 @@ if np is not None:
     @_from_numpy.register(np.uint64)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.UINT64)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -1000,7 +1000,7 @@ if np is not None:
     @_from_numpy.register(np.float32)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.FLOAT32)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()
@@ -1012,7 +1012,7 @@ if np is not None:
     @_from_numpy.register(np.float64)
     def _(np_val, stream: Stream, mr: DeviceMemoryResource):
         cdef Stream _stream = stream
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         dtype = DataType(type_id.FLOAT64)
         cdef unique_ptr[scalar] c_obj = make_numeric_scalar(
             dtype.c_obj, _cs, mr.get_mr()

--- a/python/pylibcudf/pylibcudf/search.pyx
+++ b/python/pylibcudf/pylibcudf/search.pyx
@@ -62,7 +62,7 @@ cpdef Column lower_bound(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_haystack = haystack.view()
@@ -116,7 +116,7 @@ cpdef Column upper_bound(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_haystack = haystack.view()
@@ -159,7 +159,7 @@ cpdef Column contains(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_haystack = haystack.view()

--- a/python/pylibcudf/pylibcudf/sorting.pyx
+++ b/python/pylibcudf/pylibcudf/sorting.pyx
@@ -70,7 +70,7 @@ cpdef Column sorted_order(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -116,7 +116,7 @@ cpdef Column stable_sorted_order(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -168,7 +168,7 @@ cpdef Column rank(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input_view = input_view.view()
@@ -215,7 +215,7 @@ cpdef bool is_sorted(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef table_view c_tbl = tbl.view()
 
     with nogil:
@@ -264,7 +264,7 @@ cpdef Table segmented_sort_by_key(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_values = values.view()
@@ -320,7 +320,7 @@ cpdef Table stable_segmented_sort_by_key(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_values = values.view()
@@ -372,7 +372,7 @@ cpdef Table sort_by_key(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_values = values.view()
@@ -422,7 +422,7 @@ cpdef Table stable_sort_by_key(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_values = values.view()
@@ -469,7 +469,7 @@ cpdef Table sort(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -514,7 +514,7 @@ cpdef Table stable_sort(
     cdef vector[null_order] c_null_precedence = null_precedence
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -559,7 +559,7 @@ cpdef Column top_k(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_col = col.view()
@@ -607,7 +607,7 @@ cpdef Column top_k_order(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_col = col.view()

--- a/python/pylibcudf/pylibcudf/stream_compaction.pyx
+++ b/python/pylibcudf/pylibcudf/stream_compaction.pyx
@@ -77,7 +77,7 @@ cpdef Table drop_nulls(
     cdef vector[size_type] c_keys = keys
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -117,7 +117,7 @@ cpdef Table drop_nans(
     cdef vector[size_type] c_keys = keys
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -153,7 +153,7 @@ cpdef Table apply_retention_mask(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -205,7 +205,7 @@ cpdef Table apply_deletion_mask(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_source_table = source_table.view()
@@ -255,7 +255,7 @@ cpdef Table unique(
     cdef vector[size_type] c_keys = keys
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -302,7 +302,7 @@ cpdef Table distinct(
     cdef vector[size_type] c_keys = keys
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -345,7 +345,7 @@ cpdef Column distinct_indices(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -392,7 +392,7 @@ cpdef Table stable_distinct(
     cdef vector[size_type] c_keys = keys
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -432,7 +432,7 @@ cpdef Table filter(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_predicate_table = predicate_table.view()

--- a/python/pylibcudf/pylibcudf/strings/attributes.pyx
+++ b/python/pylibcudf/pylibcudf/strings/attributes.pyx
@@ -39,7 +39,7 @@ cpdef Column count_characters(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_source_strings = source_strings.view()
     with nogil:
@@ -71,7 +71,7 @@ cpdef Column count_bytes(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_source_strings = source_strings.view()
     with nogil:
@@ -103,7 +103,7 @@ cpdef Column code_points(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_source_strings = source_strings.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/capitalize.pyx
+++ b/python/pylibcudf/pylibcudf/strings/capitalize.pyx
@@ -52,13 +52,13 @@ cpdef Column capitalize(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
 
     if delimiters is None:
         delimiters = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef const string_scalar* cpp_delimiters = <const string_scalar*>(
@@ -102,7 +102,7 @@ cpdef Column title(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -130,7 +130,7 @@ cpdef Column is_title(Column input, object stream: CudaStreamLike | None = None,
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/case.pyx
+++ b/python/pylibcudf/pylibcudf/strings/case.pyx
@@ -39,7 +39,7 @@ cpdef Column to_lower(Column input, object stream: CudaStreamLike | None = None,
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -68,7 +68,7 @@ cpdef Column to_upper(Column input, object stream: CudaStreamLike | None = None,
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -99,7 +99,7 @@ cpdef Column swapcase(Column input, object stream: CudaStreamLike | None = None,
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/char_types.pyx
+++ b/python/pylibcudf/pylibcudf/strings/char_types.pyx
@@ -57,7 +57,7 @@ cpdef Column all_characters_of_type(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_source_strings = source_strings.view()
     with nogil:
@@ -107,7 +107,7 @@ cpdef Column filter_characters_of_type(
     )
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_source_strings = source_strings.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/combine.pyx
+++ b/python/pylibcudf/pylibcudf/strings/combine.pyx
@@ -76,14 +76,14 @@ cpdef Column concatenate(
     cdef const string_scalar* c_col_narep
     cdef const string_scalar* c_separator
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef table_view c_strings_columns
     cdef column_view c_separator_view
 
     if narep is None:
         narep = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
     cdef const string_scalar* c_narep = <const string_scalar*>(
         narep.c_obj.get()
@@ -92,7 +92,7 @@ cpdef Column concatenate(
     if ColumnOrScalar is Column:
         if col_narep is None:
             col_narep = Scalar.from_libcudf(
-                cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+                cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
             )
         c_col_narep = <const string_scalar*>(
             col_narep.c_obj.get()
@@ -163,7 +163,7 @@ cpdef Column join_strings(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef const string_scalar* c_separator = <const string_scalar*>(
@@ -234,7 +234,7 @@ cpdef Column join_list_elements(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_lists_strings_column
     cdef column_view c_separator_view

--- a/python/pylibcudf/pylibcudf/strings/contains.pyx
+++ b/python/pylibcudf/pylibcudf/strings/contains.pyx
@@ -46,7 +46,7 @@ cpdef Column contains_re(
 
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     if _stream is None:
         _stream = _get_stream(None)
     mr = _get_memory_resource(mr)
@@ -88,7 +88,7 @@ cpdef Column count_re(
 
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -129,7 +129,7 @@ cpdef Column matches_re(
 
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -173,7 +173,7 @@ cpdef Column like(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
 

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_booleans.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_booleans.pyx
@@ -53,7 +53,7 @@ cpdef Column to_booleans(
         true_string.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -107,7 +107,7 @@ cpdef Column from_booleans(
         false_string.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_booleans = booleans.view()

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_datetime.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_datetime.pyx
@@ -57,7 +57,7 @@ cpdef Column to_timestamps(
     cdef unique_ptr[column] c_result
     cdef string c_format = format.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -106,7 +106,7 @@ cpdef Column from_timestamps(
     cdef unique_ptr[column] c_result
     cdef string c_format = format.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_timestamps = timestamps.view()
     cdef column_view c_input_strings_names = input_strings_names.view()
@@ -152,7 +152,7 @@ cpdef Column is_timestamp(
     cdef unique_ptr[column] c_result
     cdef string c_format = format.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_durations.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_durations.pyx
@@ -57,7 +57,7 @@ cpdef Column to_durations(
     cdef unique_ptr[column] c_result
     cdef string c_format = format.encode()
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -103,7 +103,7 @@ cpdef Column from_durations(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if format is None:

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_fixed_point.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_fixed_point.pyx
@@ -48,7 +48,7 @@ cpdef Column to_fixed_point(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -86,7 +86,7 @@ cpdef Column from_fixed_point(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -128,7 +128,7 @@ cpdef Column is_fixed_point(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if decimal_type is None:

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_floats.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_floats.pyx
@@ -50,7 +50,7 @@ cpdef Column to_floats(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_strings = strings.view()
@@ -89,7 +89,7 @@ cpdef Column from_floats(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_floats = floats.view()
@@ -123,7 +123,7 @@ cpdef Column is_float(Column input, object stream: CudaStreamLike | None = None,
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_integers.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_integers.pyx
@@ -54,7 +54,7 @@ cpdef Column to_integers(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -95,7 +95,7 @@ cpdef Column from_integers(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_integers = integers.view()
@@ -143,7 +143,7 @@ cpdef Column is_integer(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -197,7 +197,7 @@ cpdef Column hex_to_integers(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -236,7 +236,7 @@ cpdef Column is_hex(Column input, object stream: CudaStreamLike | None = None, D
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -276,7 +276,7 @@ cpdef Column integers_to_hex(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_ipv4.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_ipv4.pyx
@@ -40,7 +40,7 @@ cpdef Column ipv4_to_integers(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -75,7 +75,7 @@ cpdef Column integers_to_ipv4(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_integers = integers.view()
@@ -109,7 +109,7 @@ cpdef Column is_ipv4(Column input, object stream: CudaStreamLike | None = None, 
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_lists.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_lists.pyx
@@ -64,12 +64,12 @@ cpdef Column format_list_column(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if na_rep is None:
         na_rep = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef const string_scalar* c_na_rep = <const string_scalar*>(

--- a/python/pylibcudf/pylibcudf/strings/convert/convert_urls.pyx
+++ b/python/pylibcudf/pylibcudf/strings/convert/convert_urls.pyx
@@ -39,7 +39,7 @@ cpdef Column url_encode(Column input, object stream: CudaStreamLike | None = Non
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -72,7 +72,7 @@ cpdef Column url_decode(Column input, object stream: CudaStreamLike | None = Non
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/strings/extract.pyx
+++ b/python/pylibcudf/pylibcudf/strings/extract.pyx
@@ -48,7 +48,7 @@ cpdef Table extract(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -88,7 +88,7 @@ cpdef Column extract_all_record(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -133,7 +133,7 @@ cpdef Column extract_single(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/find.pyx
+++ b/python/pylibcudf/pylibcudf/strings/find.pyx
@@ -65,7 +65,7 @@ cpdef Column find(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_target
@@ -132,7 +132,7 @@ cpdef Column rfind(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -184,7 +184,7 @@ cpdef Column contains(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_target
@@ -250,7 +250,7 @@ cpdef Column starts_with(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_target
@@ -315,7 +315,7 @@ cpdef Column ends_with(
     """
     cdef unique_ptr[column] result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_target

--- a/python/pylibcudf/pylibcudf/strings/find_multiple.pyx
+++ b/python/pylibcudf/pylibcudf/strings/find_multiple.pyx
@@ -48,7 +48,7 @@ cpdef Column find_multiple(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     cdef column_view c_targets = targets.view()
@@ -91,7 +91,7 @@ cpdef Table contains_multiple(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     cdef column_view c_targets = targets.view()

--- a/python/pylibcudf/pylibcudf/strings/findall.pyx
+++ b/python/pylibcudf/pylibcudf/strings/findall.pyx
@@ -44,7 +44,7 @@ cpdef Column findall(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -83,7 +83,7 @@ cpdef Column find_re(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/padding.pyx
+++ b/python/pylibcudf/pylibcudf/strings/padding.pyx
@@ -53,7 +53,7 @@ cpdef Column pad(
     cdef unique_ptr[column] c_result
     cdef string c_fill_char = fill_char.encode("utf-8")
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -92,7 +92,7 @@ cpdef Column zfill(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -129,7 +129,7 @@ cpdef Column zfill_by_widths(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     cdef column_view c_widths = widths.view()

--- a/python/pylibcudf/pylibcudf/strings/repeat.pyx
+++ b/python/pylibcudf/pylibcudf/strings/repeat.pyx
@@ -51,7 +51,7 @@ cpdef Column repeat_strings(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_repeat_times

--- a/python/pylibcudf/pylibcudf/strings/replace.pyx
+++ b/python/pylibcudf/pylibcudf/strings/replace.pyx
@@ -67,7 +67,7 @@ cpdef Column replace(
     target_str = <string_scalar *>(target.c_obj.get())
     repl_str = <string_scalar *>(repl.c_obj.get())
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -117,7 +117,7 @@ cpdef Column replace_multiple(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     cdef column_view c_target = target.view()
@@ -173,13 +173,13 @@ cpdef Column replace_slice(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
 
     if repl is None:
         repl = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef const string_scalar* scalar_str = <string_scalar*>(repl.c_obj.get())

--- a/python/pylibcudf/pylibcudf/strings/replace_re.pyx
+++ b/python/pylibcudf/pylibcudf/strings/replace_re.pyx
@@ -60,13 +60,13 @@ cpdef Column replace_re(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
 
     if replacement is None:
         replacement = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
     c_input = input.view()
     with nogil:
@@ -114,7 +114,7 @@ cpdef Column replace_with_backrefs(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef string c_replacement = replacement.encode()
 

--- a/python/pylibcudf/pylibcudf/strings/reverse.pyx
+++ b/python/pylibcudf/pylibcudf/strings/reverse.pyx
@@ -39,7 +39,7 @@ cpdef Column reverse(Column input, object stream: CudaStreamLike | None = None, 
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/slice.pyx
+++ b/python/pylibcudf/pylibcudf/strings/slice.pyx
@@ -67,7 +67,7 @@ cpdef Column slice_strings(
     cdef numeric_scalar[size_type]* cpp_stop
     cdef numeric_scalar[size_type]* cpp_step
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
     cdef column_view c_start
@@ -100,15 +100,15 @@ cpdef Column slice_strings(
     elif ColumnOrScalar is Scalar:
         if start is None:
             start = Scalar.from_libcudf(
-                cpp_make_fixed_width_scalar(0, _stream.view().value(), mr.get_mr())
+                cpp_make_fixed_width_scalar(0, _stream.view().get(), mr.get_mr())
             )
         if stop is None:
             stop = Scalar.from_libcudf(
-                cpp_make_fixed_width_scalar(0, _stream.view().value(), mr.get_mr())
+                cpp_make_fixed_width_scalar(0, _stream.view().get(), mr.get_mr())
             )
         if step is None:
             step = Scalar.from_libcudf(
-                cpp_make_fixed_width_scalar(1, _stream.view().value(), mr.get_mr())
+                cpp_make_fixed_width_scalar(1, _stream.view().get(), mr.get_mr())
             )
 
         cpp_start = <numeric_scalar[size_type]*>start.c_obj.get()

--- a/python/pylibcudf/pylibcudf/strings/split/partition.pyx
+++ b/python/pylibcudf/pylibcudf/strings/split/partition.pyx
@@ -53,12 +53,12 @@ cpdef Table partition(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef const string_scalar* c_delimiter = <const string_scalar*>(
@@ -104,12 +104,12 @@ cpdef Table rpartition(
     cdef unique_ptr[table] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if delimiter is None:
         delimiter = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef const string_scalar* c_delimiter = <const string_scalar*>(

--- a/python/pylibcudf/pylibcudf/strings/split/split.pyx
+++ b/python/pylibcudf/pylibcudf/strings/split/split.pyx
@@ -71,7 +71,7 @@ cpdef Table split(
         delimiter.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_strings_column = strings_column.view()
@@ -125,7 +125,7 @@ cpdef Table rsplit(
         delimiter.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_strings_column = strings_column.view()
@@ -174,7 +174,7 @@ cpdef Column split_record(
         delimiter.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_strings = strings.view()
@@ -225,7 +225,7 @@ cpdef Column rsplit_record(
         delimiter.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_strings = strings.view()
@@ -273,7 +273,7 @@ cpdef Table split_re(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -321,7 +321,7 @@ cpdef Table rsplit_re(
     """
     cdef unique_ptr[table] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -368,7 +368,7 @@ cpdef Column split_record_re(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -412,7 +412,7 @@ cpdef Column rsplit_record_re(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -437,7 +437,7 @@ cpdef Column split_part(
         delimiter.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/strings/strip.pyx
+++ b/python/pylibcudf/pylibcudf/strings/strip.pyx
@@ -54,13 +54,13 @@ cpdef Column strip(
         New strings column.
     """
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input
 
     if to_strip is None:
         to_strip = Scalar.from_libcudf(
-            cpp_make_string_scalar("".encode(), _stream.view().value(), mr.get_mr())
+            cpp_make_string_scalar("".encode(), _stream.view().get(), mr.get_mr())
         )
 
     cdef unique_ptr[column] c_result

--- a/python/pylibcudf/pylibcudf/strings/translate.pyx
+++ b/python/pylibcudf/pylibcudf/strings/translate.pyx
@@ -79,7 +79,7 @@ cpdef Column translate(
         chars_table
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:
@@ -135,7 +135,7 @@ cpdef Column filter_characters(
         replacement.c_obj.get()
     )
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/strings/wrap.pyx
+++ b/python/pylibcudf/pylibcudf/strings/wrap.pyx
@@ -48,7 +48,7 @@ cpdef Column wrap(
     """
     cdef unique_ptr[column] c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
     cdef column_view c_input = input.view()
     with nogil:

--- a/python/pylibcudf/pylibcudf/table.pyx
+++ b/python/pylibcudf/pylibcudf/table.pyx
@@ -182,7 +182,7 @@ cdef class Table:
         cdef unique_ptr[arrow_table] c_result
 
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         mr = _get_memory_resource(mr)
 
         if hasattr(obj, "__arrow_c_device_array__"):
@@ -412,7 +412,7 @@ cdef class Table:
     def _to_host_array(self, object stream: CudaStreamLike):
         cdef ArrowArray* raw_host_array_ptr
         cdef Stream _stream = _get_stream(stream)
-        cdef cudaStream_t _cs = _stream.view().value()
+        cdef cudaStream_t _cs = _stream.view().get()
         cdef table_view c_self = self.view()
 
         with nogil:

--- a/python/pylibcudf/pylibcudf/table_equality.pyx
+++ b/python/pylibcudf/pylibcudf/table_equality.pyx
@@ -52,7 +52,7 @@ cpdef bool tables_equal(
     """
     cdef bool c_result
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     cdef table_view c_left = left.view()
     cdef table_view c_right = right.view()
 

--- a/python/pylibcudf/pylibcudf/transform.pyx
+++ b/python/pylibcudf/pylibcudf/transform.pyx
@@ -78,7 +78,7 @@ cpdef tuple[gpumemoryview, int] nans_to_nulls(
     cdef pair[unique_ptr[device_buffer], size_type] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -121,7 +121,7 @@ cpdef Column column_nans_to_nulls(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -158,7 +158,7 @@ cpdef Column compute_column(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -197,7 +197,7 @@ cpdef Column compute_column_jit(
     cdef unique_ptr[column] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -233,7 +233,7 @@ cpdef tuple[gpumemoryview, int] bools_to_mask(
     cdef pair[unique_ptr[device_buffer], size_type] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -281,7 +281,7 @@ cpdef Column mask_to_bools(
     cdef bitmask_type * bitmask_ptr = <bitmask_type*>bitmask
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     with nogil:
@@ -359,7 +359,7 @@ cpdef Column transform(
     cdef size_type base_size
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     if inputs:
@@ -427,7 +427,7 @@ cpdef tuple[Table, Column] encode(
     cdef pair[unique_ptr[table], unique_ptr[column]] c_result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input = input.view()
@@ -469,7 +469,7 @@ cpdef Table one_hot_encode(
     cdef Table owner_table
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()

--- a/python/pylibcudf/pylibcudf/transpose.pyx
+++ b/python/pylibcudf/pylibcudf/transpose.pyx
@@ -45,7 +45,7 @@ cpdef Table transpose(
     cdef pair[unique_ptr[column], table_view] c_result
     cdef Table owner_table
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef table_view c_input_table = input_table.view()

--- a/python/pylibcudf/pylibcudf/unary.pyx
+++ b/python/pylibcudf/pylibcudf/unary.pyx
@@ -62,7 +62,7 @@ cpdef Column unary_operation(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -96,7 +96,7 @@ cpdef Column is_null(Column input, object stream: CudaStreamLike | None = None, 
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -128,7 +128,7 @@ cpdef Column is_valid(Column input, object stream: CudaStreamLike | None = None,
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -164,7 +164,7 @@ cpdef Column cast(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -202,7 +202,7 @@ cpdef Column bit_cast(
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -236,7 +236,7 @@ cpdef Column is_nan(Column input, object stream: CudaStreamLike | None = None, D
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()
@@ -268,7 +268,7 @@ cpdef Column is_not_nan(Column input, object stream: CudaStreamLike | None = Non
     cdef unique_ptr[column] result
 
     cdef Stream _stream = _get_stream(stream)
-    cdef cudaStream_t _cs = _stream.view().value()
+    cdef cudaStream_t _cs = _stream.view().get()
     mr = _get_memory_resource(mr)
 
     cdef column_view c_input = input.view()


### PR DESCRIPTION
## Description

Use the `get()` compatibility alias added in [RMM #2537](https://github.com/rapidsai/rmm/pull/2537). This spelling is shared by `rmm::cuda_stream_view` and `cuda::stream_ref`.

This preserves existing stream types and public APIs while extracting mechanical accessor updates from the broader [stream migration](https://github.com/rapidsai/build-planning/issues/318). It is independently buildable without [RMM #2372](https://github.com/rapidsai/rmm/pull/2372) and leaves the migration PR focused on actual type and signature changes.

This updates raw stream extraction at Cython boundaries and uses the CUDA stream umbrella header where stream definitions are required, without changing libcudf stream types or public APIs. The remaining type, construction, and forwarding changes stay in [cuDF #23929](https://github.com/NVIDIA/cudf/pull/23929).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
