### PR TITLE
TEST: Focus concat join coverage

### DIFF
--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1071,48 +1071,96 @@ def test_concat_join_series(ignore_index, sort, join, axis):
 
 
 @pytest.mark.parametrize(
-    "df",
+    "df, other",
     [
-        pd.DataFrame(),
-        pd.DataFrame(index=[10, 20, 30]),
-        pd.DataFrame(
-            {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+        pytest.param(
+            pd.DataFrame(),
+            [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
         ),
-        pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"l": [10]}, index=[200]),
-        pd.DataFrame([], index=[100]),
-        pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
-    ],
-)
-@pytest.mark.parametrize(
-    "other",
-    [
-        [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
-        [
+        pytest.param(
+            pd.DataFrame(index=[10, 20, 30]),
+            [
+                pd.DataFrame(
+                    {"b": [10, 11, 22, 33, 44, 100]},
+                    index=[7, 8, 9, 10, 11, 20],
+                ),
+                pd.DataFrame(),
+                pd.DataFrame(),
+                pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame(
-                {"b": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+                {"c": [10, 11, 22, 33, 44, 100]},
+                index=[7, 8, 9, 10, 11, 20],
             ),
-            pd.DataFrame(),
-            pd.DataFrame(),
+            [
+                pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"l": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"cat": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-        ],
-        [
+            [
+                pd.DataFrame([]),
+                pd.DataFrame([], index=[100]),
+                pd.DataFrame(
+                    {"cat": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+            [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
+        ),
+        pytest.param(
             pd.DataFrame({"l": [10]}),
-            pd.DataFrame({"k": [10]}, index=[200]),
-            pd.DataFrame(
-                {"cat": pd.Series(["two", "three"], dtype="category")}
-            ),
-        ],
-        [
-            pd.DataFrame([]),
+            [
+                pd.DataFrame(
+                    {"b": [10, 11, 22, 33, 44, 100]},
+                    index=[7, 8, 9, 10, 11, 20],
+                ),
+                pd.DataFrame(),
+                pd.DataFrame(),
+                pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame({"l": [10]}, index=[200]),
+            [
+                pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"l": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"cat": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame([], index=[100]),
-            pd.DataFrame(
-                {"cat": pd.Series(["two", "three"], dtype="category")}
-            ),
-        ],
+            [
+                pd.DataFrame([]),
+                pd.DataFrame([], index=[100]),
+                pd.DataFrame(
+                    {"cat": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
+            [
+                pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"l": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"cat": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
     ],
 )
 def test_concat_join_empty_dataframes(

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1155,48 +1155,96 @@ def test_concat_join_empty_dataframes(
 
 
 @pytest.mark.parametrize(
-    "df",
+    "df, other",
     [
-        pd.DataFrame(),
-        pd.DataFrame(index=[10, 20, 30]),
-        pd.DataFrame(
-            {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+        pytest.param(
+            pd.DataFrame(),
+            [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
         ),
-        pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"m": [10]}, index=[200]),
-        pd.DataFrame([], index=[100]),
-        pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
-    ],
-)
-@pytest.mark.parametrize(
-    "other",
-    [
-        [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
-        [
+        pytest.param(
+            pd.DataFrame(index=[10, 20, 30]),
+            [
+                pd.DataFrame(
+                    {"b": [10, 11, 22, 33, 44, 100]},
+                    index=[7, 8, 9, 10, 11, 20],
+                ),
+                pd.DataFrame(),
+                pd.DataFrame(),
+                pd.DataFrame([[5, 6], [7, 8]], columns=list("CD")),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame(
-                {"b": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+                {"c": [10, 11, 22, 33, 44, 100]},
+                index=[7, 8, 9, 10, 11, 20],
             ),
-            pd.DataFrame(),
-            pd.DataFrame(),
-            pd.DataFrame([[5, 6], [7, 8]], columns=list("CD")),
-        ],
-        [
-            pd.DataFrame({"g": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-            pd.DataFrame({"h": [10]}),
-            pd.DataFrame({"k": [10]}, index=[200]),
-            pd.DataFrame(
-                {"dog": pd.Series(["two", "three"], dtype="category")}
-            ),
-        ],
-        [
-            pd.DataFrame([]),
+            [
+                pd.DataFrame({"g": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"h": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"dog": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+            [
+                pd.DataFrame([]),
+                pd.DataFrame([], index=[100]),
+                pd.DataFrame(
+                    {"bird": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+            [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
+        ),
+        pytest.param(
+            pd.DataFrame({"l": [10]}),
+            [
+                pd.DataFrame(
+                    {"b": [10, 11, 22, 33, 44, 100]},
+                    index=[7, 8, 9, 10, 11, 20],
+                ),
+                pd.DataFrame(),
+                pd.DataFrame(),
+                pd.DataFrame([[5, 6], [7, 8]], columns=list("CD")),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame({"m": [10]}, index=[200]),
+            [
+                pd.DataFrame({"g": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"h": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"dog": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
             pd.DataFrame([], index=[100]),
-            pd.DataFrame(
-                {"bird": pd.Series(["two", "three"], dtype="category")}
-            ),
-        ],
+            [
+                pd.DataFrame([]),
+                pd.DataFrame([], index=[100]),
+                pd.DataFrame(
+                    {"bird": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
+        pytest.param(
+            pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
+            [
+                pd.DataFrame({"g": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+                pd.DataFrame({"h": [10]}),
+                pd.DataFrame({"k": [10]}, index=[200]),
+                pd.DataFrame(
+                    {"dog": pd.Series(["two", "three"], dtype="category")}
+                ),
+            ],
+        ),
     ],
 )
 def test_concat_join_empty_dataframes_axis_1(


### PR DESCRIPTION
## Description

Focus concat join coverage on representative Series and empty-DataFrame inputs. The curated cases retain join, axis, sort, ignore-index, schema, and empty-input behavior without repeating equivalent combinations.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing tests cover these test-only changes.
- [x] Documentation updates are not needed.
