### PR TITLE
TEST: Split str.cat coverage by behavior

### DIFF
--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -2692,136 +2692,247 @@ def test_string_index_duplicate_str_cat(data, others, sep, na_rep, name):
     )
 
 
-@pytest.mark.parametrize(
-    "others",
-    [
-        None,
-        ["f", "g", "h", "i", "j"],
-        ("f", "g", "h", "i", "j"),
-        pd.Series(["f", "g", "h", "i", "j"]),
-        pd.Series(["AbC", "de", "FGHI", "j", "kLm"]),
-        pd.Index(["f", "g", "h", "i", "j"]),
-        pd.Index(["AbC", "de", "FGHI", "j", "kLm"]),
-        (
-            np.array(["f", "g", "h", "i", "j"]),
-            np.array(["f", "g", "h", "i", "j"]),
-        ),
-        [
-            np.array(["f", "g", "h", "i", "j"]),
-            np.array(["f", "g", "h", "i", "j"]),
-        ],
-        [
-            pd.Series(["f", "g", "h", "i", "j"]),
-            pd.Series(["f", "g", "h", "i", "j"]),
-        ],
-        (
-            pd.Series(["f", "g", "h", "i", "j"]),
-            pd.Series(["f", "g", "h", "i", "j"]),
-        ),
-        [
-            pd.Series(["f", "g", "h", "i", "j"]),
-            np.array(["f", "g", "h", "i", "j"]),
-        ],
-        (
-            pd.Series(["f", "g", "h", "i", "j"]),
-            np.array(["f", "g", "h", "i", "j"]),
-        ),
-        (
-            pd.Series(["f", "g", "h", "i", "j"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Series(["f", "g", "h", "i", "j"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Index(["1", "2", "3", "4", "5"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Index(["f", "g", "h", "i", "j"]),
-        ),
-        [
-            pd.Index(["f", "g", "h", "i", "j"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Series(["f", "g", "h", "i", "j"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Index(["f", "g", "h", "i", "j"]),
-            np.array(["f", "a", "b", "f", "a"]),
-            pd.Index(["f", "g", "h", "i", "j"]),
-        ],
-        [
-            pd.Series(["hello", "world", "abc", "xyz", "pqr"]),
-            pd.Series(["abc", "xyz", "hello", "pqr", "world"]),
-        ],
-        [
-            pd.Series(
-                ["hello", "world", "abc", "xyz", "pqr"],
-                index=[10, 11, 12, 13, 14],
-            ),
-            pd.Series(
-                ["abc", "xyz", "hello", "pqr", "world"],
-                index=[10, 15, 11, 13, 14],
-            ),
-        ],
-        [
-            pd.Series(
-                ["hello", "world", "abc", "xyz", "pqr"],
-                index=["10", "11", "12", "13", "14"],
-            ),
-            pd.Series(
-                ["abc", "xyz", "hello", "pqr", "world"],
-                index=["10", "11", "12", "13", "14"],
-            ),
-        ],
-        [
-            pd.Series(
-                ["hello", "world", "abc", "xyz", "pqr"],
-                index=["10", "11", "12", "13", "14"],
-            ),
-            pd.Series(
-                ["abc", "xyz", "hello", "pqr", "world"],
-                index=["10", "15", "11", "13", "14"],
-            ),
-        ],
-        [
-            pd.Series(
-                ["hello", "world", "abc", "xyz", "pqr"],
-                index=["1", "2", "3", "4", "5"],
-            ),
-            pd.Series(
-                ["abc", "xyz", "hello", "pqr", "world"],
-                index=["10", "11", "12", "13", "14"],
-            ),
-        ],
-    ],
-)
-@pytest.mark.parametrize("sep", [None, "", " ", "|", ",", "|||"])
-@pytest.mark.parametrize("na_rep", [None, "", "null", "a"])
-def test_string_cat(ps_gs, others, sep, na_rep, index, request):
-    # https://github.com/pandas-dev/pandas/issues/63371
-    ps, gs = ps_gs
+def _assert_string_cat(data, others, sep, na_rep, index=None):
+    ps = pd.Series(data, index=index, dtype="str", name="nice name")
+    gs = cudf.Series(data, index=index, dtype="str", name="nice name")
     is_any_others_ndarray = isinstance(others, (list, tuple)) and any(
         isinstance(item, np.ndarray) for item in others
     )
-    is_any_others_series_with_string_index = isinstance(
-        others, (list, tuple)
-    ) and any(
-        isinstance(item, pd.Series)
-        and isinstance(item.index.dtype, pd.StringDtype)
-        for item in others
-    )
-    request.applymarker(
-        pytest.mark.xfail(
-            is_any_others_series_with_string_index,
-            reason="https://github.com/NVIDIA/cudf/issues/21123",
-        )
-    )
-    pd_others = others
-    gd_others = _cat_convert_seq_to_cudf(others)
 
-    expect = ps.str.cat(others=pd_others, sep=sep, na_rep=na_rep)
-    got = gs.str.cat(others=gd_others, sep=sep, na_rep=na_rep)
+    expect = ps.str.cat(others=others, sep=sep, na_rep=na_rep)
+    got = gs.str.cat(
+        others=_cat_convert_seq_to_cudf(others), sep=sep, na_rep=na_rep
+    )
     if is_any_others_ndarray:
         # pandas returns Index[object] which cuDF doesn't support
         expect.index = expect.index.astype(got.index.dtype)
     assert_eq(expect, got)
+
+
+@pytest.mark.parametrize(
+    "data, sep, na_rep",
+    [
+        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], None, None),
+        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "", None),
+        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "|", None),
+        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "|||", None),
+        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", None),
+        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", ""),
+        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", "null"),
+        pytest.param([None, None, None, None, None], "|", "null"),
+    ],
+)
+def test_string_cat_join(data, sep, na_rep):
+    _assert_string_cat(data, None, sep, na_rep)
+
+
+@pytest.mark.parametrize(
+    "data, others, sep, na_rep",
+    [
+        pytest.param(
+            ["nOPq", None, "RsT", None, "uVw"],
+            ["f", "g", "h", "i", "j"],
+            None,
+            None,
+        ),
+        pytest.param(
+            ["nOPq", None, "RsT", None, "uVw"],
+            ["f", "g", "h", "i", "j"],
+            "|",
+            "",
+        ),
+        pytest.param(
+            ["nOPq", None, "RsT", None, "uVw"],
+            pd.Series(["f", "g", "h", "i", "j"]),
+            "|",
+            "null",
+        ),
+        pytest.param(
+            [None, None, None, None, None],
+            ["f", "g", "h", "i", "j"],
+            "|",
+            None,
+        ),
+        pytest.param(
+            [None, None, None, None, None],
+            pd.Index(["f", "g", "h", "i", "j"]),
+            "|",
+            "null",
+        ),
+    ],
+)
+def test_string_cat_elementwise_nulls(data, others, sep, na_rep):
+    _assert_string_cat(data, others, sep, na_rep)
+
+
+@pytest.mark.parametrize(
+    "others",
+    [
+        pytest.param(["f", "g", "h", "i", "j"], id="list"),
+        pytest.param(("f", "g", "h", "i", "j"), id="tuple"),
+        pytest.param(pd.Series(["f", "g", "h", "i", "j"]), id="series"),
+        pytest.param(pd.Index(["f", "g", "h", "i", "j"]), id="index"),
+        pytest.param(
+            (
+                np.array(["f", "g", "h", "i", "j"]),
+                np.array(["f", "g", "h", "i", "j"]),
+            ),
+            id="tuple-of-ndarrays",
+        ),
+        pytest.param(
+            [
+                np.array(["f", "g", "h", "i", "j"]),
+                np.array(["f", "g", "h", "i", "j"]),
+            ],
+            id="list-of-ndarrays",
+        ),
+        pytest.param(
+            [
+                pd.Series(["f", "g", "h", "i", "j"]),
+                pd.Series(["f", "g", "h", "i", "j"]),
+            ],
+            id="list-of-series",
+        ),
+        pytest.param(
+            (
+                pd.Series(["f", "g", "h", "i", "j"]),
+                pd.Series(["f", "g", "h", "i", "j"]),
+            ),
+            id="tuple-of-series",
+        ),
+        pytest.param(
+            [
+                pd.Series(["f", "g", "h", "i", "j"]),
+                np.array(["f", "g", "h", "i", "j"]),
+            ],
+            id="list-of-series-and-ndarray",
+        ),
+        pytest.param(
+            (
+                pd.Series(["f", "g", "h", "i", "j"]),
+                np.array(["f", "g", "h", "i", "j"]),
+            ),
+            id="tuple-of-series-and-ndarray",
+        ),
+        pytest.param(
+            (
+                pd.Series(["f", "g", "h", "i", "j"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Series(["f", "g", "h", "i", "j"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Index(["1", "2", "3", "4", "5"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Index(["f", "g", "h", "i", "j"]),
+            ),
+            id="heterogeneous-tuple",
+        ),
+        pytest.param(
+            [
+                pd.Index(["f", "g", "h", "i", "j"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Series(["f", "g", "h", "i", "j"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Index(["f", "g", "h", "i", "j"]),
+                np.array(["f", "a", "b", "f", "a"]),
+                pd.Index(["f", "g", "h", "i", "j"]),
+            ],
+            id="heterogeneous-list",
+        ),
+    ],
+)
+def test_string_cat_input_forms(others):
+    _assert_string_cat(["AbC", "de", "FGHI", "j", "kLm"], others, "|", None)
+
+
+@pytest.mark.parametrize(
+    "index, others",
+    [
+        pytest.param(
+            [10, 11, 12, 13, 14],
+            pd.Series(["f", "g", "h", "i", "j"]),
+            id="series-reindex",
+        ),
+        pytest.param(
+            None,
+            [
+                pd.Series(["hello", "world", "abc", "xyz", "pqr"]),
+                pd.Series(["abc", "xyz", "hello", "pqr", "world"]),
+            ],
+            id="multiple-series-default-index",
+        ),
+        pytest.param(
+            None,
+            [
+                pd.Series(
+                    ["hello", "world", "abc", "xyz", "pqr"],
+                    index=[10, 11, 12, 13, 14],
+                ),
+                pd.Series(
+                    ["abc", "xyz", "hello", "pqr", "world"],
+                    index=[10, 15, 11, 13, 14],
+                ),
+            ],
+            id="multiple-series-partial-integer-index",
+        ),
+        pytest.param(
+            None,
+            [
+                pd.Series(
+                    ["hello", "world", "abc", "xyz", "pqr"],
+                    index=["10", "11", "12", "13", "14"],
+                ),
+                pd.Series(
+                    ["abc", "xyz", "hello", "pqr", "world"],
+                    index=["10", "11", "12", "13", "14"],
+                ),
+            ],
+            marks=pytest.mark.xfail(
+                reason="https://github.com/NVIDIA/cudf/issues/21123"
+            ),
+            id="multiple-series-matching-string-index",
+        ),
+        pytest.param(
+            None,
+            [
+                pd.Series(
+                    ["hello", "world", "abc", "xyz", "pqr"],
+                    index=["10", "11", "12", "13", "14"],
+                ),
+                pd.Series(
+                    ["abc", "xyz", "hello", "pqr", "world"],
+                    index=["10", "15", "11", "13", "14"],
+                ),
+            ],
+            marks=pytest.mark.xfail(
+                reason="https://github.com/NVIDIA/cudf/issues/21123"
+            ),
+            id="multiple-series-partial-string-index",
+        ),
+        pytest.param(
+            None,
+            [
+                pd.Series(
+                    ["hello", "world", "abc", "xyz", "pqr"],
+                    index=["1", "2", "3", "4", "5"],
+                ),
+                pd.Series(
+                    ["abc", "xyz", "hello", "pqr", "world"],
+                    index=["10", "11", "12", "13", "14"],
+                ),
+            ],
+            marks=pytest.mark.xfail(
+                reason="https://github.com/NVIDIA/cudf/issues/21123"
+            ),
+            id="multiple-series-disjoint-string-index",
+        ),
+    ],
+)
+def test_string_cat_series_alignment(index, others):
+    _assert_string_cat(
+        ["AbC", "de", "FGHI", "j", "kLm"], others, "|", None, index
+    )
 
 
 @pytest.mark.parametrize("sep", [None, "", " ", "|", ",", "|||"])

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -2823,9 +2823,13 @@ def test_string_cat(ps_gs, others, sep, na_rep, index, request):
         expect.index = expect.index.astype(got.index.dtype)
     assert_eq(expect, got)
 
+
+@pytest.mark.parametrize("sep", [None, "", " ", "|", ",", "|||"])
+@pytest.mark.parametrize("na_rep", [None, "", "null", "a"])
+def test_string_cat_index_others(data, sep, na_rep):
     index = ["1", "2", "3", "4", "5"]
-    ps.index = index
-    gs.index = index
+    ps = pd.Series(data, index=index, dtype="str", name="nice name")
+    gs = cudf.Series(data, index=index, dtype="str", name="nice name")
 
     expect = ps.str.cat(others=ps.index, sep=sep, na_rep=na_rep)
     got = gs.str.cat(others=gs.index, sep=sep, na_rep=na_rep)

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -2705,7 +2705,7 @@ def _assert_string_cat(data, others, sep, na_rep, index=None):
     )
     if is_any_others_ndarray:
         # pandas returns Index[object] which cuDF doesn't support
-        expect.index = expect.index.astype(got.index.dtype)
+        expect.index = expect.index.astype(ps.index.dtype)
     assert_eq(expect, got)
 
 


### PR DESCRIPTION
## Description

Replace the broad `str.cat` Cartesian product with behavior-focused cases and isolate index alignment from unrelated argument combinations. The change removes repetition, not input forms or observable behaviors.

## Coverage accounting

- Join cases retain no separator, empty and multi-character separators, null inputs, and `na_rep` handling.
- Elementwise cases retain list, tuple, Series, Index, ndarray, mixed-sequence, and heterogeneous-sequence `others` forms.
- Series alignment cases retain reindexing, matching and partially overlapping integer/string indices, including the existing expected failures.
- The existing 72 `others=Index` cases remain separate and unchanged.

## Checklist

- [x] I am familiar with the CONTRIBUTING.md guidelines.
- [x] New or existing tests cover these test-only changes.
- [x] Documentation updates are not needed.