### PR TITLE
Replace shared-memory hash groupby with block-private aggregation

### DIFF
--- a/cpp/benchmarks/groupby/group_sum.cpp
+++ b/cpp/benchmarks/groupby/group_sum.cpp
@@ -8,7 +8,10 @@
 
 #include <cudf/aggregation.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/sorting.hpp>
 
 #include <nvbench/nvbench.cuh>
@@ -92,3 +95,54 @@ static void bench_groupby_pre_sorted_sum(nvbench::state& state, nvbench::type_li
 NVBENCH_BENCH_TYPES(bench_groupby_pre_sorted_sum, NVBENCH_TYPE_AXES(Types))
   .set_name("pre_sorted_sum")
   .add_int64_axis("num_rows", {100'000, 1'000'000, 10'000'000, 100'000'000});
+
+static void bench_groupby_decimal128_sum_count_cardinality(nvbench::state& state)
+{
+  auto const num_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
+
+  data_profile const key_profile = data_profile_builder().cardinality(0).no_validity().distribution(
+    cudf::type_to_id<int32_t>(), distribution_id::UNIFORM, 0, cardinality - 1);
+  auto keys = create_random_column(cudf::type_to_id<int32_t>(), row_count{num_rows}, key_profile);
+  // The random generator's cardinality option samples its dictionary with replacement. Seed one
+  // copy of every key explicitly so the 127/128/129 axis measures the requested boundary exactly.
+  auto const zero          = cudf::make_fixed_width_scalar<int32_t>(0);
+  auto const one           = cudf::make_fixed_width_scalar<int32_t>(1);
+  auto const distinct_keys = cudf::sequence(cardinality, *zero, *one);
+  auto mutable_keys        = keys->mutable_view();
+  cudf::copy_range_in_place(distinct_keys->view(), mutable_keys, 0, cardinality, 0);
+
+  data_profile const value_profile =
+    data_profile_builder().cardinality(0).no_validity().distribution(
+      cudf::type_to_id<numeric::decimal128>(),
+      distribution_id::UNIFORM,
+      0,
+      1'000,
+      numeric::scale_type{-4});
+  auto const values = create_random_column(
+    cudf::type_to_id<numeric::decimal128>(), row_count{num_rows}, value_profile);
+
+  std::vector<cudf::groupby::aggregation_request> requests(1);
+  requests[0].values = values->view();
+  requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+  requests[0].aggregations.push_back(
+    cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
+
+  state.add_global_memory_reads<nvbench::int8_t>(keys->alloc_size() + values->alloc_size());
+  auto const mem_stats_logger = cudf::memory_stats_logger();
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+    cudf::groupby::groupby gb(cudf::table_view{std::vector<cudf::column_view>{keys->view()}});
+    auto const result = gb.aggregate(requests);
+  });
+  auto const elapsed_time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  state.add_element_count(static_cast<double>(num_rows) / elapsed_time / 1'000'000., "Mrows/s");
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+}
+
+NVBENCH_BENCH(bench_groupby_decimal128_sum_count_cardinality)
+  .set_name("decimal128_sum_count_cardinality")
+  .add_int64_axis("num_rows", {30'600'000})
+  .add_int64_axis("cardinality",
+                  {64, 120, 127, 128, 129, 130, 160, 175, 256, 1'024, 4'096, 10'000, 1'000'000});

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
@@ -10,6 +10,7 @@
 #include "single_pass_functors.cuh"
 
 #include <cudf/aggregation.hpp>
+#include <cudf/detail/aggregation/device_aggregators.cuh>
 #include <cudf/detail/utilities/assert.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/cuda.hpp>
@@ -30,6 +31,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace cudf::groupby::detail::hash {
 namespace {
@@ -351,6 +353,100 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
                                d_agg_kinds);
   }
 }
+
+CUDF_KERNEL void mapped_block_private_aggs_kernel(cudf::size_type num_rows,
+                                                  cudf::size_type const* matching_keys,
+                                                  cudf::size_type const* key_transform_map,
+                                                  cudf::table_device_view input_values,
+                                                  cudf::mutable_table_device_view target_values,
+                                                  cudf::size_type num_output_rows,
+                                                  cudf::size_type num_replicas,
+                                                  cudf::aggregation::Kind const* d_agg_kinds)
+{
+  for (auto source_idx = cudf::detail::grid_1d::global_thread_id(); source_idx < num_rows;
+       source_idx += cudf::detail::grid_1d::grid_stride()) {
+    auto const sparse_target_idx = matching_keys[source_idx];
+    if (sparse_target_idx == cudf::detail::CUDF_SIZE_TYPE_SENTINEL) { continue; }
+
+    auto const replica_idx = static_cast<cudf::size_type>(blockIdx.x % num_replicas);
+    auto const target_idx  = key_transform_map[sparse_target_idx];
+    auto const private_idx = replica_idx * num_output_rows + target_idx;
+    for (auto col_idx = 0; col_idx < input_values.num_columns(); ++col_idx) {
+      auto const source_col = input_values.column(col_idx);
+      dispatch_shared_memory_type_and_aggregation(source_col.type(),
+                                                  d_agg_kinds[col_idx],
+                                                  cudf::detail::element_aggregator{},
+                                                  target_values.column(col_idx),
+                                                  private_idx,
+                                                  source_col,
+                                                  source_idx);
+    }
+  }
+}
+
+struct block_private_reducer {
+  template <typename Source, cudf::aggregation::Kind k>
+  __device__ void operator()(cudf::column_device_view source_col,
+                             cudf::mutable_column_device_view private_col,
+                             cudf::mutable_column_device_view output_col,
+                             cudf::size_type target_idx,
+                             cudf::size_type num_output_rows,
+                             cudf::size_type num_replicas) const
+  {
+    using Target       = cudf::device_storage_type_t<cudf::detail::target_type_t<Source, k>>;
+    auto* private_data = reinterpret_cast<cuda::std::byte*>(private_col.template head<void>());
+
+    for (auto replica_idx = 0; replica_idx < num_replicas; ++replica_idx) {
+      auto const private_idx = replica_idx * num_output_rows + target_idx;
+      if (private_col.nullable() && private_col.is_null(private_idx)) { continue; }
+
+      // Non-nullable ARGMIN/ARGMAX intermediates use an out-of-range index as identity. Do not
+      // feed that identity to the comparison loop in update_target_element_gmem.
+      if constexpr (k == cudf::aggregation::ARGMIN) {
+        if (private_col.template element<Target>(private_idx) == cudf::detail::ARGMIN_SENTINEL) {
+          continue;
+        }
+      } else if constexpr (k == cudf::aggregation::ARGMAX) {
+        if (private_col.template element<Target>(private_idx) == cudf::detail::ARGMAX_SENTINEL) {
+          continue;
+        }
+      }
+
+      if constexpr (!(k == cudf::aggregation::COUNT_VALID || k == cudf::aggregation::COUNT_ALL)) {
+        if (output_col.nullable() && output_col.is_null(target_idx)) {
+          output_col.set_valid(target_idx);
+        }
+      }
+      update_target_element_gmem<Source, k>{}(
+        output_col, target_idx, source_col, private_data, private_idx);
+    }
+  }
+};
+
+CUDF_KERNEL void reduce_block_private_aggs_kernel(cudf::size_type num_output_rows,
+                                                  cudf::size_type num_replicas,
+                                                  cudf::table_device_view input_values,
+                                                  cudf::mutable_table_device_view private_values,
+                                                  cudf::mutable_table_device_view output_values,
+                                                  cudf::aggregation::Kind const* d_agg_kinds)
+{
+  auto const idx         = cudf::detail::grid_1d::global_thread_id();
+  auto const num_columns = output_values.num_columns();
+  if (idx >= num_output_rows * num_columns) { return; }
+
+  auto const col_idx    = idx / num_output_rows;
+  auto const target_idx = idx % num_output_rows;
+  auto const source_col = input_values.column(col_idx);
+  dispatch_shared_memory_type_and_aggregation(source_col.type(),
+                                              d_agg_kinds[col_idx],
+                                              block_private_reducer{},
+                                              source_col,
+                                              private_values.column(col_idx),
+                                              output_values.column(col_idx),
+                                              target_idx,
+                                              num_output_rows,
+                                              num_replicas);
+}
 }  // namespace
 
 size_type get_available_shared_memory_size(cudf::size_type grid_size)
@@ -405,6 +501,71 @@ void compute_shared_memory_aggs(cudf::size_type grid_size,
                                                   d_agg_kinds,
                                                   shmem_agg_size,
                                                   offsets_size);
+  CUDF_CUDA_TRY(cudaGetLastError());
+}
+
+void compute_block_private_aggs(cudf::size_type grid_size,
+                                cudf::size_type block_size,
+                                cudf::size_type num_replicas,
+                                cudf::size_type num_input_rows,
+                                cudf::size_type const* matching_keys,
+                                cudf::size_type const* key_transform_map,
+                                cudf::table_device_view input_values,
+                                cudf::mutable_table_device_view output_values,
+                                cudf::mutable_table_device_view private_values,
+                                cudf::size_type num_output_rows,
+                                cudf::aggregation::Kind const* d_agg_kinds,
+                                cuda::stream_ref stream)
+{
+  CUDF_EXPECTS(grid_size > 0, "Invalid block-private grid size");
+  CUDF_EXPECTS(block_size > 0 && block_size <= 1024, "Invalid block-private block size");
+  CUDF_EXPECTS(num_replicas > 0 && num_replicas <= cudf::detail::num_multiprocessors(),
+               "Invalid block-private replica count");
+  CUDF_EXPECTS(num_output_rows <= std::numeric_limits<cudf::size_type>::max() / num_replicas,
+               "Block-private output size exceeds the column size limit");
+
+  mapped_block_private_aggs_kernel<<<grid_size, block_size, 0, stream.get()>>>(num_input_rows,
+                                                                               matching_keys,
+                                                                               key_transform_map,
+                                                                               input_values,
+                                                                               private_values,
+                                                                               num_output_rows,
+                                                                               num_replicas,
+                                                                               d_agg_kinds);
+  CUDF_CUDA_TRY(cudaGetLastError());
+
+  auto const num_columns = output_values.num_columns();
+  CUDF_EXPECTS(
+    num_columns > 0 && num_output_rows <= std::numeric_limits<cudf::size_type>::max() / num_columns,
+    "Block-private reduction size exceeds the launch size limit");
+  auto const num_items        = num_output_rows * num_columns;
+  auto const reduce_grid_size = cudf::util::div_rounding_up_safe(num_items, GROUPBY_BLOCK_SIZE);
+  reduce_block_private_aggs_kernel<<<reduce_grid_size, GROUPBY_BLOCK_SIZE, 0, stream.get()>>>(
+    num_output_rows, num_replicas, input_values, private_values, output_values, d_agg_kinds);
+  CUDF_CUDA_TRY(cudaGetLastError());
+}
+
+void compute_mapped_global_aggs(cudf::size_type grid_size,
+                                cudf::size_type block_size,
+                                cudf::size_type num_input_rows,
+                                cudf::size_type const* matching_keys,
+                                cudf::size_type const* key_transform_map,
+                                cudf::table_device_view input_values,
+                                cudf::mutable_table_device_view output_values,
+                                cudf::size_type num_output_rows,
+                                cudf::aggregation::Kind const* d_agg_kinds,
+                                cuda::stream_ref stream)
+{
+  CUDF_EXPECTS(grid_size > 0, "Invalid mapped-global grid size");
+  CUDF_EXPECTS(block_size > 0 && block_size <= 1024, "Invalid mapped-global block size");
+  mapped_block_private_aggs_kernel<<<grid_size, block_size, 0, stream.get()>>>(num_input_rows,
+                                                                               matching_keys,
+                                                                               key_transform_map,
+                                                                               input_values,
+                                                                               output_values,
+                                                                               num_output_rows,
+                                                                               1,
+                                                                               d_agg_kinds);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
@@ -38,4 +38,33 @@ void compute_shared_memory_aggs(size_type grid_size,
                                 mutable_table_device_view output_values,
                                 aggregation::Kind const* d_agg_kinds,
                                 cuda::stream_ref stream);
+
+/**
+ * @brief Aggregates a sparse-to-dense row mapping into replica-private global-memory partials,
+ * then reduces the partials into the final output.
+ */
+void compute_block_private_aggs(size_type grid_size,
+                                size_type block_size,
+                                size_type num_replicas,
+                                size_type num_input_rows,
+                                size_type const* matching_keys,
+                                size_type const* key_transform_map,
+                                table_device_view input_values,
+                                mutable_table_device_view output_values,
+                                mutable_table_device_view private_values,
+                                size_type num_output_rows,
+                                aggregation::Kind const* d_agg_kinds,
+                                cuda::stream_ref stream);
+
+/** @brief Aggregates a sparse-to-dense row mapping directly into the final dense output. */
+void compute_mapped_global_aggs(size_type grid_size,
+                                size_type block_size,
+                                size_type num_input_rows,
+                                size_type const* matching_keys,
+                                size_type const* key_transform_map,
+                                table_device_view input_values,
+                                mutable_table_device_view output_values,
+                                size_type num_output_rows,
+                                aggregation::Kind const* d_agg_kinds,
+                                cuda::stream_ref stream);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
@@ -14,7 +14,6 @@
 #include "output_utils.hpp"
 
 #include <cudf/detail/utilities/cuda.hpp>
-#include <cudf/detail/utilities/cuda_memcpy.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/table_device_view.cuh>
 
@@ -24,7 +23,11 @@
 #include <cuco/static_set.cuh>
 #include <cuda/iterator>
 #include <cuda/stream>
-#include <thrust/for_each.h>
+#include <thrust/transform.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
 
 namespace cudf::groupby::detail::hash {
 
@@ -72,92 +75,88 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
   // empty: empty input should already been handled before reaching here.
   if (grid_size <= 0) { return run_aggs_by_global_mem_kernel(); }
 
-  auto const [can_use_shared_mem_kernel, available_shmem_size] =
-    is_shared_memory_compatible(agg_kinds, values, grid_size);
+  auto const can_use_shared_mem_kernel =
+    is_shared_memory_compatible(agg_kinds, values, grid_size).first;
 
   if (!can_use_shared_mem_kernel) { return run_aggs_by_global_mem_kernel(); }
 
-  // Maps from the global row index of the input table to its block-wise rank.
-  rmm::device_uvector<size_type> local_mapping_indices(num_rows, stream);
-  // Maps from the block-wise rank to the row index of result table.
-  rmm::device_uvector<size_type> global_mapping_indices(grid_size * GROUPBY_CARDINALITY_THRESHOLD,
-                                                        stream);
-  // Initialize it with a sentinel value, so later we can identify which ones are unused and which
-  // ones need to be updated.
-  thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-    global_mapping_indices.begin(),
-    global_mapping_indices.end(),
-    cudf::detail::CUDF_SIZE_TYPE_SENTINEL);
-  // Compute the cardinality (the number of unique keys) encounter by each thread block.
-  rmm::device_uvector<size_type> block_cardinality(grid_size, stream);
+  // Build the ordinary sparse row-to-key mapping once. Unlike the previous shared-memory path,
+  // cardinality does not select an entirely different mapper or require a host-side fallback.
+  rmm::device_uvector<size_type> matching_keys(num_rows, stream);
+  auto mapper_set_ref = global_set.ref(cuco::op::insert_and_find);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    cuda::counting_iterator<size_type>{0},
+                    cuda::counting_iterator<size_type>{num_rows},
+                    matching_keys.begin(),
+                    [mapper_set_ref, row_bitmask] __device__(size_type const idx) mutable {
+                      if (!row_bitmask || cudf::bit_is_set(row_bitmask, idx)) {
+                        return *mapper_set_ref.insert_and_find(idx).first;
+                      }
+                      return cudf::detail::CUDF_SIZE_TYPE_SENTINEL;
+                    });
 
-  // Flag indicating whether a global memory aggregation fallback is required or not.
-  rmm::device_uvector<cuda::std::atomic_flag> needs_global_memory_fallback(1, stream);
-  CUDF_CUDA_TRY(cudaMemsetAsync(
-    needs_global_memory_fallback.data(), 0, sizeof(cuda::std::atomic_flag), stream.get()));
-
-  auto set_ref_insert = global_set.ref(cuco::op::insert_and_find);
-  compute_mapping_indices(grid_size,
-                          num_rows,
-                          set_ref_insert,
-                          row_bitmask,
-                          local_mapping_indices.data(),
-                          global_mapping_indices.data(),
-                          block_cardinality.data(),
-                          needs_global_memory_fallback.data(),
-                          stream);
-
-  auto const needs_fallback = [&] {
-    cuda::std::atomic_flag h_needs_fallback;
-    // Cannot use a value-returning helper because atomic_flag is not copy-constructible;
-    // copy the raw bytes back to host instead.
-    CUDF_CUDA_TRY(cudf::detail::memcpy_async(&h_needs_fallback,
-                                             needs_global_memory_fallback.data(),
-                                             sizeof(cuda::std::atomic_flag),
-                                             stream));
-    stream.sync();
-    return h_needs_fallback.test(cuda::std::memory_order_relaxed);
-  }();
-  if (needs_fallback) { return run_aggs_by_global_mem_kernel(); }
-
-  auto unique_keys = extract_populated_keys(global_set, num_rows, stream, mr);
-
-  // Now, update the target indices for computing aggregations using the shared memory kernel.
-  {
-    auto key_transform_map = compute_key_transform_map(
-      num_rows, unique_keys, stream, cudf::get_current_device_resource_ref());
-    thrust::for_each_n(
-      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-      cuda::counting_iterator<cudf::size_type>{0},
-      grid_size * GROUPBY_BLOCK_SIZE,
-      [key_transform_map      = key_transform_map.begin(),
-       global_mapping_indices = global_mapping_indices.begin()] __device__(auto const idx) {
-        auto const block_id    = idx / GROUPBY_BLOCK_SIZE;
-        auto const thread_rank = idx % GROUPBY_BLOCK_SIZE;
-        auto const mapping_idx = block_id * GROUPBY_CARDINALITY_THRESHOLD + thread_rank;
-        auto const old_idx     = global_mapping_indices[mapping_idx];
-        if (old_idx != cudf::detail::CUDF_SIZE_TYPE_SENTINEL) {
-          global_mapping_indices[mapping_idx] = key_transform_map[old_idx];
-        }
-      });
-  }
+  auto unique_keys           = extract_populated_keys(global_set, num_rows, stream, mr);
+  auto const num_output_rows = static_cast<size_type>(unique_keys.size());
+  auto key_transform_map     = compute_key_transform_map(
+    num_rows, unique_keys, stream, cudf::get_current_device_resource_ref());
+  auto agg_results =
+    create_results_table(num_output_rows, values, agg_kinds, is_agg_intermediate, stream, mr);
 
   auto const d_spass_values = table_device_view::create(values, stream);
-  auto agg_results          = create_results_table(
-    static_cast<size_type>(unique_keys.size()), values, agg_kinds, is_agg_intermediate, stream, mr);
-  auto d_results_ptr = mutable_table_device_view::create(*agg_results, stream);
-  compute_shared_memory_aggs(grid_size,
-                             available_shmem_size,
-                             num_rows,
-                             row_bitmask,
-                             local_mapping_indices.data(),
-                             global_mapping_indices.data(),
-                             block_cardinality.data(),
-                             *d_spass_values,
-                             *d_results_ptr,
-                             d_agg_kinds.data(),
-                             stream);
+  auto d_results_ptr        = mutable_table_device_view::create(*agg_results, stream);
+
+  if (num_output_rows > 0) {
+    constexpr size_type block_size                   = 256;
+    constexpr std::size_t block_private_budget_bytes = 16U * 1024U * 1024U;
+    auto const launch_grid_size = cudf::util::div_rounding_up_safe(num_rows, block_size);
+    auto const num_replicas =
+      std::min(launch_grid_size, static_cast<size_type>(cudf::detail::num_multiprocessors()));
+
+    // alloc_size includes result data and validity masks. Multiplying the one-replica allocation
+    // is a conservative bound for the combined allocation because its buffers are rounded only
+    // once. Division performs the budget test without overflowing size_t.
+    auto const per_replica_bytes = agg_results->alloc_size();
+    auto const private_rows_fit =
+      num_output_rows <= std::numeric_limits<size_type>::max() / num_replicas;
+    auto const private_bytes_fit =
+      per_replica_bytes <= block_private_budget_bytes / static_cast<std::size_t>(num_replicas);
+
+    if (private_rows_fit && private_bytes_fit) {
+      auto block_private_results = create_results_table(num_output_rows * num_replicas,
+                                                        values,
+                                                        agg_kinds,
+                                                        is_agg_intermediate,
+                                                        stream,
+                                                        cudf::get_current_device_resource_ref());
+      auto d_block_private_results =
+        mutable_table_device_view::create(*block_private_results, stream);
+      compute_block_private_aggs(launch_grid_size,
+                                 block_size,
+                                 num_replicas,
+                                 num_rows,
+                                 matching_keys.data(),
+                                 key_transform_map.data(),
+                                 *d_spass_values,
+                                 *d_results_ptr,
+                                 *d_block_private_results,
+                                 num_output_rows,
+                                 d_agg_kinds.data(),
+                                 stream);
+    } else {
+      // Reuse the mapping and dense output even when partials exceed the memory budget. This avoids
+      // both a second mapping pass and the num_rows-sized sparse result table/gather.
+      compute_mapped_global_aggs(launch_grid_size,
+                                 block_size,
+                                 num_rows,
+                                 matching_keys.data(),
+                                 key_transform_map.data(),
+                                 *d_spass_values,
+                                 *d_results_ptr,
+                                 num_output_rows,
+                                 d_agg_kinds.data(),
+                                 stream);
+    }
+  }
 
   finalize_output(values, aggs, agg_results, cache, stream);
   return {std::move(unique_keys), has_compound_aggs};

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,6 +11,10 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/aggregation.hpp>
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
 
 using namespace cudf::test::iterators;
 
@@ -242,4 +246,69 @@ TEST_F(groupby_argmin_struct_test, null_keys_and_values)
 
   auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
+}
+
+struct groupby_argminmax_mapped_test : public cudf::test::BaseFixture {};
+
+TEST_F(groupby_argminmax_mapped_test, BlockPrivatePartials)
+{
+  constexpr cudf::size_type num_rows   = 200'000;
+  constexpr cudf::size_type num_groups = 256;
+
+  std::vector<int32_t> keys_data(num_rows);
+  std::vector<uint8_t> key_validity(num_rows);
+  std::vector<int32_t> values_data(num_rows);
+  std::vector<cudf::size_type> expected_argmin(num_groups, 0);
+  std::vector<cudf::size_type> expected_argmax(num_groups, 0);
+  std::vector<uint8_t> expected_initialized(num_groups, false);
+
+  for (cudf::size_type row = 0; row < num_rows; ++row) {
+    auto const key   = row % num_groups;
+    auto const value = static_cast<int32_t>((static_cast<uint64_t>(row) * 48'271) % 2'147'483'647);
+    auto const key_is_valid = row % 251 != 0;
+
+    keys_data[row]    = key;
+    key_validity[row] = key_is_valid;
+    values_data[row]  = value;
+
+    if (key_is_valid) {
+      if (!expected_initialized[key]) {
+        expected_argmin[key]      = row;
+        expected_argmax[key]      = row;
+        expected_initialized[key] = true;
+      } else {
+        if (value < values_data[expected_argmin[key]]) { expected_argmin[key] = row; }
+        if (value > values_data[expected_argmax[key]]) { expected_argmax[key] = row; }
+      }
+    }
+  }
+
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>(
+    keys_data.begin(), keys_data.end(), key_validity.begin());
+  auto const values =
+    cudf::test::fixed_width_column_wrapper<int32_t>(values_data.begin(), values_data.end());
+
+  std::vector<int32_t> expected_keys(num_groups);
+  std::iota(expected_keys.begin(), expected_keys.end(), 0);
+  auto const expected_key_col = cudf::test::fixed_width_column_wrapper<int32_t>(
+    expected_keys.begin(), expected_keys.end(), no_nulls());
+  auto const expected_argmin_col = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
+    expected_argmin.begin(), expected_argmin.end());
+  auto const expected_argmax_col = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
+    expected_argmax.begin(), expected_argmax.end());
+
+  test_single_agg(keys,
+                  values,
+                  expected_key_col,
+                  expected_argmin_col,
+                  cudf::make_argmin_aggregation<cudf::groupby_aggregation>(),
+                  force_use_sort_impl::NO,
+                  cudf::null_policy::EXCLUDE);
+  test_single_agg(keys,
+                  values,
+                  expected_key_col,
+                  expected_argmax_col,
+                  cudf::make_argmax_aggregation<cudf::groupby_aggregation>(),
+                  force_use_sort_impl::NO,
+                  cudf::null_policy::EXCLUDE);
 }

