### PR TITLE
TEST: Reuse I/O test fixtures

### DIFF
--- a/python/cudf/cudf/tests/input_output/test_csv.py
+++ b/python/cudf/cudf/tests/input_output/test_csv.py
@@ -20,7 +20,7 @@ from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pd_mixed_dataframe():
     return pd.DataFrame(
         {
@@ -35,12 +35,12 @@ def pd_mixed_dataframe():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def cudf_mixed_dataframe(pd_mixed_dataframe):
     return cudf.from_pandas(pd_mixed_dataframe)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdf_np_dtypes():
     gdf_dtypes = [
         "float",
@@ -80,7 +80,7 @@ def gdf_np_dtypes():
     return dict(zip(gdf_dtypes, np_dtypes, strict=True))
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def numeric_extremes_dataframe(gdf_np_dtypes):
     data = {}
     for typ, np_type in gdf_np_dtypes.items():

--- a/python/cudf/cudf/tests/input_output/test_dlpack.py
+++ b/python/cudf/cudf/tests/input_output/test_dlpack.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
@@ -30,8 +30,9 @@ def data_size_expectation_builder(data, nan_null_param=False):
         return does_not_raise()
 
 
-@pytest.fixture(params=params_1d)
+@pytest.fixture(scope="module", params=params_1d)
 def data_1d(request):
+    # DLPack conversion tests only read the generated host array.
     nelems = request.param[0]
     dtype = request.param[1]
     nulls = request.param[2]
@@ -43,8 +44,9 @@ def data_1d(request):
     return a
 
 
-@pytest.fixture(params=params_2d)
+@pytest.fixture(scope="module", params=params_2d)
 def data_2d(request):
+    # DLPack conversion tests only read the generated host array.
     ncols = request.param[0]
     nrows = request.param[1]
     dtype = request.param[2]

--- a/python/cudf/cudf/tests/input_output/test_feather.py
+++ b/python/cudf/cudf/tests/input_output/test_feather.py
@@ -13,8 +13,9 @@ from cudf.testing import assert_eq
 from cudf.testing._utils import NUMERIC_TYPES
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def pdf(request):
+    # Feather reader and writer tests only read this source dataframe.
     rng = np.random.default_rng(seed=0)
     types = [*NUMERIC_TYPES, "bool"]
     nrows = request.param

--- a/python/cudf/cudf/tests/input_output/test_hdf5.py
+++ b/python/cudf/cudf/tests/input_output/test_hdf5.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -15,8 +15,9 @@ from cudf.testing._utils import NUMERIC_TYPES, UNSIGNED_TYPES
 pytest.importorskip("tables")
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def pdf(request):
+    # Reader and writer tests only read this source dataframe.
     types = set([*NUMERIC_TYPES, "datetime64[ns]", "bool"]) - set(
         UNSIGNED_TYPES
     )
@@ -44,7 +45,7 @@ def pdf(request):
     return (test_pdf, nrows)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdf(pdf):
     pdf, nrows = pdf
     return (cudf.DataFrame(pdf), nrows)

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -33,8 +33,9 @@ def lines(request):
     return request.param
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def pdf(request):
+    # JSON tests share this immutable source dataframe.
     rng = np.random.default_rng(seed=0)
     types = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
     nrows = request.param
@@ -50,12 +51,12 @@ def pdf(request):
     return test_pdf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdf(pdf):
     return cudf.DataFrame(pdf)
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def gdf_writer_types(request):
     # datetime64[us], datetime64[ns] are unsupported due to a bug in parser
     types = [
@@ -175,6 +176,7 @@ def test_json_writer(tmp_path, pdf, gdf):
 
 def test_cudf_json_writer(pdf, lines):
     # removing datetime column because pandas doesn't support it
+    pdf = pdf.copy()
     for col_name in pdf.columns:
         if "datetime" in col_name:
             pdf.drop(col_name, axis=1, inplace=True)

--- a/python/cudf/cudf/tests/input_output/test_orc.py
+++ b/python/cudf/cudf/tests/input_output/test_orc.py
@@ -1349,11 +1349,9 @@ def dec(num):
     return decimal.Decimal(str(num))
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        # basic + nested strings
-        {
+def _make_orc_list_data(case):
+    if case == "nested":
+        return {
             "lls": [[["a"], ["bb"]] * 5 for i in range(12345)],
             "lls2": [[["ccc", "dddd"]] * 6 for i in range(12345)],
             "ls_dict": [["X"] * 7 for i in range(12345)],
@@ -1361,9 +1359,9 @@ def dec(num):
             "li": [[i] * 11 for i in range(12345)],
             "lf": [[i * 0.5] * 13 for i in range(12345)],
             "ld": [[dec(i / 2)] * 15 for i in range(12345)],
-        },
-        # with nulls
-        {
+        }
+    elif case == "nulls":
+        return {
             "ls": [
                 [str(i) if i % 5 else None, str(2 * i)] if i % 2 else None
                 for i in range(12345)
@@ -1373,9 +1371,9 @@ def dec(num):
                 [dec(i), dec(i / 2) if i % 7 else None] if i % 5 else None
                 for i in range(12345)
             ],
-        },
-        # with empty elements
-        {
+        }
+    elif case == "empty":
+        return {
             "ls": [
                 [str(i), str(2 * i)] if i % 2 else [] for i in range(12345)
             ],
@@ -1391,18 +1389,24 @@ def dec(num):
             "ld": [
                 [dec(i), dec(i / 2)] if i % 5 else [] for i in range(12345)
             ],
-        },
-        # variable list lengths
-        {
+        }
+    elif case == "variable-lengths":
+        return {
             "ls": [[str(i)] * i for i in range(123)],
             "li": [[i, i * i] * i for i in range(123)],
             "ld": [[dec(i), dec(i / 2)] * i for i in range(123)],
-        },
-        # many child elements (more that max_stripe_rows)
-        {"li": [[i] * 1100 for i in range(11000)]},
-    ],
+        }
+    elif case == "many-child-elements":
+        # More child elements than max_stripe_rows.
+        return {"li": [[i] * 1100 for i in range(11000)]}
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["nested", "nulls", "empty", "variable-lengths", "many-child-elements"],
 )
-def test_orc_writer_lists(data):
+def test_orc_writer_lists(case):
+    data = _make_orc_list_data(case)
     buffer = BytesIO()
     cudf.DataFrame(data).to_orc(
         buffer, stripe_size_rows=2048, row_index_stride=512

--- a/python/cudf/cudf/tests/input_output/test_orc.py
+++ b/python/cudf/cudf/tests/input_output/test_orc.py
@@ -1173,7 +1173,7 @@ def test_pyspark_struct(datadir):
     assert_eq(pdf, gdf)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def map_buff():
     size = 100
     rd = random.Random(1)

--- a/python/cudf/cudf/tests/input_output/test_parquet.py
+++ b/python/cudf/cudf/tests/input_output/test_parquet.py
@@ -55,7 +55,7 @@ def datadir(datadir):
     return datadir / "parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def simple_pdf():
     nrows = 10
     rng = np.random.default_rng(seed=0)
@@ -90,7 +90,7 @@ def simple_pdf():
     return test_pdf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def simple_gdf(simple_pdf):
     return cudf.DataFrame(simple_pdf)
 
@@ -176,22 +176,22 @@ def build_pdf(num_columns, day_resolution_timestamps):
     return test_pdf
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def pdf(request):
     return build_pdf(request.param, False)
 
 
-@pytest.fixture(params=[0, 10])
+@pytest.fixture(scope="module", params=[0, 10])
 def pdf_day_timestamps(request):
     return build_pdf(request.param, True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdf(pdf):
     return cudf.DataFrame(pdf)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdf_day_timestamps(pdf_day_timestamps):
     return cudf.DataFrame(pdf_day_timestamps)
 
@@ -2981,6 +2981,7 @@ def test_parquet_writer_column_validation():
 
 
 def test_parquet_writer_nulls_pandas_read(tmp_path, pdf):
+    pdf = pdf.copy()
     if "col_bool" in pdf.columns:
         pdf.drop(columns="col_bool", inplace=True)
     if "col_category" in pdf.columns:

--- a/python/cudf/cudf/tests/input_output/test_s3.py
+++ b/python/cudf/cudf/tests/input_output/test_s3.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess
@@ -84,7 +84,7 @@ def kvikio_remote_io(request):
         yield request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pdf():
     return pd.DataFrame(
         {
@@ -97,7 +97,7 @@ def pdf():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pdf_ext():
     size = 10
     return pd.DataFrame(


### PR DESCRIPTION
## Description

Make shared I/O source data module-scoped, and construct the expensive ORC nested-list data only for the selected parameterized case.

The fixtures are read-only to surrounding tests; the two tests that mutate a pandas frame now copy it first. All original formats, assertions, and parameterized I/O cases remain executed unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.