### PR TITLE
CI: Report slow Python tests

### DIFF
--- a/ci/run_pylibcudf_pytests.sh
+++ b/ci/run_pylibcudf_pytests.sh
@@ -43,6 +43,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/pylibcudf/
 echo "RAPIDS_CUDA_VERSION: $RAPIDS_CUDA_VERSION"
 if [ -n "$TESTING_LIB" ] && [ -f "$TESTING_LIB" ] && [ "$RAPIDS_CUDA_VERSION" != "12.2.2" ]; then
     # run the stream tests without xdist to ease the burden on the compute-sanitizer checks
-    LD_PRELOAD="$TESTING_LIB" PYLIBCUDF_STREAM_TESTING=1 pytest --cache-clear -m "not uses_custom_stream" --ignore="benchmarks" -p no:xdist tests
+    LD_PRELOAD="$TESTING_LIB" PYLIBCUDF_STREAM_TESTING=1 \
+        pytest --cache-clear -m "not uses_custom_stream" --ignore="benchmarks" \
+        -p no:xdist --durations=10 --durations-min=10 tests
 fi
 pytest --cache-clear --ignore="benchmarks" "$@" tests

--- a/ci/test_python_cudf.sh
+++ b/ci/test_python_cudf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -25,7 +25,8 @@ timeout 40m ./ci/run_pylibcudf_pytests.sh \
   --cov-config=.coveragerc \
   --cov=pylibcudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/pylibcudf-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 version_gte() {
   [ "$2" = "$(echo -e "$2\n$1" | sort -V | head -n1)" ]
@@ -39,7 +40,8 @@ timeout 40m ./ci/run_cudf_pytests.sh \
   --cov-config=../.coveragerc \
   --cov=cudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 # Run benchmarks with both cudf and pandas to ensure compatibility is maintained.
 # Benchmarks are run in DEBUG_ONLY mode, meaning that only small data sizes are used.
@@ -54,7 +56,8 @@ timeout 40m ./ci/run_cudf_pytest_benchmarks.sh \
   --cov-config=.coveragerc \
   --cov=cudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-benchmark-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 rapids-logger "pytest for cudf benchmarks using pandas"
 timeout 40m ./ci/run_cudf_pandas_pytest_benchmarks.sh \
@@ -64,7 +67,8 @@ timeout 40m ./ci/run_cudf_pandas_pytest_benchmarks.sh \
   --cov-config=.coveragerc \
   --cov=cudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-benchmark-pandas-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -25,11 +25,13 @@ timeout 30m ./ci/run_dask_cudf_pytests.sh \
   --cov-config=../.coveragerc \
   --cov=dask_cudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/dask-cudf-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 rapids-logger "pytest cudf_kafka"
 timeout 30m ./ci/run_cudf_kafka_pytests.sh \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-kafka.xml"
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-kafka.xml" \
+  --durations=10 --durations-min=10
 
 rapids-logger "pytest custreamz"
 timeout 30m ./ci/run_custreamz_pytests.sh \
@@ -39,7 +41,8 @@ timeout 30m ./ci/run_custreamz_pytests.sh \
   --cov-config=../.coveragerc \
   --cov=custreamz \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/custreamz-coverage.xml" \
-  --cov-report=term
+  --cov-report=term \
+  --durations=10 --durations-min=10
 
 rapids-logger "pytest cudf-polars"
 # Fail fast (-x) rather than trying to continue because failed tests pollute the state
@@ -56,7 +59,8 @@ rapids-logger "pytest cudf-polars"
 
 rapids-logger "pytest cudf_streaming"
 timeout 30m ./ci/run_cudf_streaming_pytests.sh \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-streaming.xml"
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-streaming.xml" \
+  --durations=10 --durations-min=10
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
## Description

Add pytest `--durations=10 --durations-min=10` reporting to the cuDF, pylibcudf, and other-Python CI test wrappers.

These options affect only pytest's post-run slow-test report; test selection, execution, assertions, and coverage remain unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.