### PR TITLE
TEST: Focus concat input matrices

### DIFF
--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -2232,15 +2232,63 @@ def test_dataframe_concat_series_without_name():
     assert_eq(pd.concat([pdf, ps]), cudf.concat([df, gs]))
 
 
-@pytest.mark.parametrize(
-    "df",
+_DATAFRAME_CONCAT_LIST_DFS = [
+    pd.DataFrame(),
+    pd.DataFrame(index=[10, 20, 30]),
+    pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        }
+    ),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        },
+        index=[7, 20, 11, 9],
+    ),
+    pd.DataFrame({"l": [10]}),
+    pd.DataFrame({"l": [10]}, index=[100]),
+    pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+    pd.DataFrame(
+        {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
+        index=[100, 200, 300, 400, 500, 0],
+    ),
+]
+
+_DATAFRAME_CONCAT_LIST_OTHERS = [
+    [pd.DataFrame([[5, 6], [7, 8]], columns=list("AB"))],
     [
+        pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+        pd.DataFrame([[5, 6], [7, 8]], columns=list("BD")),
+        pd.DataFrame([[5, 6], [7, 8]], columns=list("DE")),
+    ],
+    [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
+    [
+        pd.DataFrame(
+            {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+        ),
         pd.DataFrame(),
-        pd.DataFrame(index=[10, 20, 30]),
+        pd.DataFrame(),
+        pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+    ],
+    [
+        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+        pd.DataFrame({"l": [10]}),
+        pd.DataFrame({"l": [10]}, index=[200]),
+    ],
+    [pd.DataFrame([]), pd.DataFrame([], index=[100])],
+    [
+        pd.DataFrame([]),
+        pd.DataFrame([], index=[100]),
         pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
+    ],
+    [
         pd.DataFrame(
             {
                 "a": [315.3324, 3243.32432, 3232.332, -100.32],
@@ -2252,103 +2300,93 @@ def test_dataframe_concat_series_without_name():
                 "a": [315.3324, 3243.32432, 3232.332, -100.32],
                 "z": [0.3223, 0.32, 0.0000232, 0.32224],
             },
-            index=[7, 20, 11, 9],
-        ),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"l": [10]}, index=[100]),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame(
-            {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
-            index=[100, 200, 300, 400, 500, 0],
+            index=[0, 100, 200, 300],
         ),
     ],
-)
-@pytest.mark.parametrize(
-    "other",
     [
-        [pd.DataFrame([[5, 6], [7, 8]], columns=list("AB"))],
-        [
-            pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-            pd.DataFrame([[5, 6], [7, 8]], columns=list("BD")),
-            pd.DataFrame([[5, 6], [7, 8]], columns=list("DE")),
-        ],
-        [pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()],
-        [
-            pd.DataFrame(
-                {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
-            ),
-            pd.DataFrame(),
-            pd.DataFrame(),
-            pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-        ],
-        [
-            pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-            pd.DataFrame({"l": [10]}),
-            pd.DataFrame({"l": [10]}, index=[200]),
-        ],
-        [pd.DataFrame([]), pd.DataFrame([], index=[100])],
-        [
-            pd.DataFrame([]),
-            pd.DataFrame([], index=[100]),
-            pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-        ],
-        [
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                }
-            ),
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-        ],
-        [
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-        ],
-        [
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-        ],
-        [
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-            pd.DataFrame(
-                {
-                    "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                    "z": [0.3223, 0.32, 0.0000232, 0.32224],
-                },
-                index=[0, 100, 200, 300],
-            ),
-            pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-        ],
+        pd.DataFrame(
+            {
+                "a": [315.3324, 3243.32432, 3232.332, -100.32],
+                "z": [0.3223, 0.32, 0.0000232, 0.32224],
+            },
+            index=[0, 100, 200, 300],
+        ),
+    ],
+    [
+        pd.DataFrame(
+            {
+                "a": [315.3324, 3243.32432, 3232.332, -100.32],
+                "z": [0.3223, 0.32, 0.0000232, 0.32224],
+            },
+            index=[0, 100, 200, 300],
+        ),
+        pd.DataFrame(
+            {
+                "a": [315.3324, 3243.32432, 3232.332, -100.32],
+                "z": [0.3223, 0.32, 0.0000232, 0.32224],
+            },
+            index=[0, 100, 200, 300],
+        ),
+    ],
+    [
+        pd.DataFrame(
+            {
+                "a": [315.3324, 3243.32432, 3232.332, -100.32],
+                "z": [0.3223, 0.32, 0.0000232, 0.32224],
+            },
+            index=[0, 100, 200, 300],
+        ),
+        pd.DataFrame(
+            {
+                "a": [315.3324, 3243.32432, 3232.332, -100.32],
+                "z": [0.3223, 0.32, 0.0000232, 0.32224],
+            },
+            index=[0, 100, 200, 300],
+        ),
+        pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    "df, other",
+    [
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[0], _DATAFRAME_CONCAT_LIST_OTHERS[0]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[1], _DATAFRAME_CONCAT_LIST_OTHERS[1]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[2], _DATAFRAME_CONCAT_LIST_OTHERS[2]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[3], _DATAFRAME_CONCAT_LIST_OTHERS[3]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[4], _DATAFRAME_CONCAT_LIST_OTHERS[4]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[5], _DATAFRAME_CONCAT_LIST_OTHERS[5]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[6], _DATAFRAME_CONCAT_LIST_OTHERS[6]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[7], _DATAFRAME_CONCAT_LIST_OTHERS[7]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[8], _DATAFRAME_CONCAT_LIST_OTHERS[8]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[9], _DATAFRAME_CONCAT_LIST_OTHERS[9]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[10], _DATAFRAME_CONCAT_LIST_OTHERS[10]
+        ),
+        pytest.param(
+            _DATAFRAME_CONCAT_LIST_DFS[11], _DATAFRAME_CONCAT_LIST_OTHERS[3]
+        ),
     ],
 )
 def test_dataframe_concat_dataframe_lists(df, other, sort, ignore_index):

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -2463,66 +2463,81 @@ def test_dataframe_concat_series(df, other, sort):
         assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
