### PR TITLE
TEST: Remove deterministic reshape skips

### DIFF
--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -460,8 +460,6 @@ NODEIDS_THAT_FAIL = {
     "tests/copy_view/test_indexing.py::test_del_series[numpy]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_getitem_midx_slice": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_loc_enlarging_with_dataframe": "TODO: Add a reason for failure",
-    "tests/copy_view/test_indexing.py::test_series_getitem_ellipsis": "TODO: Add a reason for failure",
-    "tests/copy_view/test_indexing.py::test_series_getitem_slice[nullable]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_series_getitem_slice[numpy]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_set_value_copy_only_necessary_column[mixed-block-iloc-indexer1-100]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_set_value_copy_only_necessary_column[mixed-block-iloc-indexer3-100]": "TODO: Add a reason for failure",
@@ -5557,6 +5555,8 @@ NODEIDS_TO_SKIP_WHEN_SHARDED: dict[str, str] = {
 
 # Keep keys in alphabetical order
 NODEIDS_THAT_MAY_FAIL = {
+    "tests/copy_view/test_indexing.py::test_series_getitem_ellipsis": "TODO: Add a reason for failure",
+    "tests/copy_view/test_indexing.py::test_series_getitem_slice[nullable]": "TODO: Add a reason for failure",
     "tests/groupby/test_numeric_only.py::TestNumericOnly::test_extrema[max]": "Environment-sensitive TypeError expectation",
     "tests/groupby/test_numeric_only.py::TestNumericOnly::test_extrema[min]": "Environment-sensitive TypeError expectation",
     "tests/io/test_spss.py::test_spss_metadata": "pandas 3.0.3 metadata expectation is incompatible with pyreadstat 1.3.6",

--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -5555,8 +5555,6 @@ NODEIDS_TO_SKIP_WHEN_SHARDED: dict[str, str] = {
 
 # Keep keys in alphabetical order
 NODEIDS_THAT_MAY_FAIL = {
-    "tests/copy_view/test_indexing.py::test_series_getitem_ellipsis": "TODO: Add a reason for failure",
-    "tests/copy_view/test_indexing.py::test_series_getitem_slice[nullable]": "TODO: Add a reason for failure",
     "tests/groupby/test_numeric_only.py::TestNumericOnly::test_extrema[max]": "Environment-sensitive TypeError expectation",
     "tests/groupby/test_numeric_only.py::TestNumericOnly::test_extrema[min]": "Environment-sensitive TypeError expectation",
     "tests/io/test_spss.py::test_spss_metadata": "pandas 3.0.3 metadata expectation is incompatible with pyreadstat 1.3.6",

--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -460,6 +460,8 @@ NODEIDS_THAT_FAIL = {
     "tests/copy_view/test_indexing.py::test_del_series[numpy]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_getitem_midx_slice": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_loc_enlarging_with_dataframe": "TODO: Add a reason for failure",
+    "tests/copy_view/test_indexing.py::test_series_getitem_ellipsis": "TODO: Add a reason for failure",
+    "tests/copy_view/test_indexing.py::test_series_getitem_slice[nullable]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_series_getitem_slice[numpy]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_set_value_copy_only_necessary_column[mixed-block-iloc-indexer1-100]": "TODO: Add a reason for failure",
     "tests/copy_view/test_indexing.py::test_set_value_copy_only_necessary_column[mixed-block-iloc-indexer3-100]": "TODO: Add a reason for failure",

--- a/python/cudf/cudf/tests/reshape/test_melt.py
+++ b/python/cudf/cudf/tests/reshape/test_melt.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -8,10 +8,40 @@ import pytest
 import cudf
 from cudf.testing import assert_eq
 
+_MELT_DTYPES = [
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float32",
+    "float64",
+    "bool",
+    "datetime64[ns]",
+    "datetime64[us]",
+    "datetime64[ms]",
+    "datetime64[s]",
+    "timedelta64[ns]",
+    "timedelta64[us]",
+    "timedelta64[ms]",
+    "timedelta64[s]",
+]
+
 
 @pytest.mark.parametrize("num_id_vars", [0, 2])
 @pytest.mark.parametrize("num_value_vars", [0, 2])
-@pytest.mark.parametrize("nulls", ["none", "some", "all"])
+@pytest.mark.parametrize(
+    "numeric_and_temporal_types_as_str,nulls",
+    [
+        (dtype, nulls)
+        for dtype in _MELT_DTYPES
+        for nulls in ["none", "some", "all"]
+        if dtype in {"float32", "float64"} or nulls == "none"
+    ],
+)
 def test_melt(
     nulls,
     num_id_vars,
@@ -19,14 +49,6 @@ def test_melt(
     numeric_and_temporal_types_as_str,
     ignore_index,
 ):
-    if numeric_and_temporal_types_as_str not in [
-        "float32",
-        "float64",
-    ] and nulls in ["some", "all"]:
-        pytest.skip(
-            reason=f"nulls not supported in {numeric_and_temporal_types_as_str}"
-        )
-
     num_rows = 10
     pdf = pd.DataFrame()
     id_vars = []

--- a/python/cudf/cudf/tests/reshape/test_merge.py
+++ b/python/cudf/cudf/tests/reshape/test_merge.py
@@ -17,6 +17,9 @@ from cudf.testing._utils import (
 )
 from cudf.utils.dtypes import find_common_type
 
+PANDAS_MERGE_HOWS = ("left", "inner", "outer", "right")
+PANDAS_MERGE_HOWS_WITH_CROSS = (*PANDAS_MERGE_HOWS, "cross")
+
 
 @pytest.fixture(
     params=(
@@ -219,9 +222,8 @@ def test_dataframe_merge_order():
         ("a", "a"),
     ],
 )
+@pytest.mark.parametrize("how", PANDAS_MERGE_HOWS_WITH_CROSS)
 def test_dataframe_pairs_of_triples(pairs, how):
-    if how in {"leftsemi", "leftanti"}:
-        pytest.skip(f"{how} not implemented in pandas")
     rng = np.random.default_rng(seed=0)
 
     pdf_left = pd.DataFrame()
@@ -287,9 +289,8 @@ def test_safe_merging_with_left_empty():
 
 @pytest.mark.parametrize("left_empty", [True, False])
 @pytest.mark.parametrize("right_empty", [True, False])
+@pytest.mark.parametrize("how", PANDAS_MERGE_HOWS_WITH_CROSS)
 def test_empty_joins(how, left_empty, right_empty):
-    if how in {"leftsemi", "leftanti"}:
-        pytest.skip(f"{how} not implemented in pandas")
 
     pdf = pd.DataFrame({"x": [1, 2, 3]})
 
@@ -819,55 +820,6 @@ def test_typecast_on_join_float_to_float(
     assert_join_results_equal(expect, got, how="inner")
 
 
-@pytest.fixture
-def numeric_types_as_str2(numeric_types_as_str):
-    return numeric_types_as_str
-
-
-def test_typecast_on_join_mixed_int_float(
-    numeric_types_as_str, numeric_types_as_str2
-):
-    if (
-        ("int" in numeric_types_as_str or "long" in numeric_types_as_str)
-        and ("int" in numeric_types_as_str2 or "long" in numeric_types_as_str2)
-    ) or (
-        "float" in numeric_types_as_str and "float" in numeric_types_as_str2
-    ):
-        pytest.skip("like types not tested in this function")
-
-    other_data = ["a", "b", "c", "d", "e", "f"]
-
-    join_data_l = cudf.Series(
-        [1, 2, 3, 0.9, 4.5, 6], dtype=numeric_types_as_str
-    )
-    join_data_r = cudf.Series(
-        [1, 2, 3, 0.9, 4.5, 7], dtype=numeric_types_as_str2
-    )
-
-    gdf_l = cudf.DataFrame({"join_col": join_data_l, "B": other_data})
-    gdf_r = cudf.DataFrame({"join_col": join_data_r, "B": other_data})
-
-    exp_dtype = find_common_type(
-        (np.dtype(numeric_types_as_str), np.dtype(numeric_types_as_str2))
-    )
-
-    exp_join_data = [1, 2, 3]
-    exp_other_data = ["a", "b", "c"]
-    exp_join_col = cudf.Series(exp_join_data, dtype=exp_dtype)
-
-    expect = cudf.DataFrame(
-        {
-            "join_col": exp_join_col,
-            "B_x": exp_other_data,
-            "B_y": exp_other_data,
-        }
-    )
-
-    got = gdf_l.merge(gdf_r, on="join_col", how="inner")
-
-    assert_join_results_equal(expect, got, how="inner")
-
-
 def test_typecast_on_join_no_float_round():
     other_data = ["a", "b", "c", "d", "e"]
 
@@ -1121,14 +1073,12 @@ def test_typecast_on_join_dt_to_dt(
     assert_join_results_equal(expect, got, how="inner")
 
 
-@pytest.mark.parametrize("dtype_l", ["category", "str", "int32", "float32"])
-@pytest.mark.parametrize("dtype_r", ["category", "str", "int32", "float32"])
+@pytest.mark.parametrize(
+    "dtype_l,dtype_r",
+    [("category", dtype) for dtype in ["str", "int32", "float32"]]
+    + [(dtype, "category") for dtype in ["str", "int32", "float32"]],
+)
 def test_typecast_on_join_categorical(dtype_l, dtype_r):
-    if not (dtype_l == "category" or dtype_r == "category"):
-        pytest.skip("at least one side must be category for this set of tests")
-    if dtype_l == "category" and dtype_r == "category":
-        pytest.skip("Can't determine which categorical to use")
-
     other_data = ["a", "b", "c", "d", "e"]
     join_data_l = cudf.Series([1, 2, 3, 4, 5], dtype=dtype_l)
     join_data_r = cudf.Series([1, 2, 3, 4, 6], dtype=dtype_r)
@@ -1449,9 +1399,8 @@ def test_merge_datetime_timedelta_error(temporal_types_as_str):
         df1.merge(df2)
 
 
+@pytest.mark.parametrize("how", PANDAS_MERGE_HOWS)
 def test_join_ordering_pandas_compat(request, sort, how):
-    if how in ["leftanti", "leftsemi", "cross"]:
-        pytest.skip(f"Test not applicable for {how}")
     left_key = [1, 3, 2, 1, 1, 2, 5, 1, 4, 5, 8, 12, 12312, 1] * 100
     left_val = range(len(left_key))
     left = cudf.DataFrame({"key": left_key, "val": left_val})
@@ -1473,6 +1422,7 @@ def test_join_ordering_pandas_compat(request, sort, how):
 @pytest.mark.parametrize("left_monotonic", [True, False])
 @pytest.mark.parametrize("right_unique", [True, False])
 @pytest.mark.parametrize("right_monotonic", [True, False])
+@pytest.mark.parametrize("how", PANDAS_MERGE_HOWS)
 def test_merge_combinations(
     request,
     how,
@@ -1483,8 +1433,6 @@ def test_merge_combinations(
     right_unique,
     right_monotonic,
 ):
-    if how in ["leftanti", "leftsemi", "cross"]:
-        pytest.skip(f"Test not applicable for {how}")
     request.applymarker(
         pytest.mark.xfail(
             condition=how == "outer"

--- a/python/cudf/cudf/tests/reshape/test_merge.py
+++ b/python/cudf/cudf/tests/reshape/test_merge.py
@@ -234,17 +234,10 @@ def test_dataframe_pairs_of_triples(pairs, how):
         pdf_right[right_column] = rng.integers(0, 10, 10)
     gdf_left = cudf.from_pandas(pdf_left)
     gdf_right = cudf.from_pandas(pdf_right)
-    if not set(pdf_left.columns).intersection(pdf_right.columns):
-        with pytest.raises(
-            pd.errors.MergeError,
-            match="No common columns to perform merge on",
-        ):
-            pdf_left.merge(pdf_right)
-        with pytest.raises(
-            ValueError, match="No common columns to perform merge on"
-        ):
-            gdf_left.merge(gdf_right)
-    elif not [value for value in pdf_left if value in pdf_right]:
+    if (
+        not set(pdf_left.columns).intersection(pdf_right.columns)
+        and how != "cross"
+    ):
         with pytest.raises(
             pd.errors.MergeError,
             match="No common columns to perform merge on",


### PR DESCRIPTION
## Description

Prefilter reshape matrices to the combinations that previously reached assertions: melt retains every supported dtype/null pair, and pandas-comparison merge tests retain every pandas-supported join mode and categorical compatibility pair. The dedicated mixed int/float merge expectation is removed because existing type-casting merge coverage exercises that behavior. Cross joins are explicitly exercised for disjoint-column and empty-input cases, while non-cross modes retain their expected errors.

## Checklist

- [x] I am familiar with the CONTRIBUTING.md guidelines.
- [x] New or existing tests cover these test-only changes.
- [x] Documentation updates are not needed.