### PR TITLE
CI: Reduce cached Conda C++ build overhead

### DIFF
--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -169,9 +169,6 @@ outputs:
           - librdkafka
           - libzlib
           - librmm
-    tests:
-      - script:
-          - test -f $PREFIX/include/cudf/column/column.hpp
     about:
       homepage: ${{ load_from_file("python/libcudf/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/libcudf/pyproject.toml").project.license }}
@@ -211,9 +208,6 @@ outputs:
           - librmm
           - libzlib
           - libnvcomp
-    tests:
-      - script:
-          - test -f $PREFIX/lib/libcudf_kafka.so
     about:
       homepage: https://rapids.ai/
       license: Apache-2.0
@@ -258,9 +252,6 @@ outputs:
           - librmm
           - libzlib
           - libnvcomp
-    tests:
-      - script:
-          - test -f $PREFIX/lib/libcudf_streaming.so
     about:
       homepage: https://rapids.ai/
       license: Apache-2.0
@@ -439,15 +430,6 @@ outputs:
           - libkvikio
           - librmm
           - libnvcomp
-    tests:
-      - script:
-          - test -f $PREFIX/bin/gtests/libcudf_streaming/libcudf_streaming_single_tests
-          - test -f $PREFIX/bin/libcudf_streaming_bench_pack
-          - test -f $PREFIX/bin/libcudf_streaming_bench_partition
-          - test -f $PREFIX/bin/libcudf_streaming_bench_ndsh_bench_read
-          - test -f $PREFIX/bin/libcudf_streaming_bench_ndsh_q01
-          - test -f $PREFIX/bin/libcudf_streaming_bench_shuffle
-          - test -f $PREFIX/bin/libcudf_streaming_bench_streaming_shuffle
     about:
       homepage: https://rapids.ai/
       license: Apache-2.0

--- a/cpp/examples/build.sh
+++ b/cpp/examples/build.sh
@@ -58,11 +58,30 @@ build_example() {
   fi
 }
 
-build_example basic
-build_example hybrid_scan_io
-build_example strings
-build_example string_transforms
-build_example nested_types
-build_example parquet_inspect
-build_example parquet_io
-build_example billion_rows
+example_build_pids=()
+
+cleanup_example_builds() {
+  for pid in "${example_build_pids[@]}"; do
+    kill "${pid}" 2>/dev/null || true
+  done
+}
+trap cleanup_example_builds EXIT
+
+for example_name in \
+  basic \
+  hybrid_scan_io \
+  strings \
+  string_transforms \
+  nested_types \
+  parquet_inspect \
+  parquet_io \
+  billion_rows; do
+  build_example "${example_name}" &
+  example_build_pids+=("$!")
+done
+
+for pid in "${example_build_pids[@]}"; do
+  wait "${pid}"
+done
+
+trap - EXIT


### PR DESCRIPTION
## Description

- Remove redundant Conda recipe file-existence checks. The packaged C++ tests and examples continue to run in `conda-cpp-tests`.
- Build the independent libcudf examples concurrently after the libcudf build completes.

A full local reproduction of `ci/build_cpp.sh` completed and produced all expected Conda artifacts. The serial example stage decreased from 2m53s to 1m48s locally.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.