### PR TITLE
TEST: Remove deterministic temporal and rolling skips

### DIFF
--- a/python/cudf/cudf/tests/indexes/timedeltaindex/test_binops.py
+++ b/python/cudf/cudf/tests/indexes/timedeltaindex/test_binops.py
@@ -138,6 +138,9 @@ def test_timedelta_datetime_index_ops_misc(
         np.timedelta64(1, "ns"),
     ],
 )
+@pytest.mark.parametrize(
+    "arithmetic_op_method", ["add", "sub", "truediv", "floordiv"]
+)
 @pytest.mark.filterwarnings("ignore:divide by zero:RuntimeWarning:pandas")
 def test_timedelta_index_ops_with_scalars(
     request,
@@ -146,9 +149,6 @@ def test_timedelta_index_ops_with_scalars(
     timedelta_types_as_str,
     arithmetic_op_method,
 ):
-    if arithmetic_op_method not in ("add", "sub", "truediv", "floordiv"):
-        pytest.skip(f"Test not applicable for {arithmetic_op_method}")
-
     gtdi = cudf.Index(data=data_non_overflow, dtype=timedelta_types_as_str)
     ptdi = gtdi.to_pandas()
 

--- a/python/cudf/cudf/tests/series/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/series/methods/test_reductions.py
@@ -866,11 +866,12 @@ def test_categorical_reductions(request, reduction_methods):
         [12, 11, 2.32, 2234.32411, 2343.241, 23432.4, 23234],
     ],
 )
+@pytest.mark.parametrize(
+    "reduction_methods", ["sum", "mean", "median", "quantile"]
+)
 def test_timedelta_reduction_ops(
     data_non_overflow, timedelta_types_as_str, reduction_methods
 ):
-    if reduction_methods not in ["sum", "mean", "median", "quantile"]:
-        pytest.skip(f"{reduction_methods} not supported for timedelta")
     gsr = cudf.Series(data_non_overflow, dtype=timedelta_types_as_str)
     psr = gsr.to_pandas()
 
@@ -1103,9 +1104,8 @@ def test_object_min_max_with_null(method, skipna):
 
 
 @pytest.mark.parametrize("data", [[1, 2, 3], [], [1, 20, 1000, None]])
+@pytest.mark.parametrize("reduction_methods", ["mean", "quantile"])
 def test_datetime_stats(data, datetime_types_as_str, reduction_methods):
-    if reduction_methods not in ["mean", "quantile"]:
-        pytest.skip(f"{reduction_methods} not applicable for test")
     gsr = cudf.Series(data, dtype=datetime_types_as_str)
     psr = gsr.to_pandas()
 
@@ -1129,9 +1129,8 @@ def test_datetime_stats(data, datetime_types_as_str, reduction_methods):
         [1231],
     ],
 )
+@pytest.mark.parametrize("reduction_methods", ["max", "min", "std", "median"])
 def test_datetime_reductions(data, reduction_methods, datetime_types_as_str):
-    if reduction_methods not in ["max", "min", "std", "median"]:
-        pytest.skip(f"{reduction_methods} not applicable for test")
     sr = cudf.Series(data, dtype=datetime_types_as_str)
     psr = sr.to_pandas()
 

--- a/python/cudf/cudf/tests/series/test_binops.py
+++ b/python/cudf/cudf/tests/series/test_binops.py
@@ -21,6 +21,33 @@ from cudf.testing._utils import (
     gen_rand_series,
 )
 
+TIMEDELTA_SERIES_BINARY_OP_METHODS = [
+    "add",
+    "radd",
+    "sub",
+    "rsub",
+    "truediv",
+    "rtruediv",
+    "floordiv",
+    "rfloordiv",
+    "mod",
+    "rmod",
+    "lt",
+    "le",
+    "eq",
+    "ne",
+    "ge",
+    "gt",
+]
+
+TIMEDELTA_SCALAR_ARITHMETIC_OP_METHODS = [
+    "add",
+    "sub",
+    "truediv",
+    "floordiv",
+    "mod",
+]
+
 
 @pytest.mark.parametrize(
     "sr1", [pd.Series([10, 11, 12], index=["a", "b", "z"]), pd.Series(["a"])]
@@ -60,11 +87,12 @@ def test_series_error_equality(sr1, sr2, comparison_op):
         (cp.asarray([10, 20, 30, 100]), cp.asarray([10, 20, 30, 100])),
     ],
 )
+@pytest.mark.parametrize(
+    "binary_op_method", TIMEDELTA_SERIES_BINARY_OP_METHODS
+)
 def test_timedelta_ops_misc_inputs(
     data, other, timedelta_types_as_str, binary_op_method
 ):
-    if binary_op_method in {"mul", "rmul", "pow", "rpow"}:
-        pytest.skip(f"Test not applicable for {binary_op_method}")
     gsr = cudf.Series(data, dtype=timedelta_types_as_str)
     other_gsr = cudf.Series(other, dtype=timedelta_types_as_str)
 
