### PR TITLE
Ignore coverage of untaken branches in cudf-polars timezone handling

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/datetime.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/datetime.py
@@ -48,7 +48,7 @@ def _tz_transition_columns(
         tzif_dir, zone_name, stream=stream
     )
     columns = table.columns()
-    if len(columns) == 0:
+    if len(columns) == 0:  # pragma: no cover
         return None
     transition_times, offsets = columns
     return transition_times, offsets
@@ -61,7 +61,7 @@ def _local_wall_clock(
     if from_zone_desc is None:
         return column
     data = _tz_transition_columns(*from_zone_desc, stream)
-    if data is None:
+    if data is None:  # pragma: no cover
         return column
     transition_times, offsets = data
     unit = column.type()
@@ -359,7 +359,7 @@ def _localize(
 ) -> plc.Column:
     """Interpret naive wall-clock timestamps as local times in ``to_zone``."""
     data = _tz_transition_columns(to_zone, tzif_dir, stream)
-    if data is None:
+    if data is None:  # pragma: no cover
         return _apply_ambiguous_without_transitions(
             local, ambiguous_scalar, ambiguous_column, stream
         )


### PR DESCRIPTION
## Description

On some of the CI systems these branches can never be taken.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
