### PR TITLE
Build noarch packages in parallel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   python-build-noarch:
-    needs: [build-details, telemetry-setup, cpp-build, python-build]
+    needs: [build-details, telemetry-setup]
     permissions:
       actions: read
       contents: read
@@ -304,7 +304,7 @@ jobs:
       # trailing underscore to avoid collision with `cudf-streaming` and `cudf-polars`
       publish-wheel-search-key: cudf_wheel_python_cudf_
   wheel-python-build-noarch:
-    needs: [build-details, telemetry-setup, wheel-cpp-build, wheel-python-build]
+    needs: [build-details, telemetry-setup]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -332,7 +332,7 @@ jobs:
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-build-noarch:
-    needs: [build-details, conda-cpp-build, conda-python-build]
+    needs: [build-details]
     permissions:
       actions: read
       contents: read
@@ -364,7 +364,7 @@ jobs:
       matrix_filter: map(select(.GPU != "gb300" and .GPU != "gh200"))
   conda-python-other-tests:
     # Tests for dask_cudf, cudf_polars, custreamz, cudf_kafka are separated for CI parallelism
-    needs: [conda-python-build-noarch, changed-files]
+    needs: [conda-python-build, conda-python-build-noarch, changed-files]
     permissions:
       actions: read
       contents: read
@@ -541,7 +541,7 @@ jobs:
       # https://github.com/NVIDIA/cudf/issues/23498
       matrix_filter: map(select(.GPU != "gb300" and .GPU != "gh200"))
   wheel-python-build-noarch:
-    needs: [build-details, wheel-cpp-build, wheel-python-build]
+    needs: [build-details, checks]
     permissions:
       actions: read
       contents: read
@@ -628,7 +628,7 @@ jobs:
         --cudf-polars-shard-id ${{ matrix.shard_id }}
         --cudf-polars-num-shards ${{ matrix.num_shards }}
   wheel-tests-dask-cudf:
-    needs: [wheel-python-build-noarch, changed-files]
+    needs: [wheel-python-build, wheel-python-build-noarch, changed-files]
     permissions:
       actions: read
       contents: read

--- a/ci/build_python_noarch.sh
+++ b/ci/build_python_noarch.sh
@@ -15,18 +15,11 @@ rapids-generate-version > ./python/cudf/cudf/VERSION
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libcudf cudf --cuda "$RAPIDS_CUDA_VERSION")")
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python cudf cudf --stable --cuda "$RAPIDS_CUDA_VERSION")")
-
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION)
 export RAPIDS_PACKAGE_VERSION
 
 # populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
-
-rapids-logger "Prepending channels ${CPP_CHANNEL} and ${PYTHON_CHANNEL} to RATTLER_CHANNELS"
-
-RATTLER_CHANNELS=("--channel" "${CPP_CHANNEL}" "--channel" "${PYTHON_CHANNEL}" "${RATTLER_CHANNELS[@]}")
 
 rapids-logger "Building dask-cudf"
 

--- a/conda/recipes/custreamz/recipe.yaml
+++ b/conda/recipes/custreamz/recipe.yaml
@@ -29,7 +29,6 @@ requirements:
     - rapids-build-backend >=0.4.0,<0.5.0
     - setuptools>=77.0.0
     - python-confluent-kafka
-    - cudf_kafka =${{ version }}
   run:
     - python
     - streamz
@@ -37,12 +36,6 @@ requirements:
     - cudf_kafka =${{ version }}
     - rapids-dask-dependency =${{ minor_version }}
     - python-confluent-kafka
-
-tests:
-  - python:
-      imports:
-        - custreamz
-      pip_check: false
 
 about:
   homepage: ${{ load_from_file("python/custreamz/pyproject.toml").project.urls.Homepage }}

--- a/conda/recipes/dask-cudf/recipe.yaml
+++ b/conda/recipes/dask-cudf/recipe.yaml
@@ -35,12 +35,6 @@ requirements:
     - nvidia-ml-py>=12
     - rapids-dask-dependency =${{ minor_version }}
 
-tests:
-  - python:
-      imports:
-        - dask_cudf
-      pip_check: false
-
 about:
   homepage: ${{ load_from_file("python/dask_cudf/pyproject.toml").project.urls.Homepage }}
   license: ${{ load_from_file("python/dask_cudf/pyproject.toml").project.license }}


### PR DESCRIPTION
## Description

Build the Conda and wheel noarch package stages in parallel with the platform-specific package stages. This change also allows us to stop downloading platform package artifacts in the noarch Conda build. The test job dependencies are updated so tests still wait for all artifacts they consume.

I had to remove the `dask-cudf` and `custreamz` recipe import checks because those checks would require cudf to already be built and therefore serialize these builds after the other python build job. I'm comfortable removing those checks since they are redundant with the real test jobs, and we never see meaningful errors from these tests anyway. 

I also removed the unnecessary `cudf_kafka` host dependency from the pure-Python `custreamz` recipe. That dependency was erroneous, it's only a runtime dependency.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing package test jobs cover these changes.
- [x] Documentation is not affected by these CI-only changes.