--- a/cpp/tests/groupby/sum_tests.cpp
+++ b/cpp/tests/groupby/sum_tests.cpp
@@ -16,6 +16,11 @@
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 
+#include <cstdint>
+#include <numeric>
+#include <string>
+#include <vector>
+
 using namespace cudf::test::iterators;
 
 namespace {
@@ -333,5 +338,81 @@ TEST_F(GroupByDecimal128ShmemAlignmentTest, MultiColumnDecimal128Sum)
       cudf::gather(cudf::table_view({results[c].results[0]->view()}), *sort_order);
     auto const expected = fp128(sums[c].begin(), sums[c].end(), scale);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, sorted->get_column(0));
+  }
+}
+
+// Regression test for https://github.com/NVIDIA/cudf/issues/24026. Exercise the 128-group boundary
+// and the mapped block-private reduction with nullable decimal128 SUM and COUNT results.
+TEST_F(GroupByDecimal128ShmemAlignmentTest, MappedBlockPrivateCardinalitySweep)
+{
+  using namespace numeric;
+  using fp128 = cudf::test::fixed_point_column_wrapper<__int128_t>;
+
+  constexpr cudf::size_type num_rows = 1'000'000;
+  constexpr __int128_t base          = static_cast<__int128_t>(1) << 50;
+  auto const scale                   = scale_type{-2};
+
+  for (auto const cardinality : {127, 128, 129, 130, 175, 256, 1'024}) {
+    SCOPED_TRACE("cardinality=" + std::to_string(cardinality));
+
+    std::vector<int32_t> keys_data(num_rows);
+    std::vector<uint8_t> key_validity(num_rows);
+    std::vector<__int128_t> values_data(num_rows);
+    std::vector<uint8_t> value_validity(num_rows);
+    std::vector<__int128_t> expected_sums(cardinality, 0);
+    std::vector<cudf::size_type> expected_counts(cardinality, 0);
+
+    for (cudf::size_type i = 0; i < num_rows; ++i) {
+      // SplitMix64 gives every aggregation block a deterministic, well-mixed key stream.
+      auto mixed = static_cast<uint64_t>(i) + 0x9e3779b97f4a7c15ULL;
+      mixed      = (mixed ^ (mixed >> 30)) * 0xbf58476d1ce4e5b9ULL;
+      mixed      = (mixed ^ (mixed >> 27)) * 0x94d049bb133111ebULL;
+      mixed      = mixed ^ (mixed >> 31);
+
+      auto const key = static_cast<int32_t>(mixed % cardinality);
+      auto value     = base + static_cast<__int128_t>((i % 1'009) * 101 + key);
+      if (i % 5 == 0) { value = -value; }
+      auto const key_is_valid   = i % 251 != 0;
+      auto const value_is_valid = i % 7 != 0;
+
+      keys_data[i]      = key;
+      key_validity[i]   = key_is_valid;
+      values_data[i]    = value;
+      value_validity[i] = value_is_valid;
+      if (key_is_valid and value_is_valid) {
+        expected_sums[key] += value;
+        ++expected_counts[key];
+      }
+    }
+
+    auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>(
+      keys_data.begin(), keys_data.end(), key_validity.begin());
+    auto const values =
+      fp128(values_data.begin(), values_data.end(), value_validity.begin(), scale);
+
+    std::vector<cudf::groupby::aggregation_request> requests(1);
+    requests[0].values = values;
+    requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+    requests[0].aggregations.push_back(
+      cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
+
+    cudf::groupby::groupby gb(cudf::table_view({keys}), cudf::null_policy::EXCLUDE);
+    auto [result_keys, results] = gb.aggregate(requests);
+    auto const order            = cudf::sorted_order(result_keys->view());
+    auto const sorted_keys      = cudf::gather(result_keys->view(), *order);
+    auto const sorted_results   = cudf::gather(
+      cudf::table_view({results[0].results[0]->view(), results[0].results[1]->view()}), *order);
+
+    std::vector<int32_t> expected_keys(cardinality);
+    std::iota(expected_keys.begin(), expected_keys.end(), 0);
+    auto const expected_key_col =
+      cudf::test::fixed_width_column_wrapper<int32_t>(expected_keys.begin(), expected_keys.end());
+    auto const expected_sum_col   = fp128(expected_sums.begin(), expected_sums.end(), scale);
+    auto const expected_count_col = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
+      expected_counts.begin(), expected_counts.end());
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_key_col, sorted_keys->get_column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_sum_col, sorted_results->get_column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_count_col, sorted_results->get_column(1));
   }
 }


### PR DESCRIPTION
## Description

⚠️ WIP!

This PR replaces the shared-memory aggregation path in single-pass hash groupby with dense, replica-private partial aggregation for the aggregation and type combinations that currently use that path.

The new path builds the row-to-hash-slot mapping once, transforms occupied slots to dense output group IDs, and distributes thread blocks across an SM-count set of replica result tables. Rows atomically update the selected replica, after which a second kernel reduces the replica partials into the final dense output. Replica storage is capped at 16 MiB; when it would exceed that budget, the implementation reuses the same mapping and aggregates directly into the final dense output.

This removes the per-block 128-group capacity decision, host-side overflow check, and restart through the sparse global aggregation path.

Related to #24026.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
