### PR TITLE
TEST: Focus logical binop coverage

### DIFF
--- a/python/cudf/cudf/tests/series/test_binops.py
+++ b/python/cudf/cudf/tests/series/test_binops.py
@@ -1494,9 +1494,19 @@ def test_operator_func_between_series_logical(
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("has_nulls", [True, False])
-@pytest.mark.parametrize("scalar", [-59.0, np.nan, 0, 59.0])
-@pytest.mark.parametrize("fill_value", [None, 1.0])
+@pytest.mark.parametrize(
+    "has_nulls, scalar, fill_value",
+    [
+        (False, -59.0, None),
+        (False, np.nan, 1.0),
+        (False, 0, None),
+        (False, 59.0, 1.0),
+        (True, -59.0, 1.0),
+        (True, np.nan, 1.0),
+        (True, 0, 1.0),
+        (True, 59.0, None),
+    ],
+)
 def test_operator_func_series_and_scalar_logical(
     request,
     float_types_as_str,

--- a/python/cudf/cudf/tests/series/test_binops.py
+++ b/python/cudf/cudf/tests/series/test_binops.py
@@ -1468,9 +1468,19 @@ def test_operator_func_series_and_scalar(
     assert_eq(pdf_series_result, gdf_series_result)
 
 
-@pytest.mark.parametrize("fill_value", [0, 1, None, np.nan])
-@pytest.mark.parametrize("scalar_a", [0, 1, None, np.nan])
-@pytest.mark.parametrize("scalar_b", [0, 1, None, np.nan])
+@pytest.mark.parametrize(
+    "scalar_a, scalar_b, fill_value",
+    [
+        (0, 0, 0),
+        (1, 1, 1),
+        (None, None, None),
+        (np.nan, np.nan, np.nan),
+        (0, 1, None),
+        (1, 0, np.nan),
+        (None, np.nan, 0),
+        (np.nan, None, 1),
+    ],
+)
 def test_operator_func_between_series_logical(
     float_types_as_str, comparison_op_method, scalar_a, scalar_b, fill_value
 ):


### PR DESCRIPTION
## Description

Replace redundant logical binary-operation Cartesian products with representative scalar and Series cases. The parameter sets retain both null states, every scalar category, and the fill-value behavior under test.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing tests cover these test-only changes.
- [x] Documentation updates are not needed.
