### PR TITLE
PERF: Lazily initialize the JIT runtime context

### DIFF
--- a/cpp/include/cudf/context.hpp
+++ b/cpp/include/cudf/context.hpp
@@ -19,10 +19,12 @@ enum class init_flags : std::uint32_t {
   NONE = 0,
   /// @brief Load the nvCOMP library during initialization
   LOAD_NVCOMP = 1 << 0,
+  /// @brief Initialize the JIT runtime and caches during initialization
+  INITIALIZE_JIT = 1 << 1,
   /// @brief Default initialization steps
   DEFAULT = NONE,
   /// @brief All initialization steps
-  ALL = LOAD_NVCOMP
+  ALL = LOAD_NVCOMP | INITIALIZE_JIT
 };
 
 /// @brief Bitwise OR operator for init_flags

--- a/cpp/include/cudf/context.hpp
+++ b/cpp/include/cudf/context.hpp
@@ -19,12 +19,10 @@ enum class init_flags : std::uint32_t {
   NONE = 0,
   /// @brief Load the nvCOMP library during initialization
   LOAD_NVCOMP = 1 << 0,
-  /// @brief Initialize the JIT runtime and program cache
-  INITIALIZE_JIT = 1 << 1,
   /// @brief Default initialization steps
   DEFAULT = NONE,
   /// @brief All initialization steps
-  ALL = LOAD_NVCOMP | INITIALIZE_JIT
+  ALL = LOAD_NVCOMP
 };
 
 /// @brief Bitwise OR operator for init_flags

