### PR TITLE
Delta_decode fast path for non-null columns

### DIFF
--- a/cpp/src/io/comp/common.hpp
+++ b/cpp/src/io/comp/common.hpp
@@ -25,6 +25,7 @@ namespace cudf::io::detail {
  * See https://github.com/NVIDIA/cudf/issues/13605.
  */
 constexpr std::size_t BUFFER_PADDING_MULTIPLE{8};
+constexpr std::size_t BUFFER_EXTRA_PADDING{16};
 
 [[nodiscard]] std::string compression_type_name(compression_type compression);
 

--- a/cpp/src/io/parquet/io_utils/parquet_io_utils.cpp
+++ b/cpp/src/io/parquet/io_utils/parquet_io_utils.cpp
@@ -337,7 +337,7 @@ fetch_byte_ranges_to_device_async_impl(
 
       // Buffer needs to be padded. Required by `gpuDecodePageData`.
       column_chunk_buffers.emplace_back(
-        cudf::util::round_up_safe(buffer_size, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
+        cudf::util::round_up_safe(buffer_size + cudf::io::detail::BUFFER_EXTRA_PADDING, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
         stream,
         mr);
 

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -15,11 +15,317 @@
 
 #include <thrust/transform_scan.h>
 
+
 namespace cudf::io::parquet::detail {
 
 namespace {
 
 namespace cg = cooperative_groups;
+namespace delta_fastpath {
+
+CUDF_HOST_DEVICE __forceinline__ bool supported(PageInfo const &page,
+                                                ColumnChunkDesc const &chunk) {
+  return BitAnd(static_cast<uint32_t>(decode_kernel_mask::DELTA_BINARY),
+                page.kernel_mask) != 0 &&
+         chunk.physical_type == Type::INT64 &&
+         chunk.max_level[level_type::DEFINITION] == 0 &&
+         chunk.max_level[level_type::REPETITION] == 0 &&
+         chunk.max_nesting_depth == 1;
+}
+
+constexpr unsigned full_mask = 0xffffffffu;
+constexpr int warp_size = 32;
+constexpr int vals_per_block_multiple = 128;
+constexpr int vals_per_miniblock_multiple = 32;
+constexpr int bits_per_word = 32;
+constexpr int block_size = 128;
+constexpr int word_alignment = 4;
+constexpr int max_fast_bit_width = 27;
+
+__device__ __forceinline__ int64_t wrapping_i64_add(int64_t a, int64_t b) {
+  return static_cast<int64_t>(static_cast<uint64_t>(a) +
+                              static_cast<uint64_t>(b));
+}
+
+__device__ __forceinline__ int64_t wrapping_i64_mul(int64_t a, int64_t b) {
+  return static_cast<int64_t>(static_cast<uint64_t>(a) *
+                              static_cast<uint64_t>(b));
+}
+
+__device__ __forceinline__ int64_t decode_zz(uint64_t enc) {
+  int64_t non_sign_val = enc >> 1;
+  int sign_bit = (enc & 1);
+  // if sign_bit == 0, return non_sign_val
+  // if sign_bit == 1, return ~non_sign_val
+  // this can be done by XOR with 000..0 or 11...1, e.g. 0 or -1.
+  return non_sign_val ^ (-sign_bit);
+}
+
+template <bool FAST> struct ret_t;
+template <> struct ret_t<true> { using ty = uint32_t; };
+template <> struct ret_t<false> { using ty = int64_t; };
+
+template <bool ASSUME_FAST>
+__device__ __forceinline__ static int
+read_uleb128(uint8_t const *input, int lane_id,
+             typename ret_t<ASSUME_FAST>::ty &decoded) {
+  // One approach is replicated mapping, by loading a packed aligned 4B word,
+  // and using dp2a trick to add up the bytes. Instead, use warp-coop approach.
+  int loc_lane_id = (~lane_id & 3);
+  uint8_t my_byte = __ldg(&input[loc_lane_id]);
+  uint32_t to_send = (my_byte & 0x7f) << (7 * loc_lane_id);
+
+  // the ~lane_id gives us reversal, such that __clz gives #bytes.
+  uint32_t term_mask =
+      __ballot_sync(full_mask, static_cast<int8_t>(my_byte) >= 0);
+  int n_bytes = __clz(term_mask) + 1;
+  uint32_t result = __reduce_or_sync(full_mask, to_send);
+  uint32_t mask = (1u << (7 * n_bytes)) - 1;
+
+  if constexpr (ASSUME_FAST) {
+    decoded = result & mask;
+    return n_bytes;
+  }
+  if (__builtin_expect(n_bytes <= 4, true)) {
+    decoded = static_cast<uint64_t>(result & mask);
+    return n_bytes;
+  }
+
+  decoded = 0ull;
+  int i = 0;
+  uint8_t byte;
+  do {
+    byte = input[i];
+    decoded |= static_cast<uint64_t>(byte & 0x7f) << (7 * i);
+    i += 1;
+  } while (byte & 0x80);
+  return i;
+}
+
+template <bool FAST>
+__device__ __forceinline__ static void
+extract_bitpack(uint32_t const *w_input, int bit_width, int i, int align,
+                typename ret_t<FAST>::ty &out) {
+  if (bit_width < 0 || i < 0) {
+    __builtin_unreachable();
+  }
+
+  // 32 values, which are at least 1bit in size, are guaranteed to jump in
+  // multiples of 4B.
+  int bit_idx = bit_width * i + align;
+  int word_idx = bit_idx / bits_per_word;
+
+  if constexpr (FAST) {
+    if (bit_width > max_fast_bit_width) {
+      __builtin_unreachable();
+    }
+    int addr1 = word_idx;
+    int addr2 = word_idx + 1;
+    // safe to read unconditionally?
+    uint32_t w1 = __ldg(&w_input[addr1]);
+    uint32_t w2 = __ldg(&w_input[addr2]);
+    uint32_t mask = (1u << bit_width) - 1;
+    out = __funnelshift_r(w1, w2, bit_idx) & mask;
+  } else {
+    int addr1 = word_idx;
+    int addr2 = word_idx + 1;
+    int addr3 = word_idx + 2;
+    uint32_t w1 = __ldg(&w_input[addr1]);
+    uint32_t w2 = __ldg(&w_input[addr2]);
+    uint32_t w3 = __ldg(&w_input[addr3]);
+
+    uint64_t f1 = __funnelshift_r(w1, w2, bit_idx);
+    uint64_t f2 = __funnelshift_r(w2, w3, bit_idx);
+    uint64_t mask =
+        bit_width == 64 ? ((uint64_t)-1) : ((1ull << bit_width) - 1);
+
+    out = (f1 | (f2 << 32)) & mask;
+  }
+}
+
+template <bool FAST>
+__device__ __forceinline__ static int
+handle_32_elements(uint32_t const *w_input, int bit_width, int align,
+                   int lane_id, int64_t min_delta, int64_t &offset_value,
+                   int n_decoded, int n_skip, int n_to_decode,
+                   int64_t *__restrict__ output_ptr) {
+  using val_t = typename ret_t<FAST>::ty;
+  val_t decoded;
+  extract_bitpack<FAST>(w_input, bit_width, lane_id, align, decoded);
+
+  val_t prefix_sum = decoded;
+#pragma unroll
+  for (int jump = 1; jump < warp_size; jump *= 2) {
+    if constexpr (FAST) {
+      // Taken from cub/cub/warp/specializations/warp_scan_shfl.cuh.
+      asm volatile("{"
+                   ".reg .pred p;"
+                   ".reg .b32 y;"
+                   "shfl.sync.up.b32 y|p, %0, %1, 0, 0xffffffff;"
+                   "@p add.u32 %0, %0, y;"
+                   "}"
+                   : "+r"(prefix_sum)
+                   : "r"(jump));
+    } else {
+      int64_t partial = __shfl_up_sync(full_mask, prefix_sum, jump);
+      if (lane_id >= jump) {
+        prefix_sum = wrapping_i64_add(prefix_sum, partial);
+      }
+    }
+  }
+  val_t full_sum;
+  if constexpr (FAST) {
+    // can be interleaved with above.
+    full_sum = __reduce_add_sync(full_mask, decoded);
+  } else {
+    full_sum = __shfl_sync(full_mask, prefix_sum, warp_size - 1);
+  }
+
+  int64_t min_delta_lane =
+      wrapping_i64_mul(static_cast<int64_t>(1 + lane_id), min_delta);
+  int64_t delta =
+      wrapping_i64_add(static_cast<int64_t>(prefix_sum), min_delta_lane);
+  int64_t value = wrapping_i64_add(delta, offset_value);
+
+  int64_t min_delta_total =
+      wrapping_i64_mul(static_cast<int64_t>(warp_size), min_delta);
+  int64_t new_offset_value =
+      wrapping_i64_add(static_cast<int64_t>(full_sum), min_delta_total);
+  offset_value = wrapping_i64_add(offset_value, new_offset_value);
+
+  if (FAST ||
+      (n_decoded + lane_id >= n_skip && n_decoded + lane_id < n_to_decode)) {
+    __stcs(&output_ptr[n_decoded - n_skip + lane_id], value);
+  }
+  return vals_per_miniblock_multiple * bit_width / bits_per_word;
+}
+
+CUDF_KERNEL void __launch_bounds__(block_size)
+    decode(PageInfo const *__restrict pages, int n_pages,
+           ColumnChunkDesc const *__restrict chunks, size_t min_row,
+           size_t num_rows, bool const *__restrict page_mask) {
+  int warp_id = __shfl_sync(full_mask, threadIdx.x / warp_size, 0);
+  int lane_id = threadIdx.x % warp_size;
+
+  int page_idx = blockIdx.x * (block_size / warp_size) + warp_id;
+  if (page_idx >= n_pages) {
+    return;
+  }
+
+  PageInfo p_info = pages[page_idx];
+  bool const p_mask = page_mask == nullptr || page_mask[page_idx];
+  ColumnChunkDesc c_info = chunks[p_info.chunk_idx];
+  if (!supported(p_info, c_info)) {
+    return;
+  }
+
+  int64_t abs_page_base_row = c_info.start_row + p_info.chunk_row;
+  if (!p_mask || abs_page_base_row + p_info.num_input_values <= min_row ||
+      abs_page_base_row >= min_row + num_rows) {
+    return;
+  }
+
+  int64_t *__restrict__ output_ptr =
+      static_cast<int64_t *>(c_info.column_data_base[0]) +
+      max((int64_t)0, (int64_t)(abs_page_base_row - min_row));
+  uint8_t const *__restrict__ input_ptr =
+      p_info.page_data + ((p_info.flags & PAGEINFO_FLAGS_V2)
+                              ? p_info.lvl_bytes[level_type::REPETITION] +
+                                    p_info.lvl_bytes[level_type::DEFINITION]
+                              : 0);
+  int n_skip = max((int64_t)0, (int64_t)(min_row - abs_page_base_row));
+  int n_valid = min((int64_t)p_info.num_input_values,
+                    (int64_t)(min_row + num_rows - abs_page_base_row));
+
+  int n_vals_per_blk;
+  int n_miniblks_per_blk;
+  int64_t offset_value;
+  uint32_t h1, h2, h3;
+  int64_t h4;
+
+  input_ptr += read_uleb128<true>(input_ptr, lane_id, h1);
+  n_vals_per_blk = static_cast<int>(h1);
+  __builtin_assume(n_vals_per_blk % vals_per_block_multiple == 0);
+  input_ptr += read_uleb128<true>(input_ptr, lane_id, h2);
+  n_miniblks_per_blk = static_cast<int>(h2);
+  input_ptr += read_uleb128<true>(input_ptr, lane_id, h3);
+  input_ptr += read_uleb128<false>(input_ptr, lane_id, h4);
+  offset_value = decode_zz(h4);
+
+  int n_vals_per_miniblk = n_vals_per_blk / n_miniblks_per_blk;
+  __builtin_assume(n_vals_per_miniblk % vals_per_miniblock_multiple == 0);
+
+  int n_decoded = 0;
+  if (n_skip == 0 && lane_id == 0) {
+    __stcs(&output_ptr[0], offset_value);
+  }
+  n_decoded += 1;
+
+  int n_to_decode = n_valid;
+  // main block decoding loop.
+  while (n_decoded < n_to_decode) {
+    int64_t h5 = 0;
+    input_ptr += read_uleb128<false>(input_ptr, lane_id, h5);
+
+    int64_t min_delta = decode_zz(h5);
+    uint8_t const *bitwidths = input_ptr;
+    uint8_t const *data = input_ptr + n_miniblks_per_blk;
+
+    int align_bytes = reinterpret_cast<uintptr_t>(data) & (word_alignment - 1);
+    uint32_t const *w_data =
+        reinterpret_cast<uint32_t const *>(data - align_bytes);
+
+    int n_miniblk_groups = 0;
+    int m_id = 0;
+    for (int ug = 0; ug < n_vals_per_blk; ug += vals_per_block_multiple) {
+      int u_bitwidths[vals_per_block_multiple / vals_per_miniblock_multiple];
+      bool fast_path = n_decoded >= n_skip &&
+                       n_decoded + vals_per_block_multiple <= n_to_decode;
+
+#pragma unroll
+      for (int g = 0; g < vals_per_block_multiple / vals_per_miniblock_multiple;
+           ++g) {
+        int m = m_id;
+        if (++n_miniblk_groups ==
+            n_vals_per_miniblk / vals_per_miniblock_multiple) {
+          ++m_id;
+          n_miniblk_groups = 0;
+        }
+
+        // Keep in mind, bitwidths are 1B each- so a lot will fit in a single
+        // sector.
+        //
+        u_bitwidths[g] = __ldg(&bitwidths[m]);
+        fast_path &= u_bitwidths[g] <= max_fast_bit_width;
+      }
+
+      if (__builtin_expect(fast_path, true)) {
+#pragma unroll
+        for (int g = 0;
+             g < vals_per_block_multiple / vals_per_miniblock_multiple; ++g) {
+          w_data += handle_32_elements<true>(
+              w_data, u_bitwidths[g], align_bytes * 8, lane_id, min_delta,
+              offset_value, n_decoded + g * vals_per_miniblock_multiple, n_skip,
+              n_to_decode, output_ptr);
+        }
+        n_decoded += vals_per_block_multiple;
+      } else {
+        for (int g = 0;
+             g < vals_per_block_multiple / vals_per_miniblock_multiple &&
+             n_decoded < n_to_decode;
+             ++g) {
+          w_data += handle_32_elements<false>(
+              w_data, u_bitwidths[g], align_bytes * 8, lane_id, min_delta,
+              offset_value, n_decoded, n_skip, n_to_decode, output_ptr);
+          n_decoded += vals_per_miniblock_multiple;
+        }
+      }
+      input_ptr = reinterpret_cast<uint8_t const *>(w_data) + align_bytes;
+    }
+  }
+}
+
+} // namespace delta_fastpath
 
 constexpr int decode_block_size              = 128;
 constexpr int decode_delta_binary_block_size = 96;
@@ -373,6 +679,9 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 
   // Exit early if the page is pruned
   if (page_mask.size() > 0 and not page_mask[page_idx]) { return; }
+  if (delta_fastpath::supported(pages[page_idx], chunks[pages[page_idx].chunk_idx])) {
+    return;
+  }
 
   [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
 
@@ -982,6 +1291,15 @@ void decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
                          cuda::stream_ref stream)
 {
   CUDF_EXPECTS(pages.size() > 0, "There is no page to decode");
+
+  dim3 const v3_block(delta_fastpath::block_size, 1);
+  dim3 const v3_grid((pages.size() + (delta_fastpath::block_size / delta_fastpath::warp_size) - 1) /
+                       (delta_fastpath::block_size / delta_fastpath::warp_size),
+                     1);
+  delta_fastpath::decode<<<v3_grid, v3_block, 0, stream.get()>>>(
+    pages.device_ptr(), static_cast<int>(pages.size()), chunks.device_ptr(), min_row, num_rows,
+    page_mask.empty() ? nullptr : page_mask.data());
+  CUDF_CUDA_TRY(cudaGetLastError());
 
   dim3 dim_block(decode_delta_binary_block_size, 1);
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -504,12 +504,12 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
   // Dispatch batches of pages to decompress for each codec.
   // Buffer needs to be padded, required by `gpuDecodePageData`.
   rmm::device_buffer pass_decomp_pages(
-    cudf::util::round_up_safe(total_pass_decomp_size, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
+    cudf::util::round_up_safe(total_pass_decomp_size + cudf::io::detail::BUFFER_EXTRA_PADDING, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
     stream,
     mr);
   auto const total_subpass_decomp_size = total_decomp_size - total_pass_decomp_size;
   rmm::device_buffer subpass_decomp_pages(
-    cudf::util::round_up_safe(total_subpass_decomp_size, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
+    cudf::util::round_up_safe(total_subpass_decomp_size + cudf::io::detail::BUFFER_EXTRA_PADDING, cudf::io::detail::BUFFER_PADDING_MULTIPLE),
     stream,
     mr);
 


### PR DESCRIPTION
This MR adds a fast path for non-null, flat int64 delta encoded pages. The int64 case is not fundamental, it could probably be generalized to other flat data-types.

The fast path works by handling the pages it wants to, and then the regular kernel runs on pages the fast path chooses not to handle (done via a consistent function / no state, currently).

Instead of the 3-warp task-parallel design that communicates through shared memory, it simply dedicates 1 warp per data page to decode, which for this case can avoid certain overheads.

In addition, to avoid relying purely on inter-page overlapping to hide stalls, we create a fast path as follows. There are guaranteed to be a multiple of 128 values per block (potentially split among 32-aligned miniblocks). We then have a per-32-element decode logic, itself optimized with several common-case paths, unrolled 4x, to provide more ILP.

To avoid unnecessary instructions checking for tiny OOB reads on last-block-of-page cases, we instead add 16B padding to the page allocations as well.

In our preliminary benchmarks for a specific TPC-H workload matching the fast path's restrictions, this can provide up to an order of magnitude reduction in the time spent decoding delta-encoded pages. (But this is just a preliminary number and probably has many caveats).