+_DATAFRAME_CONCAT_DFS = [
+    pd.DataFrame(),
+    pd.DataFrame(index=[10, 20, 30]),
+    pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        }
+    ),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        },
+        index=[7, 20, 11, 9],
+    ),
+    pd.DataFrame({"l": [10]}),
+    pd.DataFrame({"l": [10]}, index=[100]),
+    pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+    pd.DataFrame(
+        {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
+        index=[100, 200, 300, 400, 500, 0],
+    ),
+]
+
+_DATAFRAME_CONCAT_OTHERS = [
+    pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
+    pd.DataFrame([[5, 6], [7, 8]], columns=list("BD")),
+    pd.DataFrame([[5, 6], [7, 8]], columns=list("DE")),
+    pd.DataFrame(),
+    pd.DataFrame(
+        {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
+    ),
+    pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+    pd.DataFrame({"l": [10]}),
+    pd.DataFrame({"l": [10]}, index=[200]),
+    pd.DataFrame([]),
+    pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
+    pd.DataFrame([], index=[100]),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        }
+    ),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        },
+        index=[0, 100, 200, 300],
+    ),
+]
+
+
 @pytest.mark.parametrize(
-    "df",
+    "df, other",
     [
-        pd.DataFrame(),
-        pd.DataFrame(index=[10, 20, 30]),
-        pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            },
-            index=[7, 20, 11, 9],
-        ),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"l": [10]}, index=[100]),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame(
-            {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
-            index=[100, 200, 300, 400, 500, 0],
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "other",
-    [
-        pd.DataFrame([[5, 6], [7, 8]], columns=list("AB")),
-        pd.DataFrame([[5, 6], [7, 8]], columns=list("BD")),
-        pd.DataFrame([[5, 6], [7, 8]], columns=list("DE")),
-        pd.DataFrame(),
-        pd.DataFrame(
-            {"c": [10, 11, 22, 33, 44, 100]}, index=[7, 8, 9, 10, 11, 20]
-        ),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"l": [10]}, index=[200]),
-        pd.DataFrame([]),
-        pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-        pd.DataFrame([], index=[100]),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            },
-            index=[0, 100, 200, 300],
-        ),
+        pytest.param(_DATAFRAME_CONCAT_DFS[0], _DATAFRAME_CONCAT_OTHERS[0]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[1], _DATAFRAME_CONCAT_OTHERS[1]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[2], _DATAFRAME_CONCAT_OTHERS[2]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[3], _DATAFRAME_CONCAT_OTHERS[3]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[4], _DATAFRAME_CONCAT_OTHERS[4]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[5], _DATAFRAME_CONCAT_OTHERS[5]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[6], _DATAFRAME_CONCAT_OTHERS[6]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[7], _DATAFRAME_CONCAT_OTHERS[7]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[8], _DATAFRAME_CONCAT_OTHERS[8]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[9], _DATAFRAME_CONCAT_OTHERS[9]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[10], _DATAFRAME_CONCAT_OTHERS[10]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[11], _DATAFRAME_CONCAT_OTHERS[11]),
+        pytest.param(_DATAFRAME_CONCAT_DFS[0], _DATAFRAME_CONCAT_OTHERS[12]),
     ],
 )
 def test_dataframe_concat_dataframe(df, other, sort, ignore_index):

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -2140,44 +2140,57 @@ def test_series_concat_existing_buffers():
     )
 
 