@@ -232,21 +260,12 @@ def test_timedelta_dataframe_ops(df, op):
         np.timedelta64(1, "ns"),
     ],
 )
+@pytest.mark.parametrize(
+    "arithmetic_op_method", TIMEDELTA_SCALAR_ARITHMETIC_OP_METHODS
+)
 def test_timedelta_series_ops_with_scalars(
-    data, other_scalars, timedelta_types_as_str, arithmetic_op_method, request
+    data, other_scalars, timedelta_types_as_str, arithmetic_op_method
 ):
-    if arithmetic_op_method in {
-        "mul",
-        "rmul",
-        "rtruediv",
-        "pow",
-        "rpow",
-        "radd",
-        "rsub",
-        "rfloordiv",
-        "rmod",
-    }:
-        pytest.skip(f"Test not applicable for {arithmetic_op_method}")
     gsr = cudf.Series(data=data, dtype=timedelta_types_as_str)
     psr = gsr.to_pandas()
 

--- a/python/cudf/cudf/tests/window/test_rolling.py
+++ b/python/cudf/cudf/tests/window/test_rolling.py
@@ -140,10 +140,15 @@ def test_rolling_with_offset(supported_rolling_reductions):
     )
 
 
-@pytest.mark.parametrize("agg", ["std", "var"])
-@pytest.mark.parametrize("ddof", [0, 1])
-@pytest.mark.parametrize("window_size", [2, 100])
-def test_rolling_var_std_large(agg, ddof, center, window_size):
+@pytest.fixture(scope="module", params=[2, 100])
+def rolling_var_std_window_size(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def rolling_var_std_large_data(rolling_var_std_window_size):
+    # All consumers only read these inputs while varying the rolling options.
+    window_size = rolling_var_std_window_size
     iupper_bound = math.sqrt(np.iinfo(np.int64).max / window_size)
     ilower_bound = -math.sqrt(abs(np.iinfo(np.int64).min) / window_size)
 
@@ -180,7 +185,20 @@ def test_rolling_var_std_large(agg, ddof, center, window_size):
         seed=100,
     )
     gdf = cudf.DataFrame.from_arrow(data)
-    pdf = gdf.to_pandas()
+    return gdf, gdf.to_pandas()
+
+
+@pytest.mark.parametrize("agg", ["std", "var"])
+@pytest.mark.parametrize("ddof", [0, 1])
+def test_rolling_var_std_large(
+    agg,
+    ddof,
+    center,
+    rolling_var_std_window_size,
+    rolling_var_std_large_data,
+):
+    window_size = rolling_var_std_window_size
+    gdf, pdf = rolling_var_std_large_data
 
     expect = getattr(pdf.rolling(window_size, 1, center), agg)(ddof=ddof)
     got = getattr(gdf.rolling(window_size, 1, center), agg)(ddof=ddof)

--- a/python/cudf/cudf/tests/window/test_rolling.py
+++ b/python/cudf/cudf/tests/window/test_rolling.py
@@ -19,19 +19,9 @@ def center(request):
     return request.param
 
 
-@pytest.fixture
-def supported_rolling_reductions(reduction_methods):
-    if reduction_methods in [
-        "product",
-        "quantile",
-        "all",
-        "any",
-        "median",
-        "kurtosis",
-        "skew",
-    ]:
-        pytest.skip(f"{reduction_methods} not implemented")
-    return reduction_methods
+@pytest.fixture(params=["min", "max", "sum", "std", "var"])
+def supported_rolling_reductions(request):
+    return request.param
 
 
 @pytest.mark.parametrize(
@@ -388,11 +378,15 @@ def test_rolling_numba_udf_with_offset():
     )
 
 
-@pytest.mark.parametrize("window_size", [1, 2, 3])
-@pytest.mark.parametrize("min_periods", [1, 2, 3])
+@pytest.mark.parametrize(
+    "window_size,min_periods",
+    [
+        (window_size, min_periods)
+        for window_size in [1, 2, 3]
+        for min_periods in range(1, window_size + 1)
+    ],
+)
 def test_rolling_groupby_numba_udf(window_size, min_periods):
-    if min_periods > window_size:
-        pytest.skip("min_periods cannot exceed window_size")
     pdf = pd.DataFrame(
         {
             "a": [1, 1, 1, 2, 2, 2, 2],


### PR DESCRIPTION
## Description

Replace temporal, reduction, and rolling parameter combinations that deterministically skipped before an assertion with their existing supported subsets. Every combination that previously ran, including its expected failures and warning checks, still runs. The rolling variance/std inputs are additionally module-scoped and read-only, so option variants reuse identical data rather than reconstructing it.

## Checklist

- [x] I am familiar with the CONTRIBUTING.md guidelines.
- [x] New or existing tests cover these test-only changes.
- [x] Documentation updates are not needed.