### PR TITLE
TEST: Reuse invariant Python test inputs

### DIFF
--- a/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
@@ -1394,7 +1394,7 @@ def test_slice_empty_columns(indexer, column_slice):
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mi_df():
     # 2-level row MultiIndex, single-level columns.
     index = cudf.MultiIndex.from_product(

--- a/python/cudf/cudf/tests/dataframe/methods/test_apply.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_apply.py
@@ -72,7 +72,8 @@ def run_masked_udf_test(func, data, args=(), nullable=True, **kwargs):
     assert_eq(expect, obtain, **kwargs)
 
 
-@pytest.fixture
+# String UDF tests only read this input, so one instance is sufficient per worker.
+@pytest.fixture(scope="module")
 def str_udf_data():
     return cudf.DataFrame(
         {

--- a/python/cudf/cudf/tests/dataframe/test_at_iat.py
+++ b/python/cudf/cudf/tests/dataframe/test_at_iat.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -6,14 +6,15 @@ import pytest
 import cudf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def df_with_index():
+    # All consumers except the scalar setter only read this dataframe.
     return cudf.DataFrame(
         {"A": [1, 2, 3], "B": [4, 5, 6]}, index=["x", "y", "z"]
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def df_without_index():
     return cudf.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
 
@@ -24,6 +25,7 @@ def test_dataframe_at_scalar_getitem(df_with_index):
 
 
 def test_dataframe_at_scalar_setitem(df_with_index):
+    df_with_index = df_with_index.copy(deep=True)
     df_with_index.at["x", "A"] = 10
     assert df_with_index.at["x", "A"] == 10
 
@@ -46,6 +48,7 @@ def test_dataframe_iat_scalar_getitem(df_without_index):
 
 
 def test_dataframe_iat_scalar_setitem(df_without_index):
+    df_without_index = df_without_index.copy(deep=True)
     df_without_index.iat[0, 0] = 10
     assert df_without_index.iat[0, 0] == 10
 

--- a/python/cudf/cudf/tests/dataframe/test_repr.py
+++ b/python/cudf/cudf/tests/dataframe/test_repr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import textwrap
@@ -9,6 +9,43 @@ import pytest
 from hypothesis import given, settings, strategies as st
 
 import cudf
+
+_FULL_REPR_DTYPES = [
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float32",
+    "float64",
+    "datetime64[ns]",
+    "datetime64[us]",
+    "datetime64[ms]",
+    "datetime64[s]",
+    "timedelta64[ns]",
+    "timedelta64[us]",
+    "timedelta64[ms]",
+    "timedelta64[s]",
+    "str",
+    "bool",
+    "category",
+]
+
+
+@pytest.fixture(
+    scope="module",
+    params=[(dtype, size) for dtype in _FULL_REPR_DTYPES for size in [20, 21]],
+)
+def full_dataframe(request):
+    dtype, size = request.param
+    rng = np.random.default_rng(seed=0)
+    pdf = pd.DataFrame(
+        {idx: rng.integers(0, 100, size) for idx in range(size)}
+    ).astype(dtype)
+    return pdf, cudf.from_pandas(pdf)
 
 
 @pytest.mark.parametrize("ncols", [1, 2, 10])
@@ -37,13 +74,8 @@ def test_null_dataframe(ncols):
 
 @pytest.mark.parametrize("nrows", [5, 10, 15])
 @pytest.mark.parametrize("ncols", [5, 10, 15])
-@pytest.mark.parametrize("size", [20, 21])
-def test_full_dataframe_20(all_supported_types_as_str, size, nrows, ncols):
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(
-        {idx: rng.integers(0, 100, size) for idx in range(size)}
-    ).astype(all_supported_types_as_str)
-    gdf = cudf.from_pandas(pdf)
+def test_full_dataframe_20(full_dataframe, nrows, ncols):
+    pdf, gdf = full_dataframe
 
     with pd.option_context(
         "display.max_rows", int(nrows), "display.max_columns", int(ncols)

--- a/python/cudf/cudf/tests/dataframe/test_repr.py
+++ b/python/cudf/cudf/tests/dataframe/test_repr.py
@@ -166,9 +166,9 @@ def test_groupby_MI(nrows, ncols):
         assert repr(gdg.T) == repr(pdg.T)
 
 
-@pytest.mark.parametrize(
-    "gdf",
-    [
+@pytest.fixture(
+    scope="module",
+    params=[
         lambda: cudf.DataFrame({"a": range(10000)}),
         lambda: cudf.DataFrame({"a": range(10000), "b": range(10000)}),
         lambda: cudf.DataFrame({"a": range(20), "b": range(20)}),
@@ -193,6 +193,10 @@ def test_groupby_MI(nrows, ncols):
         ),
     ],
 )
+def sliced_dataframe(request):
+    return request.param()
+
+
 @pytest.mark.parametrize(
     "slc",
     [
@@ -206,14 +210,13 @@ def test_groupby_MI(nrows, ncols):
 )
 @pytest.mark.parametrize("max_seq_items", [1, 10, 60, 10000, None])
 @pytest.mark.parametrize("max_rows", [1, 10, 60, 10000, None])
-def test_dataframe_sliced(gdf, slc, max_seq_items, max_rows):
-    gdf = gdf()
+def test_dataframe_sliced(sliced_dataframe, slc, max_seq_items, max_rows):
     with pd.option_context(
         "display.max_seq_items", max_seq_items, "display.max_rows", max_rows
     ):
-        pdf = gdf.to_pandas()
+        pdf = sliced_dataframe.to_pandas()
 
-        sliced_gdf = gdf[slc]
+        sliced_gdf = sliced_dataframe[slc]
         sliced_pdf = pdf[slc]
 
         expected_repr = repr(sliced_pdf)

--- a/python/cudf/cudf/tests/indexes/multiindex/methods/test_contains.py
+++ b/python/cudf/cudf/tests/indexes/multiindex/methods/test_contains.py
@@ -7,8 +7,9 @@ import pytest
 import cudf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mi_pair():
+    # Containment tests only read the shared cuDF and pandas indexes.
     arrays = [[1, 1, 2, 2], ["a", "b", "a", "b"], [10, 20, 30, 40]]
     pmi = pd.MultiIndex.from_arrays(arrays, names=["x", "y", "z"])
     return cudf.from_pandas(pmi), pmi

--- a/python/cudf/cudf/tests/private_objects/test_column_accessor.py
+++ b/python/cudf/cudf/tests/private_objects/test_column_accessor.py
@@ -23,13 +23,14 @@ def check_ca_equal(lhs, rhs):
 
 
 @pytest.fixture(
+    scope="module",
     params=[
         {},
         {"a": []},
         {"a": [1]},
         {"a": ["a"]},
         {"a": [1, 2, 3], "b": ["a", "b", "c"]},
-    ]
+    ],
 )
 def simple_data(request):
     return {key: as_column(data) for key, data in request.param.items()}

--- a/python/cudf/cudf/tests/series/test_at_iat.py
+++ b/python/cudf/cudf/tests/series/test_at_iat.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -6,12 +6,13 @@ import pytest
 import cudf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def sr_with_index():
+    # All consumers except the scalar setter only read this Series.
     return cudf.Series([1, 2, 3], index=["x", "y", "z"])
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def sr_without_index():
     return cudf.Series([1, 2, 3])
 
@@ -22,6 +23,7 @@ def test_series_at_scalar_getitem(sr_with_index):
 
 
 def test_series_at_scalar_setitem(sr_with_index):
+    sr_with_index = sr_with_index.copy(deep=True)
     sr_with_index.at["x"] = 10
     assert sr_with_index.at["x"] == 10
 
@@ -43,6 +45,7 @@ def test_series_iat_scalar_getitem(sr_without_index):
 
 
 def test_series_iat_scalar_setitem(sr_without_index):
+    sr_without_index = sr_without_index.copy(deep=True)
     sr_without_index.iat[0] = 10
     assert sr_without_index.iat[0] == 10
 

--- a/python/cudf/cudf/tests/testing/test_assert_column_equal.py
+++ b/python/cudf/cudf/tests/testing/test_assert_column_equal.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyarrow as pa
@@ -14,12 +14,13 @@ from cudf.testing.testing import assert_column_equal
 
 
 @pytest.fixture(
+    scope="module",
     params=[
         range(10),
         ["hello", "world", "rapids", "AI"],
         [[1, 2, 3], [4, 5], [6], [], [7]],
         [{"f0": "hello", "f1": 42}, {"f0": "world", "f1": 3}],
-    ]
+    ],
 )
 def arrow_arrays(request):
     return pa.array(request.param)


### PR DESCRIPTION
## Description

Move immutable, read-only test inputs to module-scoped fixtures so parameterized cases reuse construction work within each pytest worker. Every original dtype, size, slicing, display-option, UDF, indexing, and assertion case remains; the only mutating `at`/`iat` tests take a deep copy before assignment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.