+_DATAFRAME_LIST_DFS = [
+    pd.DataFrame(),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
+    pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        }
+    ),
+    pd.DataFrame(
+        {
+            "a": [315.3324, 3243.32432, 3232.332, -100.32],
+            "z": [0.3223, 0.32, 0.0000232, 0.32224],
+        },
+        index=[7, 20, 11, 9],
+    ),
+    pd.DataFrame({"l": [10]}),
+    pd.DataFrame({"l": [10]}, index=[100]),
+    pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
+    pd.DataFrame(
+        {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
+        index=[100, 200, 300, 400, 500, 0],
+    ),
+    pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
+]
+
+_DATAFRAME_LIST_OTHERS = [
+    [[1, 2], [10, 100]],
+    [[1, 2, 10, 100, 0.1, 0.2, 0.0021]],
+    [[]],
+    [[], [], [], []],
+    [[0.23, 0.00023, -10.00, 100, 200, 1000232, 1232.32323]],
+]
+
+
 @pytest.mark.parametrize(
-    "df",
+    "df, other",
     [
-        pd.DataFrame(),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB")),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[10, 20]),
-        pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[7, 8]),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "a": [315.3324, 3243.32432, 3232.332, -100.32],
-                "z": [0.3223, 0.32, 0.0000232, 0.32224],
-            },
-            index=[7, 20, 11, 9],
-        ),
-        pd.DataFrame({"l": [10]}),
-        pd.DataFrame({"l": [10]}, index=[100]),
-        pd.DataFrame({"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]}),
-        pd.DataFrame(
-            {"f": [10.2, 11.2332, 0.22, 3.3, 44.23, 10.0]},
-            index=[100, 200, 300, 400, 500, 0],
-        ),
-        pd.DataFrame({"first_col": [], "second_col": [], "third_col": []}),
-    ],
-)
-@pytest.mark.parametrize(
-    "other",
-    [
-        [[1, 2], [10, 100]],
-        [[1, 2, 10, 100, 0.1, 0.2, 0.0021]],
-        [[]],
-        [[], [], [], []],
-        [[0.23, 0.00023, -10.00, 100, 200, 1000232, 1232.32323]],
+        pytest.param(_DATAFRAME_LIST_DFS[0], _DATAFRAME_LIST_OTHERS[0]),
+        pytest.param(_DATAFRAME_LIST_DFS[1], _DATAFRAME_LIST_OTHERS[1]),
+        pytest.param(_DATAFRAME_LIST_DFS[2], _DATAFRAME_LIST_OTHERS[2]),
+        pytest.param(_DATAFRAME_LIST_DFS[3], _DATAFRAME_LIST_OTHERS[3]),
+        pytest.param(_DATAFRAME_LIST_DFS[4], _DATAFRAME_LIST_OTHERS[4]),
+        pytest.param(_DATAFRAME_LIST_DFS[5], _DATAFRAME_LIST_OTHERS[0]),
+        pytest.param(_DATAFRAME_LIST_DFS[6], _DATAFRAME_LIST_OTHERS[1]),
+        pytest.param(_DATAFRAME_LIST_DFS[7], _DATAFRAME_LIST_OTHERS[2]),
+        pytest.param(_DATAFRAME_LIST_DFS[8], _DATAFRAME_LIST_OTHERS[3]),
+        pytest.param(_DATAFRAME_LIST_DFS[9], _DATAFRAME_LIST_OTHERS[4]),
+        pytest.param(_DATAFRAME_LIST_DFS[10], _DATAFRAME_LIST_OTHERS[2]),
     ],
 )
 def test_dataframe_concat_lists(df, other, sort, ignore_index):


### PR DESCRIPTION
## Description

Replace broad DataFrame concat input Cartesian products with representative input pairs. The selected cases retain distinct DataFrame/Series/list shapes, dtypes, column names, index forms, and existing-buffer behavior.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing tests cover these test-only changes.
- [x] Documentation updates are not needed.
