### PR TITLE
CI: benchmark pip cache reuse

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,3 +1,4 @@
+# Full-CI baseline for the pip-cache experiment.
 name: pr
 on:
   push:

--- a/ci/build_wheel_common.sh
+++ b/ci/build_wheel_common.sh
@@ -4,7 +4,7 @@
 
 source rapids-configure-sccache
 source rapids-datetime-string
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 

--- a/ci/cudf_pandas_scripts/pandas-tests/merge-nightly.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/merge-nightly.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 # shellcheck source=ci/cudf_pandas_scripts/pandas-tests/shard-results.sh
 source ci/cudf_pandas_scripts/pandas-tests/shard-results.sh
 

--- a/ci/cudf_pandas_scripts/pandas-tests/run.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/run.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 EXITCODE=0
 trap "EXITCODE=1" ERR

--- a/ci/cudf_pandas_scripts/pandas-tests/summary.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/summary.sh
@@ -19,7 +19,7 @@
 # every fallible command is guarded explicitly and the script always exits 0.
 set -uo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 # shellcheck source=ci/cudf_pandas_scripts/pandas-tests/shard-results.sh
 source ci/cudf_pandas_scripts/pandas-tests/shard-results.sh
 

--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -4,7 +4,7 @@
 
 set -eoxu pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}

--- a/ci/rapids-init-pip-prototype.sh
+++ b/ci/rapids-init-pip-prototype.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use the unreleased rapids-init-pip change under evaluation. Keeping the tool in
+# the workspace makes it available to every pip invocation in this CI job, while
+# deliberately not persisting it across jobs.
+RAPIDS_INIT_PIP_SHA=a1aa4d1a80fcbf09da0f0b8eebf0e41ab42c0f48
+RAPIDS_INIT_PIP_DIR="${GITHUB_WORKSPACE:-${PWD}}/.cache/gha-tools/${RAPIDS_INIT_PIP_SHA}"
+RAPIDS_INIT_PIP_PATH="${RAPIDS_INIT_PIP_DIR}/rapids-init-pip"
+
+if [[ ! -f "${RAPIDS_INIT_PIP_PATH}" ]]; then
+  mkdir -p "${RAPIDS_INIT_PIP_DIR}"
+  curl --fail --location --silent --show-error \
+    "https://raw.githubusercontent.com/rapidsai/gha-tools/${RAPIDS_INIT_PIP_SHA}/tools/rapids-init-pip" \
+    --output "${RAPIDS_INIT_PIP_PATH}"
+fi
+
+# shellcheck disable=SC1090
+source "${RAPIDS_INIT_PIP_PATH}"
+python -m pip cache dir

--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 rapids-logger "Download wheels"
 

--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 CI_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 cd "${CI_DIR}/../"
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 # Common setup steps shared by Python test jobs
 source ./ci/test_python_common.sh test_python_narwhals

--- a/ci/test_wheel_cudf.sh
+++ b/ci/test_wheel_cudf.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 RUN_PYLIBCUDF_TESTS="${RUN_PYLIBCUDF_TESTS:-true}"

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 rapids-logger "Download wheels"
 

--- a/ci/test_wheel_dask_cudf.sh
+++ b/ci/test_wheel_dask_cudf.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-init-pip
+source ci/rapids-init-pip-prototype.sh
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 DASK_CUDF_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python dask-cudf cudf --pure --arch any --cuda "$RAPIDS_CUDA_VERSION")")


### PR DESCRIPTION
## Description

Temporary control for measuring pip-cache impact.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes (temporary CI benchmark).