### PR TITLE
TEST: Reduce redundant numerical test matrices

### DIFF
--- a/python/cudf/cudf/tests/private_objects/test_extension_compilation.py
+++ b/python/cudf/cudf/tests/private_objects/test_extension_compilation.py
@@ -72,8 +72,7 @@ def test_compile_masked_unary(op, ty):
 
 
 @pytest.mark.parametrize("op", arith_ops)
-@pytest.mark.parametrize("ty", number_types, ids=number_ids)
-def test_execute_masked_binary(op, ty):
+def test_execute_masked_binary(op):
     @cuda.jit(device=True)
     def func(x, y):
         return op(x, y)

--- a/python/cudf/cudf/tests/series/methods/test_cov_corr.py
+++ b/python/cudf/cudf/tests/series/methods/test_cov_corr.py
@@ -14,13 +14,13 @@ from cudf.testing._utils import expect_warning_if
 COV_CORR_DATA_PAIRS = [
     pytest.param(
         np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        id="normal",
+        np.random.default_rng(seed=0).integers(-50, 50, 1000),
+        id="normal-integers",
     ),
     pytest.param(
         np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        id="integers",
+        np.random.default_rng(seed=0).normal(-100, 100, 1000),
+        id="integers-normal",
     ),
     pytest.param(np.zeros(100), np.zeros(100), id="constant"),
     pytest.param(

--- a/python/cudf/cudf/tests/series/methods/test_cov_corr.py
+++ b/python/cudf/cudf/tests/series/methods/test_cov_corr.py
@@ -33,12 +33,12 @@ COV_CORR_DATA_PAIRS = [
     ),
     pytest.param(
         pa.array([5, 10, 53, None, np.nan, None]),
-        pd.Series([1.1, 2.32, 43.4], index=[0, 500, 4000]),
-        id="arrow-and-indexed-series",
+        np.array([1.0, 4.0, 9.0, np.nan, 16.0, 25.0]),
+        id="arrow",
     ),
     pytest.param(
         pd.Series([1.1, 2.32, 43.4], index=[0, 4, 3]),
-        pd.Series([1.1, 2.32, 43.4], index=[0, 500, 4000]),
+        pd.Series([43.4, 1.1, 2.32], index=[3, 0, 4]),
         id="indexed-series",
     ),
     pytest.param(np.array([], dtype="float64"), np.array([5]), id="empty"),

--- a/python/cudf/cudf/tests/series/methods/test_cov_corr.py
+++ b/python/cudf/cudf/tests/series/methods/test_cov_corr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -11,33 +11,46 @@ import cudf
 from cudf.testing import assert_eq
 from cudf.testing._utils import expect_warning_if
 
-
-@pytest.mark.parametrize(
-    "data1",
-    [
+COV_CORR_DATA_PAIRS = [
+    pytest.param(
         np.random.default_rng(seed=0).normal(-100, 100, 1000),
+        np.random.default_rng(seed=0).normal(-100, 100, 1000),
+        id="normal",
+    ),
+    pytest.param(
         np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.zeros(100),
-        np.repeat(np.nan, 100),
+        np.random.default_rng(seed=0).integers(-50, 50, 1000),
+        id="integers",
+    ),
+    pytest.param(np.zeros(100), np.zeros(100), id="constant"),
+    pytest.param(
+        np.repeat(np.nan, 100), np.repeat(np.nan, 100), id="all-null"
+    ),
+    pytest.param(
         np.array([1.123, 2.343, np.nan, 0.0]),
+        np.array([1.123, 2.343, np.nan, 0.0]),
+        id="nullable",
+    ),
+    pytest.param(
         pa.array([5, 10, 53, None, np.nan, None]),
-        pd.Series([1.1, 2.32, 43.4], index=[0, 4, 3]),
-        np.array([], dtype="float64"),
-        np.array([-3]),
-    ],
-)
-@pytest.mark.parametrize(
-    "data2",
-    [
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.zeros(100),
-        np.repeat(np.nan, 100),
-        np.array([1.123, 2.343, np.nan, 0.0]),
         pd.Series([1.1, 2.32, 43.4], index=[0, 500, 4000]),
-        np.array([5]),
-    ],
-)
+        id="arrow-and-indexed-series",
+    ),
+    pytest.param(
+        pd.Series([1.1, 2.32, 43.4], index=[0, 4, 3]),
+        pd.Series([1.1, 2.32, 43.4], index=[0, 500, 4000]),
+        id="indexed-series",
+    ),
+    pytest.param(np.array([], dtype="float64"), np.array([5]), id="empty"),
+    pytest.param(
+        np.array([-3]),
+        np.random.default_rng(seed=0).normal(-100, 100, 1000),
+        id="singleton",
+    ),
+]
+
+
+@pytest.mark.parametrize(("data1", "data2"), COV_CORR_DATA_PAIRS)
 def test_cov1d(data1, data2):
     gs1 = cudf.Series(data1)
     gs2 = cudf.Series(data2)
@@ -56,32 +69,7 @@ def test_cov1d(data1, data2):
     np.testing.assert_approx_equal(got, expected, significant=8)
 
 
-@pytest.mark.parametrize(
-    "data1",
-    [
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.zeros(100),
-        np.repeat(np.nan, 100),
-        np.array([1.123, 2.343, np.nan, 0.0]),
-        pa.array([5, 10, 53, None, np.nan, None]),
-        pd.Series([1.1032, 2.32, 43.4], index=[0, 4, 3]),
-        np.array([], dtype="float64"),
-        np.array([-3]),
-    ],
-)
-@pytest.mark.parametrize(
-    "data2",
-    [
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.zeros(100),
-        np.repeat(np.nan, 100),
-        np.array([1.123, 2.343, np.nan, 0.0]),
-        pd.Series([1.1, 2.32, 43.4], index=[0, 500, 4000]),
-        np.array([5]),
-    ],
-)
+@pytest.mark.parametrize(("data1", "data2"), COV_CORR_DATA_PAIRS)
 def test_corr1d(data1, data2, corr_method):
     if corr_method == "spearman":
         # Pandas uses scipy.stats.spearmanr code-path


### PR DESCRIPTION
## Description

Replace covariance/correlation’s redundant operand Cartesian product with nine explicit representative pairs, and remove an unused parameter from one masked-binary execution test.

## Coverage accounting

- The pairs retain normal and integer inputs, constant and all-null values, nullable arrays, Arrow input, empty input, and singleton input.
- The indexed-Series pair uses the same three labels in a different order on both sides, retaining multi-row index-alignment behavior rather than only a singular/NaN outcome.
- The same pairs run for covariance and both Pearson and Spearman correlation (189 items to 27).
- The removed extension-compilation type parameter was not consumed by the test: every former node executed the same integer-scalar kernel.

## Checklist

- [x] I am familiar with the CONTRIBUTING.md guidelines.
- [x] New or existing tests cover these test-only changes.
- [x] Documentation updates are not needed.