### PR TITLE
Implement Series/DataFrame.first_valid_index and last_valid_index

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1458,6 +1458,65 @@ class IndexedFrame(Frame):
 
         return self.iloc[-n:]
 
+    def _find_valid_index(self, *, how: str) -> Hashable:
+        valid = self.notna()
+        if valid.ndim == 2:
+            valid = valid.any(axis=1)
+        valid_index = self.index[valid]
+        if len(valid_index) == 0:
+            return None
+        return valid_index[0] if how == "first" else valid_index[-1]
+
+    @_performance_tracking
+    def first_valid_index(self) -> Hashable:
+        """
+        Return index for first non-NA value or None, if no non-NA value is found.
+
+        Returns
+        -------
+        type of index
+            Index of first non-missing value, or None if all entries are
+            missing or the Series/DataFrame is empty.
+
+        See Also
+        --------
+        Series.last_valid_index : Return index for last non-NA value.
+        DataFrame.last_valid_index : Return index for last non-NA value.
+
+        Examples
+        --------
+        >>> import cudf
+        >>> s = cudf.Series([None, 3, 4])
+        >>> s.first_valid_index()
+        np.int64(1)
+        """
+        return self._find_valid_index(how="first")
+
+    @_performance_tracking
+    def last_valid_index(self) -> Hashable:
+        """
+        Return index for last non-NA value or None, if no non-NA value is found.
+
+        Returns
+        -------
+        type of index
+            Index of last non-missing value, or None if all entries are
+            missing or the Series/DataFrame is empty.
+
+        See Also
+        --------
+        Series.first_valid_index : Return index for first non-NA value.
+        DataFrame.first_valid_index : Return index for first non-NA value.
+
+        Examples
+        --------
+        >>> import cudf
+        >>> s = cudf.Series([None, 3, 4])
+        >>> s.last_valid_index()
+        np.int64(2)
+        """
+        return self._find_valid_index(how="last")
+
     @_performance_tracking
     def pipe(self, func, *args, **kwargs):
         """

--- a/python/cudf/cudf/tests/dataframe/methods/test_first_last_valid_index.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_first_last_valid_index.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import pytest
+
+import cudf
+
+
+@pytest.mark.parametrize(
+    "data,index",
+    [
+        ([None, 3, 4], None),
+        ([None, None], None),
+        ([1, 2, 3, 4], None),
+        ([], None),
+        ([None, 3, 4], ["x", "y", "z"]),
+    ],
+)
+def test_series_first_last_valid_index(data, index):
+    ps = pd.Series(data, index=index, dtype="float64" if data else "object")
+    gs = cudf.from_pandas(ps)
+
+    assert gs.first_valid_index() == ps.first_valid_index()
+    assert gs.last_valid_index() == ps.last_valid_index()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"A": [None, None, 2], "B": [None, 3, 4]},
+        {"A": [None, None, None], "B": [None, None, None]},
+        {"A": [1, 2, 3], "B": [4, 5, 6]},
+        {},
+    ],
+)
+def test_dataframe_first_last_valid_index(data):
+    pdf = pd.DataFrame(data)
+    gdf = cudf.from_pandas(pdf)
+
+    assert gdf.first_valid_index() == pdf.first_valid_index()
+    assert gdf.last_valid_index() == pdf.last_valid_index()


### PR DESCRIPTION
## Description

Implements `Series.first_valid_index()` / `Series.last_valid_index()` and
the same on `DataFrame`, closing #1480 (open since 2019).

A maintainer's comment on the issue explicitly left the door open to either
a Python-only implementation or a dedicated libcudf primitive ("I would be
happy to solve this with either a cuDF-python change or a small libcudf
function"), so this takes the Python route: `notna()` plus boolean-mask
indexing directly against the frame's own `Index`. For a `DataFrame`, the
per-cell mask is first reduced with `any(axis=1)` (matching pandas' own
`_find_valid_index`, which does the same 2D-to-1D reduction). Everything
stays column/GPU-resident - no `.values`/host round-trip anywhere in the
path.

Empty frames, all-null frames, and non-default index labels all fall out
of the same "mask the index, check its length" logic without any special
casing, which is actually simpler than pandas' own implementation (which
needs an explicit early-return for the empty case).

## Testing

Installed a real `cudf` build (`cudf-cu12==26.08.01`, prebuilt wheels
from `pypi.nvidia.com`) against a real GPU available in this environment
and verified end to end, not just read through:

- Reproduced every example in pandas' own `first_valid_index`/
  `last_valid_index` docstrings directly against the patched, installed
  package (matching values, `None` results on all-null/empty frames,
  correct labels on a non-default index).
- Added `test_first_last_valid_index.py` (9 parametrized cases across
  `Series`/`DataFrame`, covering nulls, all-null, no-nulls, empty, and a
  custom string index), asserting cudf's result equals real pandas'
  result for the same input. Ran with `pytest` against the same real
  install: 9 passed.
- Confirmed the tests actually exercise the fix: reverted the change,
  reran - all 9 failed with `AttributeError: ... has no attribute
  first_valid_index`, then passed again after restoring it.
- Also ran the existing `dataframe/methods/test_head_tail.py` and both
  `test_isna_notnull.py` suites against the patched file as a regression
  check: 204 passed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
