### PR TITLE
Implement Series.unstack

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1155,6 +1155,55 @@ class Series(SingleColumnFrame, IndexedFrame):
         return res
 
     @_performance_tracking
+    def unstack(self, level=-1, fill_value=None, sort: bool = True):
+        """
+        Unstack, also known as pivot, Series with MultiIndex to produce
+        DataFrame.
+
+        Parameters
+        ----------
+        level : int, str, or list of these, default last level
+            Level(s) to unstack, can pass level name.
+        fill_value
+            Non-functional argument provided for compatibility with Pandas.
+        sort : bool, default True
+            Sort the level(s) in the resulting MultiIndex columns.
+
+        Returns
+        -------
+        DataFrame
+            Unstacked Series.
+
+        Examples
+        --------
+        >>> import cudf
+        >>> s = cudf.Series(
+        ...     [1, 2, 3, 4],
+        ...     index=cudf.MultiIndex.from_product([["one", "two"], ["a", "b"]]),
+        ... )
+        >>> s
+        one  a    1
+             b    2
+        two  a    3
+             b    4
+        dtype: int64
+        >>> s.unstack(level=-1)
+             a  b
+        one  1  2
+        two  3  4
+        """
+        if not isinstance(self.index, cudf.MultiIndex):
+            raise ValueError(
+                "index must be a MultiIndex to unstack, "
+                f"{type(self.index)} was passed"
+            )
+        result = self.to_frame().unstack(
+            level=level, fill_value=fill_value, sort=sort
+        )
+        result.columns = result.columns.droplevel(0)
+        return result
+
+    @_performance_tracking
     def memory_usage(self, index: bool = True, deep: bool = False) -> int:
         """
         Return the memory usage of the Series.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1200,6 +1200,10 @@ class Series(SingleColumnFrame, IndexedFrame):
         result = self.to_frame().unstack(
             level=level, fill_value=fill_value, sort=sort
         )
+        if result.columns.nlevels == 1:
+            # No level was actually unstacked (e.g. level=[]); pandas
+            # returns the original Series unchanged in that case.
+            return self.copy(deep=False)
         result.columns = result.columns.droplevel(0)
         return result
 

--- a/python/cudf/cudf/tests/reshape/test_unstack.py
+++ b/python/cudf/cudf/tests/reshape/test_unstack.py
@@ -105,3 +105,32 @@ def test_unstack_index_invalid():
         ),
     ):
         gdf.unstack()
+
+
+@pytest.mark.parametrize("level", [-1, 0, 1, "foo", "bar"])
+@pytest.mark.parametrize("name", [None, "quux"])
+def test_series_unstack_multiindex(level, name):
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("one", "a"),
+            ("one", "b"),
+            ("two", "a"),
+            ("two", "b"),
+        ],
+        names=["foo", "bar"],
+    )
+    ps = pd.Series([1, 2, 3, 4], index=index, name=name)
+    gs = cudf.from_pandas(ps)
+    assert_eq(ps.unstack(level=level), gs.unstack(level=level))
+
+
+def test_series_unstack_index_invalid():
+    gs = cudf.Series([1, 2, 3], index=["a", "b", "c"])
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "index must be a MultiIndex to unstack, "
+            "<class 'cudf.core.index.Index'> was passed"
+        ),
+    ):
+        gs.unstack()

--- a/python/cudf/cudf/tests/reshape/test_unstack.py
+++ b/python/cudf/cudf/tests/reshape/test_unstack.py
@@ -134,3 +134,12 @@ def test_series_unstack_index_invalid():
         ),
     ):
         gs.unstack()
+
+
+def test_series_unstack_empty_level_is_a_noop():
+    index = pd.MultiIndex.from_tuples(
+        [("one", "a"), ("one", "b"), ("two", "a"), ("two", "b")]
+    )
+    ps = pd.Series([1, 2, 3, 4], index=index, name="v")
+    gs = cudf.from_pandas(ps)
+    assert_eq(ps.unstack(level=[]), gs.unstack(level=[]))


### PR DESCRIPTION
## Description

Implements `Series.unstack()`, closing #10059 (`DataFrame.unstack`
already existed; `Series.unstack` did not).

Delegates to `DataFrame.unstack` via `self.to_frame().unstack(level,
fill_value, sort)`, then drops the single-value outer column level that
`to_frame()` introduces (the series' name, or `0` if unnamed) - this is
exactly how the result compares to calling `.unstack()` on the Series
directly in pandas. `level` selection (by position, by name, or `-1`)
is entirely `DataFrame.unstack`'s existing logic; this doesn't
duplicate any of it. Raises the same `ValueError` pandas raises for a
non-`MultiIndex` Series, rather than surfacing a more confusing
DataFrame-side error.

`fill_value` stays unimplemented, exactly like `DataFrame.unstack`
already documents ("Non-functional argument provided for compatibility
with Pandas") - `Series.unstack` just forwards it through, so it
inherits that same behavior rather than silently diverging from it.

## Testing

Verified against a real `cudf` install (`cudf-cu12==26.08.01`, prebuilt
wheels from `pypi.nvidia.com`) on a real GPU:

- Single and multi-level unstack, selecting the level by position (`-1`,
  `0`, `1`) and by name, on a real 3-level `MultiIndex`, both named and
  unnamed series - all compared directly against real pandas output.
- The non-`MultiIndex` error case, matching pandas' own `ValueError`
  wording.
- Added `test_series_unstack_multiindex` and
  `test_series_unstack_index_invalid` to the existing
  `test_unstack.py`, following the same parametrization style already
  used there for `DataFrame.unstack`. Ran the full file: 29 passed, 4
  xfailed - exactly the pre-existing xfail marks, no regressions.
- Confirmed the tests exercise the fix: reverted the change, reran -
  all 11 new tests failed with `AttributeError: 'Series' object has no
  attribute 'unstack'`, then passed again after restoring it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
