### PR TITLE
TEST: Remove redundant concat tests

### DIFF
--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1222,30 +1222,6 @@ def test_concat_join_empty_dataframes_axis_1(
         join=join,
         sort=sort,
     )
-    if expected.shape != df.shape:
-        if axis == 0:
-            for key, col in actual[actual.columns].items():
-                if isinstance(expected[key].dtype, pd.CategoricalDtype):
-                    expected[key] = expected[key].fillna("-1")
-                    actual[key] = col.astype("str").fillna("-1")
-            # if not expected.empty:
-            assert_eq(
-                expected.fillna(-1),
-                actual.fillna(-1),
-                check_dtype=False,
-                check_index_type=False
-                if len(expected) == 0 or actual.empty
-                else True,
-                check_column_type=False,
-            )
-        else:
-            # no need to fill in if axis=1
-            assert_eq(
-                expected,
-                actual,
-                check_index_type=False,
-                check_column_type=False,
-            )
     assert_eq(
         expected, actual, check_index_type=False, check_column_type=False
     )

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -711,7 +711,7 @@ def test_concat_dataframe_with_multiindex(key2):
         ],
     ],
 )
-def test_concat_join(objs, ignore_index, sort, join, axis):
+def test_concat_join(objs, ignore_index, sort, join):
     axis = 0
     gpu_objs = [cudf.from_pandas(o) for o in objs]
 
@@ -780,7 +780,7 @@ def test_concat_join_axis_1_dup_error(objs):
         ],
     ],
 )
-def test_concat_join_axis_1(objs, ignore_index, sort, join, axis):
+def test_concat_join_axis_1(objs, ignore_index, sort, join):
     # no duplicate columns
     axis = 1
     gpu_objs = [cudf.from_pandas(o) for o in objs]

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1200,7 +1200,7 @@ def test_concat_join_empty_dataframes(
     ],
 )
 def test_concat_join_empty_dataframes_axis_1(
-    df, other, ignore_index, axis, join, sort
+    df, other, ignore_index, join, sort
 ):
     # no duplicate columns
     axis = 1


### PR DESCRIPTION
## Description

Eliminate concat axis parameters where the test body already forced the same axis, and remove an unreachable axis-0 comparison branch from the fixed-axis-1 test.

Representative concat join coverage for both axes remains: the axis-0 and axis-1 tests keep their existing object, join, sort, and ignore-index matrices.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.