--- a/cpp/include/cudf/context.hpp
+++ b/cpp/include/cudf/context.hpp
@@ -19,10 +19,12 @@ enum class init_flags : std::uint32_t {
   NONE = 0,
   /// @brief Load the nvCOMP library during initialization
   LOAD_NVCOMP = 1 << 0,
+  /// @brief Initialize the JIT runtime and program cache
+  INITIALIZE_JIT = 1 << 1,
   /// @brief Default initialization steps
   DEFAULT = NONE,
   /// @brief All initialization steps
-  ALL = LOAD_NVCOMP
+  ALL = LOAD_NVCOMP | INITIALIZE_JIT
 };
 
 /// @brief Bitwise OR operator for init_flags

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -67,37 +67,43 @@ void context::preload_nvcomp()
 
 void context::initialize_jit()
 {
-  std::call_once(_jit_init_flag, [&] {
-    CUDF_FUNC_RANGE();
+  CUDF_FUNC_RANGE();
 
-    // make sure the required directories exist
-    std::filesystem::create_directories(_config.rtcx_cache_dir);
-    std::filesystem::create_directories(_config.jit_bundle_dir);
-    std::filesystem::create_directories(_config.jit_pch_dir);
-    std::filesystem::create_directories(_config.jit_tmp_dir);
+  // make sure the required directories exist
+  std::filesystem::create_directories(_config.rtcx_cache_dir);
+  std::filesystem::create_directories(_config.jit_bundle_dir);
+  std::filesystem::create_directories(_config.jit_pch_dir);
+  std::filesystem::create_directories(_config.jit_tmp_dir);
 
-    rtcx::initialize();
-    _rtcx_initialized = true;
+  _nvrtc_version     = rtcx::nvrtc_version();
+  _nvjitlink_version = rtcx::nvjitlink_version();
 
-    _nvrtc_version     = rtcx::nvrtc_version();
-    _nvjitlink_version = rtcx::nvjitlink_version();
+  auto limits = rtcx::cache_limits{.num_mem_blobs     = _config.kernel_cache_limit_process,
+                                   .num_mem_libraries = _config.kernel_cache_limit_process};
 
-    auto limits = rtcx::cache_limits{.num_mem_blobs     = _config.kernel_cache_limit_process,
-                                     .num_mem_libraries = _config.kernel_cache_limit_process};
+  _rtcx_cache = std::make_unique<rtcx::cache_t>(_config.rtcx_cache_dir,
+                                                _config.jit_tmp_dir,
+                                                limits,
+                                                bool{_config.preload_jit_cache},
+                                                bool{_config.disable_jit_cache});
 
-    _rtcx_cache = std::make_unique<rtcx::cache_t>(_config.rtcx_cache_dir,
-                                                  _config.jit_tmp_dir,
-                                                  limits,
-                                                  bool{_config.preload_jit_cache},
-                                                  bool{_config.disable_jit_cache});
+  if (_config.clear_jit_cache) {
+    _rtcx_cache->clear_memory_store();
+    _rtcx_cache->clear_disk_store();
+  }
 
-    if (_config.clear_jit_cache) {
-      _rtcx_cache->clear_memory_store();
-      _rtcx_cache->clear_disk_store();
+  // note that jit_bundle depends on rtcx_cache, so we ensure rtcx_cache is initialized first.
+  _jit_bundle = std::make_unique<jit_bundle_t>(_config.jit_bundle_dir, *_rtcx_cache);
+}
+
+void context::ensure_jit_initialized()
+{
+  std::call_once(_jit_init_flag, [this] {
+    if (!_rtcx_initialized) {
+      rtcx::initialize();
+      _rtcx_initialized = true;
     }
-
-    // note that jit_bundle depends on rtcx_cache, so we ensure rtcx_cache is initialized first.
-    _jit_bundle = std::make_unique<jit_bundle_t>(_config.jit_bundle_dir, *_rtcx_cache);
+    initialize_jit();
   });
 }
 
@@ -110,13 +116,13 @@ context::~context()
 
 rtcx::cache_t& context::rtcx_cache()
 {
-  initialize_jit();
+  ensure_jit_initialized();
   return *_rtcx_cache;
 }
 
 jit_bundle_t& context::jit_bundle()
 {
-  initialize_jit();
+  ensure_jit_initialized();
   return *_jit_bundle;
 }
 
@@ -140,7 +146,6 @@ std::optional<int32_t> context::nvjitlink_version() const { return _nvjitlink_ve
 void context::initialize_components(detail::init_flags flags)
 {
   CUDF_FUNC_RANGE();
-  if (has_flag(flags, detail::init_flags::INITIALIZE_JIT)) { initialize_jit(); }
   if (has_flag(flags, detail::init_flags::LOAD_NVCOMP)) { preload_nvcomp(); }
 }
 

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -53,12 +53,8 @@ int32_t get_current_device_compute_capability()
 context::context(context_config cfg, detail::init_flags flags)
   : _config{std::move(cfg)},
     _device_properties{
-      get_driver_version(), get_runtime_version(), get_current_device_compute_capability()},
-    _nvrtc_version{0},
-    _nvjitlink_version{0}
+      get_driver_version(), get_runtime_version(), get_current_device_compute_capability()}
 {
-  rtcx::initialize();
-  initialize_jit();
   initialize_components(flags);
 }
 
@@ -71,45 +67,58 @@ void context::preload_nvcomp()
 
 void context::initialize_jit()
 {
-  CUDF_FUNC_RANGE();
+  std::call_once(_jit_init_flag, [&] {
+    CUDF_FUNC_RANGE();
 
-  // make sure the required directories exist
-  std::filesystem::create_directories(_config.rtcx_cache_dir);
-  std::filesystem::create_directories(_config.jit_bundle_dir);
-  std::filesystem::create_directories(_config.jit_pch_dir);
-  std::filesystem::create_directories(_config.jit_tmp_dir);
+    // make sure the required directories exist
+    std::filesystem::create_directories(_config.rtcx_cache_dir);
+    std::filesystem::create_directories(_config.jit_bundle_dir);
+    std::filesystem::create_directories(_config.jit_pch_dir);
+    std::filesystem::create_directories(_config.jit_tmp_dir);
 
-  _nvrtc_version     = rtcx::nvrtc_version();
-  _nvjitlink_version = rtcx::nvjitlink_version();
+    rtcx::initialize();
+    _rtcx_initialized = true;
 
-  auto limits = rtcx::cache_limits{.num_mem_blobs     = _config.kernel_cache_limit_process,
-                                   .num_mem_libraries = _config.kernel_cache_limit_process};
+    _nvrtc_version     = rtcx::nvrtc_version();
+    _nvjitlink_version = rtcx::nvjitlink_version();
 
-  _rtcx_cache = std::make_unique<rtcx::cache_t>(_config.rtcx_cache_dir,
-                                                _config.jit_tmp_dir,
-                                                limits,
-                                                bool{_config.preload_jit_cache},
-                                                bool{_config.disable_jit_cache});
+    auto limits = rtcx::cache_limits{.num_mem_blobs     = _config.kernel_cache_limit_process,
+                                     .num_mem_libraries = _config.kernel_cache_limit_process};
 
-  if (_config.clear_jit_cache) {
-    _rtcx_cache->clear_memory_store();
-    _rtcx_cache->clear_disk_store();
-  }
+    _rtcx_cache = std::make_unique<rtcx::cache_t>(_config.rtcx_cache_dir,
+                                                  _config.jit_tmp_dir,
+                                                  limits,
+                                                  bool{_config.preload_jit_cache},
+                                                  bool{_config.disable_jit_cache});
 
-  // note that jit_bundle depends on rtcx_cache, so we ensure rtcx_cache is initialized first.
-  _jit_bundle = std::make_unique<jit_bundle_t>(_config.jit_bundle_dir, *_rtcx_cache);
+    if (_config.clear_jit_cache) {
+      _rtcx_cache->clear_memory_store();
+      _rtcx_cache->clear_disk_store();
+    }
+
+    // note that jit_bundle depends on rtcx_cache, so we ensure rtcx_cache is initialized first.
+    _jit_bundle = std::make_unique<jit_bundle_t>(_config.jit_bundle_dir, *_rtcx_cache);
+  });
 }
 
 context::~context()
 {
   _jit_bundle.reset();
   _rtcx_cache.reset();
-  rtcx::teardown();
+  if (_rtcx_initialized) { rtcx::teardown(); }
 }
 
-rtcx::cache_t& context::rtcx_cache() { return *_rtcx_cache; }
+rtcx::cache_t& context::rtcx_cache()
+{
+  initialize_jit();
+  return *_rtcx_cache;
+}
 
-jit_bundle_t& context::jit_bundle() { return *_jit_bundle; }
+jit_bundle_t& context::jit_bundle()
+{
+  initialize_jit();
+  return *_jit_bundle;
+}
 
 bool context::dump_codegen() const { return _config.dump_codegen; }
 

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -140,6 +140,7 @@ std::optional<int32_t> context::nvjitlink_version() const { return _nvjitlink_ve
 void context::initialize_components(detail::init_flags flags)
 {
   CUDF_FUNC_RANGE();
+  if (has_flag(flags, detail::init_flags::INITIALIZE_JIT)) { initialize_jit(); }
   if (has_flag(flags, detail::init_flags::LOAD_NVCOMP)) { preload_nvcomp(); }
 }
 

--- a/cpp/src/runtime/context.cpp
+++ b/cpp/src/runtime/context.cpp
@@ -147,6 +147,7 @@ void context::initialize_components(detail::init_flags flags)
 {
   CUDF_FUNC_RANGE();
   if (has_flag(flags, detail::init_flags::LOAD_NVCOMP)) { preload_nvcomp(); }
+  if (has_flag(flags, detail::init_flags::INITIALIZE_JIT)) { ensure_jit_initialized(); }
 }
 
 namespace {

--- a/cpp/src/runtime/context.hpp
+++ b/cpp/src/runtime/context.hpp
@@ -65,6 +65,8 @@ class context {
  private:
   void preload_nvcomp();
 
+  void ensure_jit_initialized();
+
   void initialize_jit();
 
   void initialize_components(detail::init_flags flags);

--- a/cpp/src/runtime/context.hpp
+++ b/cpp/src/runtime/context.hpp
@@ -9,6 +9,7 @@
 #include <cudf/utilities/export.hpp>
 
 #include <memory>
+#include <mutex>
 #include <optional>
 
 namespace rtcx {
@@ -53,6 +54,8 @@ class context {
 
  private:
   context_config _config;
+  std::once_flag _jit_init_flag;
+  bool _rtcx_initialized = false;
   std::unique_ptr<rtcx::cache_t> _rtcx_cache;
   std::unique_ptr<jit_bundle_t> _jit_bundle;
   device_properties _device_properties;

--- a/cpp/tests/utilities_tests/context_tests.cpp
+++ b/cpp/tests/utilities_tests/context_tests.cpp
@@ -14,7 +14,27 @@
 
 #include <gtest/gtest.h>
 
+#include <barrier>
+#include <future>
+#include <vector>
+
 struct ContextTest : public cudf::test::BaseFixture {};
+
+namespace {
+
+cudf::size_type compute_column_jit()
+{
+  auto c_0        = cudf::test::fixed_width_column_wrapper<cudf::size_type>{3, 20, 1, 50};
+  auto c_1        = cudf::test::fixed_width_column_wrapper<cudf::size_type>{10, 7, 20, 0};
+  auto table      = cudf::table_view{{c_0, c_1}};
+  auto col_ref_0  = cudf::ast::column_reference(0);
+  auto col_ref_1  = cudf::ast::column_reference(1);
+  auto expression = cudf::ast::operation(cudf::ast::ast_operator::ADD, col_ref_0, col_ref_1);
+
+  return cudf::compute_column_jit(table, expression)->size();
+}
+
+}  // namespace
 
 TEST_F(ContextTest, MultipleInitializeCalls)
 {
@@ -24,25 +44,32 @@ TEST_F(ContextTest, MultipleInitializeCalls)
   EXPECT_NO_THROW(cudf::detail::initialize(cudf::detail::init_flags::ALL));
 }
 
+TEST_F(ContextTest, ConcurrentFirstJitCacheUse)
+{
+  constexpr auto num_threads = 4;
+  std::barrier start{num_threads};
+  std::vector<std::future<cudf::size_type>> results;
+  results.reserve(num_threads);
+
+  for (auto i = 0; i < num_threads; ++i) {
+    results.push_back(std::async(std::launch::async, [&] {
+      start.arrive_and_wait();
+      return compute_column_jit();
+    }));
+  }
+
+  for (auto& result : results) {
+    EXPECT_EQ(result.get(), cudf::size_type{4});
+  }
+}
+
 TEST_F(ContextTest, JitCacheUse)
 {
-  auto compute_column = [] {
-    auto c_0        = cudf::test::fixed_width_column_wrapper<cudf::size_type>{3, 20, 1, 50};
-    auto c_1        = cudf::test::fixed_width_column_wrapper<cudf::size_type>{10, 7, 20, 0};
-    auto table      = cudf::table_view{{c_0, c_1}};
-    auto col_ref_0  = cudf::ast::column_reference(0);
-    auto col_ref_1  = cudf::ast::column_reference(1);
-    auto expression = cudf::ast::operation(cudf::ast::ast_operator::ADD, col_ref_0, col_ref_1);
-
-    auto result = cudf::compute_column_jit(table, expression);
-    EXPECT_EQ(result->size(), cudf::size_type{4});
-  };
+  cudf::detail::initialize(cudf::detail::init_flags::DEFAULT);
+  EXPECT_EQ(compute_column_jit(), cudf::size_type{4});
 
   cudf::detail::initialize(cudf::detail::init_flags::DEFAULT);
-  ASSERT_NO_THROW(compute_column());
-
-  cudf::detail::initialize(cudf::detail::init_flags::DEFAULT);
-  ASSERT_NO_THROW(compute_column());
+  EXPECT_EQ(compute_column_jit(), cudf::size_type{4});
 }
 
 template <typename Lambda>


### PR DESCRIPTION
## Description

The first ordinary `cudf::get_context()` call currently initializes RTCX and constructs the JIT cache and bundle even when the process never uses a JIT-backed operation. Since the RTCX migration in [#22654](https://github.com/NVIDIA/cudf/pull/22654), that initialization also loads NVRTC, adding avoidable startup latency and an unnecessary NVRTC dependency to interpreter-only users.

### Context

Before [#23760](https://github.com/NVIDIA/cudf/pull/23760), the cache accessors supported lazy initialization, but the default initialization flags requested the JIT cache eagerly. #23760 simplified the global context into a Meyers singleton and retained that eager default policy through unconditional construction. Its review explicitly documented why benchmarks should still be able to preload JIT initialization rather than charge it to the first measured operation ([discussion](https://github.com/NVIDIA/cudf/pull/23760#issuecomment-5377885693)).

This also fixes #23903, where an interpreter-only path with `LIBCUDF_JIT_ENABLED=false` still loads RTCX/NVRTC. The JNI `CompiledExpression.computeColumn` implementation dispatches to the same `cudf::compute_column` path validated here.

This change preserves the Meyers-singleton lifecycle while making ordinary `DEFAULT` initialization lazy. RTCX/JIT initialization occurs when `rtcx_cache()` or `jit_bundle()` is first requested, remains thread-safe through `std::call_once`, and is torn down only if it was initialized. Explicit `ALL` initialization still preloads RTCX/JIT before returning, preserving the benchmark and fail-fast behavior described in #23760.

Fresh-process measurements used an empty, unique JIT cache directory for every run:

| Environment | Runs | Before median | After median | Change |
|---|---:|---:|---:|---:|
| AWS g7.8xlarge, RTX PRO 4500 Blackwell | 12 paired | 153.246 ms | 111.313 ms | -27.4% |
| Local RTX PRO 4500 Blackwell server | 10 per arm | 569.915 ms | 523.293 ms | -8.2% |

All 12 AWS pairs favored the lazy version, with a median paired saving of 41.962 ms. A real CUDA transform JIT smoke test also compiled and executed successfully before and after the change; warm execution was effectively unchanged.

The #23903 path was validated by interposing `dlopen` to reject `libnvrtc.so` while setting `LIBCUDF_JIT_ENABLED=false`. Latest main failed before evaluating the interpreter expression, while the patched interpreter returned the expected three rows without attempting to load NVRTC. As a negative control, the patched explicit-JIT path attempted to load NVRTC and failed as expected.

Validation:

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Full `libcudf.so` and `UTILITIES_TEST` build
- `UTILITIES_TEST --gtest_filter=ContextTest.*` (including JIT-backed and concurrent first-JIT initialization tests)
- Real transform JIT smoke tests on local and AWS GPUs
- `DEFAULT` and `ALL` initialization negative controls with `libnvrtc.so` loading disabled (`DEFAULT` succeeds without loading NVRTC; `ALL` loads NVRTC and fails immediately)
- Interpreter and explicit-JIT negative-control tests with `libnvrtc.so` loading disabled

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
