### PR TITLE
Cache Cython generated sources in wheel builds

### DIFF
--- a/.github/workflows/wheels-build-stage.yaml
+++ b/.github/workflows/wheels-build-stage.yaml
@@ -105,15 +105,31 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         with:
           log-file: ${{ env.RAPIDS_ARTIFACTS_DIR }}/sccache.log
+      - name: Restore Cython cache
+        id: cython-cache-restore
+        if: inputs.stage == 'python'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.cache/cython
+          key: cython-v1-${{ runner.os }}-${{ runner.arch }}-cuda${{ matrix.CUDA_VER }}-py${{ matrix.PY_VER }}-${{ hashFiles('dependencies.yaml', 'python/**/*.pyx', 'python/**/*.pxd', 'python/**/CMakeLists.txt', 'python/**/pyproject.toml') }}
+          restore-keys: |
+            cython-v1-${{ runner.os }}-${{ runner.arch }}-cuda${{ matrix.CUDA_VER }}-py${{ matrix.PY_VER }}-
       - name: Build staged wheels
         id: build-wheels
         run: |
           ulimit -n "$(ulimit -Hn)"
           source "${INPUTS_SCRIPT}"
         env:
+          CYTHON_CACHE_DIR: ${{ github.workspace }}/.cache/cython
           GH_TOKEN: ${{ github.token }}
           INPUTS_SCRIPT: ${{ inputs.script }}
         shell: bash -leo pipefail {0}
+      - name: Save Cython cache
+        if: inputs.stage == 'python' && steps.cython-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.cache/cython
+          key: ${{ steps.cython-cache-restore.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.stage == 'cpp'
         with:

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -30,7 +30,7 @@ include(rapids-cython-core)
 rapids_cython_init()
 
 # Enable Cython's translation cache when CI supplies a persistent cache directory.
-if(DEFINED ENV{CYTHON_CACHE_DIR})
+if(DEFINED ENV{CYTHON_CACHE_DIR} AND NOT "$ENV{CYTHON_CACHE_DIR}" STREQUAL "")
   list(PREPEND CYTHON_FLAGS "--cache")
 endif()
 

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -28,6 +28,11 @@ find_package(cudf "${RAPIDS_VERSION}" REQUIRED)
 
 include(rapids-cython-core)
 rapids_cython_init()
+
+# Enable Cython's translation cache when CI supplies a persistent cache directory.
+if(DEFINED ENV{CYTHON_CACHE_DIR})
+  list(PREPEND CYTHON_FLAGS "--cache")
+endif()
 
 add_subdirectory(cudf/_lib)
 add_subdirectory(udf_cpp)

--- a/python/cudf_streaming/CMakeLists.txt
+++ b/python/cudf_streaming/CMakeLists.txt
@@ -37,7 +37,7 @@ include(rapids-cython-core)
 rapids_cython_init()
 
 # Enable Cython's translation cache when CI supplies a persistent cache directory.
-if(DEFINED ENV{CYTHON_CACHE_DIR})
+if(DEFINED ENV{CYTHON_CACHE_DIR} AND NOT "$ENV{CYTHON_CACHE_DIR}" STREQUAL "")
   list(PREPEND CYTHON_FLAGS "--cache")
 endif()
 

--- a/python/cudf_streaming/CMakeLists.txt
+++ b/python/cudf_streaming/CMakeLists.txt
@@ -36,6 +36,11 @@ find_package(CUDAToolkit REQUIRED)
 include(rapids-cython-core)
 rapids_cython_init()
 
+# Enable Cython's translation cache when CI supplies a persistent cache directory.
+if(DEFINED ENV{CYTHON_CACHE_DIR})
+  list(PREPEND CYTHON_FLAGS "--cache")
+endif()
+
 set(cython_sources
     cudf_streaming/approx_distinct_count.pyx
     cudf_streaming/bloom_filter.pyx

--- a/python/pylibcudf/CMakeLists.txt
+++ b/python/pylibcudf/CMakeLists.txt
@@ -37,7 +37,7 @@ include(rapids-cython-core)
 rapids_cython_init()
 
 # Enable Cython's translation cache when CI supplies a persistent cache directory.
-if(DEFINED ENV{CYTHON_CACHE_DIR})
+if(DEFINED ENV{CYTHON_CACHE_DIR} AND NOT "$ENV{CYTHON_CACHE_DIR}" STREQUAL "")
   list(PREPEND CYTHON_FLAGS "--cache")
 endif()
 

--- a/python/pylibcudf/CMakeLists.txt
+++ b/python/pylibcudf/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -35,5 +35,10 @@ include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
 include(rapids-cython-core)
 
 rapids_cython_init()
+
+# Enable Cython's translation cache when CI supplies a persistent cache directory.
+if(DEFINED ENV{CYTHON_CACHE_DIR})
+  list(PREPEND CYTHON_FLAGS "--cache")
+endif()
 
 add_subdirectory(pylibcudf)


### PR DESCRIPTION
## Description

Restores and saves Cython translation outputs for the in-repository staged Python-wheel workflow. Cython caching is enabled only when CI supplies a persistent cache directory; cache keys include runner platform, the CUDA/Python matrix, and relevant Cython/CMake build inputs.

Contributes to https://github.com/rapidsai/build-planning/issues/128

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.