### PR TITLE
fix(java): restore parquet writer factory compatibility

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -1588,11 +1588,10 @@ public final class Table implements AutoCloseable {
    * Get a table writer to write parquet data to a file.
    * @param options the parquet writer options.
    * @param outputFile where to write the file.
-   * @return a Parquet table writer to use for writing out multiple tables.
+   * @return a table writer to use for writing out multiple tables.
    */
-  public static ParquetTableWriter writeParquetChunked(ParquetWriterOptions options,
-                                                       File outputFile) {
-    return new ParquetTableWriter(options, outputFile);
+  public static TableWriter writeParquetChunked(ParquetWriterOptions options, File outputFile) {
+    return writeParquetChunkedWithFooter(options, outputFile);
   }
 
   /**
@@ -1601,17 +1600,48 @@ public final class Table implements AutoCloseable {
    * @param consumer a class that will be called when host buffers are ready with parquet
    *                 formatted data in them.
    * @param hostMemoryAllocator allocator for host memory buffers
+   * @return a table writer to use for writing out multiple tables.
+   */
+  public static TableWriter writeParquetChunked(ParquetWriterOptions options,
+                                                HostBufferConsumer consumer,
+                                                HostMemoryAllocator hostMemoryAllocator) {
+    return writeParquetChunkedWithFooter(options, consumer, hostMemoryAllocator);
+  }
+
+  public static TableWriter writeParquetChunked(ParquetWriterOptions options,
+                                                HostBufferConsumer consumer) {
+    return writeParquetChunked(options, consumer, DefaultHostMemoryAllocator.get());
+  }
+
+  /**
+   * Get a Parquet table writer that can return footer metadata when writing to a file.
+   * @param options the parquet writer options.
+   * @param outputFile where to write the file.
    * @return a Parquet table writer to use for writing out multiple tables.
    */
-  public static ParquetTableWriter writeParquetChunked(ParquetWriterOptions options,
-                                                       HostBufferConsumer consumer,
-                                                       HostMemoryAllocator hostMemoryAllocator) {
+  public static ParquetTableWriter writeParquetChunkedWithFooter(ParquetWriterOptions options,
+                                                                 File outputFile) {
+    return new ParquetTableWriter(options, outputFile);
+  }
+
+  /**
+   * Get a Parquet table writer that can return footer metadata and handle each chunk with a
+   * callback.
+   * @param options the parquet writer options.
+   * @param consumer a class that will be called when host buffers are ready with parquet
+   *                 formatted data in them.
+   * @param hostMemoryAllocator allocator for host memory buffers
+   * @return a Parquet table writer to use for writing out multiple tables.
+   */
+  public static ParquetTableWriter writeParquetChunkedWithFooter(ParquetWriterOptions options,
+                                                                 HostBufferConsumer consumer,
+                                                                 HostMemoryAllocator hostMemoryAllocator) {
     return new ParquetTableWriter(options, consumer, hostMemoryAllocator);
   }
 
-  public static ParquetTableWriter writeParquetChunked(ParquetWriterOptions options,
-                                                       HostBufferConsumer consumer) {
-    return writeParquetChunked(options, consumer, DefaultHostMemoryAllocator.get());
+  public static ParquetTableWriter writeParquetChunkedWithFooter(ParquetWriterOptions options,
+                                                                 HostBufferConsumer consumer) {
+    return writeParquetChunkedWithFooter(options, consumer, DefaultHostMemoryAllocator.get());
   }
 
   /**

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -10182,7 +10182,7 @@ public class TableTest extends CudfTestBase {
              .column("a", "b", "c")
              .build();
          ParquetTableWriter writer =
-             Table.writeParquetChunked(options, tempFile.getFile())) {
+             Table.writeParquetChunkedWithFooter(options, tempFile.getFile())) {
       writer.write(table);
       writer.write(table);
       try (HostMemoryBuffer footer = writer.closeAndGetFooter()) {
@@ -10210,7 +10210,7 @@ public class TableTest extends CudfTestBase {
              .build();
          MyBufferConsumer consumer = new MyBufferConsumer();
          ParquetTableWriter writer =
-             Table.writeParquetChunked(options, consumer, allocator)) {
+             Table.writeParquetChunkedWithFooter(options, consumer, allocator)) {
       writer.write(table);
       try (HostMemoryBuffer footer = writer.closeAndGetFooter()) {
         byte[] parquetData = new byte[(int) consumer.offset];
@@ -10231,12 +10231,36 @@ public class TableTest extends CudfTestBase {
         .build();
     try (TempFile tempFile = TempFile.create("discarded-footer", ".parquet");
          Table table = new Table.TestBuilder().column(1, 2, 3).build()) {
-      ParquetTableWriter writer = Table.writeParquetChunked(options, tempFile.getFile());
+      ParquetTableWriter writer =
+          Table.writeParquetChunkedWithFooter(options, tempFile.getFile());
       writer.write(table);
       writer.close();
       assertThrows(IllegalStateException.class, writer::closeAndGetFooter);
       assertDoesNotThrow(writer::close);
     }
+  }
+
+  @Test
+  void testParquetWriterFactoryReturnTypes() throws NoSuchMethodException {
+    assertEquals(TableWriter.class,
+        Table.class.getMethod("writeParquetChunked", ParquetWriterOptions.class, File.class)
+            .getReturnType());
+    assertEquals(TableWriter.class,
+        Table.class.getMethod("writeParquetChunked", ParquetWriterOptions.class,
+            HostBufferConsumer.class, HostMemoryAllocator.class).getReturnType());
+    assertEquals(TableWriter.class,
+        Table.class.getMethod("writeParquetChunked", ParquetWriterOptions.class,
+            HostBufferConsumer.class).getReturnType());
+
+    assertEquals(ParquetTableWriter.class,
+        Table.class.getMethod("writeParquetChunkedWithFooter", ParquetWriterOptions.class,
+            File.class).getReturnType());
+    assertEquals(ParquetTableWriter.class,
+        Table.class.getMethod("writeParquetChunkedWithFooter", ParquetWriterOptions.class,
+            HostBufferConsumer.class, HostMemoryAllocator.class).getReturnType());
+    assertEquals(ParquetTableWriter.class,
+        Table.class.getMethod("writeParquetChunkedWithFooter", ParquetWriterOptions.class,
+            HostBufferConsumer.class).getReturnType());
   }
 
   private static void assertReturnedFooterMatches(byte[] parquetData,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Restore the three `Table.writeParquetChunked` overloads to their established `TableWriter` return type, restoring the JVM descriptors used by binaries compiled before #23912. Add matching `writeParquetChunkedWithFooter` overloads returning `ParquetTableWriter`, route the legacy factories through them, and move the footer-specific tests to the new API while adding return-type regression coverage.

Binaries compiled against the short-lived #23912 `ParquetTableWriter` return descriptors are not simultaneously binary-compatible with the restored legacy descriptors and must be recompiled; callers that need the concrete writer should migrate to `writeParquetChunkedWithFooter`.

Closes #23972

Java main/test compilation, JVM descriptor inspection, pre-commit, and diff validation passed. The focused native-backed Maven tests could not run because the environment has no `nvcc` or configured libcudf native build/install.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.