### PR TITLE
TEST: Merge import subprocess checks

### DIFF
--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import sys
 import uuid
 from io import BytesIO, StringIO
 
@@ -481,15 +479,3 @@ def test_write_chunked_parquet(s3_bucket_public, s3so):
         actual.sort_values(["b"]).reset_index(drop=True),
         cudf.concat([df1, df2]).sort_values(["b"]).reset_index(drop=True),
     )
-
-
-def test_no_s3fs_on_cudf_import():
-    output = subprocess.check_call(
-        [
-            sys.executable,
-            "-c",
-            "import cudf, sys; assert 'pyarrow._s3fs' not in sys.modules",
-        ],
-        cwd="/",
-    )
-    assert output == 0

--- a/python/cudf/cudf/tests/test_no_device.py
+++ b/python/cudf/cudf/tests/test_no_device.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import subprocess
 import sys
@@ -8,7 +8,11 @@ def test_cudf_import_no_device(monkeypatch):
     with monkeypatch.context() as m:
         m.setenv("CUDA_VISIBLE_DEVICES", "-1")
         output = subprocess.check_call(
-            [sys.executable, "-c", "import cudf"],
+            [
+                sys.executable,
+                "-c",
+                "import cudf, sys; assert 'pyarrow._s3fs' not in sys.modules",
+            ],
             cwd="/",
         )
     assert output == 0

--- a/python/cudf/cudf/tests/test_no_device.py
+++ b/python/cudf/cudf/tests/test_no_device.py
@@ -4,14 +4,20 @@ import subprocess
 import sys
 
 
-def test_cudf_import_no_device(monkeypatch):
+def test_cudf_import_invariants(monkeypatch):
     with monkeypatch.context() as m:
+        # Importing cuDF must not require a visible CUDA device.
         m.setenv("CUDA_VISIBLE_DEVICES", "-1")
         output = subprocess.check_call(
             [
                 sys.executable,
                 "-c",
-                "import cudf, sys; assert 'pyarrow._s3fs' not in sys.modules",
+                (
+                    "import cudf, sys; "
+                    # Importing cuDF must not eagerly load PyArrow's optional
+                    # S3 extension module.
+                    "assert 'pyarrow._s3fs' not in sys.modules"
+                ),
             ],
             cwd="/",
         )


### PR DESCRIPTION
## Description

Merge the two isolated import subprocess checks. The existing no-device subprocess now also asserts that importing cuDF does not import `pyarrow._s3fs`.

Both contracts are still verified after the same cold, isolated cuDF import, so this removes only a redundant Python startup and not any assertion.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.