### PR TITLE
Fix scalar assignment to empty DataFrame loc selections

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -42,6 +42,7 @@ from cudf.api.extensions import no_default
 from cudf.api.types import (
     _is_categorical_dtype,
     _is_scalar_or_zero_d_array,
+    is_bool_dtype,
     is_decimal32_dtype,
     is_decimal64_dtype,
     is_decimal128_dtype,
@@ -334,7 +335,12 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
             )
 
     @_performance_tracking
-    def _setitem_tuple_arg(self, key, value):
+    def __setitem__(self, key, value):
+        indexing_utils.check_dict_or_set_indexers(key)
+        row_only = not isinstance(key, tuple)
+        if row_only:
+            key = (key, slice(None))
+
         if (
             isinstance(self._frame.index, MultiIndex)
             or self._frame._data.multiindex
@@ -388,9 +394,38 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
             if is_scalar(value):
                 try:
                     if columns_df._num_columns:
-                        self._frame[
+                        row_key = self._frame[
                             columns_df._column_names[0]
                         ].loc._loc_to_iloc(key[0])
+                        # Empty positional selections are no-ops before
+                        # validating the scalar's dtype. A full-column
+                        # assignment can still change an empty frame's dtype.
+                        if isinstance(row_key, slice):
+                            if (
+                                key[0] != slice(None)
+                                and not range(len(self._frame))[row_key]
+                            ):
+                                return
+                        elif not is_scalar(row_key):
+                            if row_key.dtype.kind == "b":
+                                mask = BooleanMask(
+                                    row_key, len(self._frame)
+                                ).column
+                                # pandas converts a bare .loc mask to
+                                # positions, but retains masks in tuples.
+                                # Nulls require an explicitly boolean dtype;
+                                # untyped/object indexers still need validation.
+                                if len(mask) == 0 or (
+                                    row_only
+                                    and (
+                                        not mask.has_nulls()
+                                        or is_bool_dtype(key[0])
+                                    )
+                                    and not mask.any()
+                                ):
+                                    return
+                            elif len(row_key) == 0:
+                                return
                     for col in columns_df._column_names:
                         self._frame[col].loc[key[0]] = value
                 except KeyError:
@@ -570,7 +605,7 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
 
         else:
             # TODO: consolidate code path with identical counterpart
-            # in `_DataFrameLocIndexer._setitem_tuple_arg`
+            # in `_DataFrameLocIndexer.__setitem__`
             if not is_column_like(value):
                 value = cupy.asarray(value)
             if getattr(value, "ndim", 1) == 2:

--- a/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
@@ -753,6 +753,119 @@ def test_dataframe_setitem_loc(key, value):
     assert_eq(pdf, gdf)
 
 
+@pytest.mark.parametrize("pandas_compatible", [False, True])
+@pytest.mark.parametrize("mixed_dtypes", [False, True])
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param([], id="empty-list"),
+        pytest.param([False, False], id="false-mask"),
+        pytest.param(slice(0, -1), id="empty-slice"),
+        pytest.param(np.array([]), id="empty-array"),
+        pytest.param(([], "a"), id="empty-list-scalar-column"),
+        pytest.param((slice(0, -1), ["a"]), id="empty-slice-column-list"),
+        pytest.param(
+            (np.array([]), slice(None)), id="empty-array-all-columns"
+        ),
+    ],
+)
+def test_dataframe_setitem_loc_empty_selection(
+    key, mixed_dtypes, pandas_compatible
+):
+    data = {"a": [1, 2]}
+    if mixed_dtypes:
+        data["b"] = ["x", "y"]
+    pdf = pd.DataFrame(data)
+    expected = pdf.copy()
+
+    with cudf.option_context("mode.pandas_compatible", pandas_compatible):
+        gdf = cudf.from_pandas(pdf)
+        pdf.loc[key] = 1.5
+        gdf.loc[key] = 1.5
+
+        assert_eq(expected, pdf, check_dtype=True)
+        assert_eq(expected, gdf, check_dtype=True)
+
+
+@pytest.mark.parametrize(
+    "key", [np.array([], dtype=bool), (np.array([], dtype=bool), "a")]
+)
+def test_dataframe_setitem_loc_empty_frame_boolean_mask(key):
+    pdf = pd.DataFrame({"a": pd.Series([], dtype="int64")})
+    gdf = cudf.from_pandas(pdf)
+    expected = pdf.copy()
+
+    pdf.loc[key] = 1.5
+    gdf.loc[key] = 1.5
+
+    assert_eq(expected, pdf)
+    assert_eq(expected, gdf)
+
+
+@pytest.mark.parametrize("pandas_compatible", [False, True])
+@pytest.mark.parametrize("mask_values", [[False, False], [False, pd.NA]])
+def test_dataframe_setitem_loc_empty_boolean_series(
+    mask_values, pandas_compatible
+):
+    pdf = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    expected = pdf.copy()
+    pmask = pd.Series(mask_values, index=[1, 0], dtype="boolean")
+
+    with cudf.option_context("mode.pandas_compatible", pandas_compatible):
+        gdf = cudf.from_pandas(pdf)
+        gmask = cudf.from_pandas(pmask)
+        pdf.loc[pmask] = 1.5
+        gdf.loc[gmask] = 1.5
+
+        assert_eq(expected, pdf, check_dtype=True)
+        assert_eq(expected, gdf, check_dtype=True)
+
+
+@pytest.mark.parametrize("pandas_compatible", [False, True])
+@pytest.mark.parametrize(
+    "key, error",
+    [
+        pytest.param([False], IndexError, id="short-false-mask"),
+        pytest.param([False, False, False], IndexError, id="long-false-mask"),
+        pytest.param(np.array([], dtype=bool), IndexError, id="empty-bool"),
+        pytest.param([4], KeyError, id="missing-row"),
+    ],
+)
+def test_dataframe_setitem_loc_invalid_indexer(key, error, pandas_compatible):
+    pdf = pd.DataFrame({"a": [1, 2]})
+    with cudf.option_context("mode.pandas_compatible", pandas_compatible):
+        gdf = cudf.from_pandas(pdf)
+        for frame in (pdf, gdf):
+            with pytest.raises(error):
+                frame.loc[key] = 1.5
+
+        assert_eq(pdf, gdf, check_dtype=True)
+
+
+@pytest.mark.parametrize("pandas_compatible", [False, True])
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param([0], id="nonempty-list"),
+        pytest.param([True, False], id="nonempty-mask"),
+        pytest.param(([False, False], "a"), id="false-mask-scalar-column"),
+        pytest.param(([False, False], ["a"]), id="false-mask-column-list"),
+        pytest.param(
+            ([False, False], slice(None)), id="false-mask-all-columns"
+        ),
+    ],
+)
+def test_dataframe_setitem_loc_incompatible_scalar(key, pandas_compatible):
+    pdf = pd.DataFrame({"a": [1, 2]})
+    with cudf.option_context("mode.pandas_compatible", pandas_compatible):
+        gdf = cudf.from_pandas(pdf)
+        for frame in (pdf, gdf):
+            with pytest.raises(TypeError, match="Invalid value"):
+                frame.loc[key] = 1.5
+
+        assert_eq(pdf, gdf, check_dtype=True)
+
+
 @pytest.mark.parametrize(
     "key, value",
     [

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas_no_fallback.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas_no_fallback.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas_no_fallback.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas_no_fallback.py
@@ -120,6 +120,22 @@ def test_no_fallback_in_get_shape(dataframe):
     df.shape
 
 
+@pytest.mark.parametrize("mixed_dtypes", [False, True])
+@pytest.mark.parametrize(
+    "key", [[], [False, False], slice(0, -1), np.array([])]
+)
+def test_loc_setitem_empty_selection(key, mixed_dtypes):
+    data = {"a": [1, 2]}
+    if mixed_dtypes:
+        data["b"] = ["x", "y"]
+    df = pd.DataFrame(data)
+    expected = df.copy()
+
+    df.loc[key] = 1.5
+
+    pd.testing.assert_frame_equal(df, expected, check_exact=True)
+
+
 def test_no_fallback_in_array_ufunc_op(array):
     np.add(array, array)
 


### PR DESCRIPTION
## Description

Assigning a scalar to an empty DataFrame `.loc` selection currently validates the value against each column's dtype and can raise even though no rows will change. For example, `df.loc[[]] = 1.5` raises for an integer column instead of leaving the frame unchanged.

Return before scalar dtype validation for empty positional selections and bare all-false boolean masks. Preserve pandas' distinct behavior for explicit row-and-column boolean masks, validate mask lengths, and retain Series assignment and new-column behavior. Add direct cuDF regressions and `cudf.pandas` tests that prohibit CPU fallback.

Fixes #20720.

## Validation

- Direct DataFrame `.loc` and Series assignment suites: **484 passed, 10 xfailed**, including **52 new regression cases**.
- New `cudf.pandas` regressions with CPU fallback disabled: **8 passed**.
- All eight issue cases passed through `run-pandas-tests.sh` with both pandas plugins, including with fallback disabled during test execution.
- Broader pandas `tests/series/indexing/` run: **2,324 passed, 506 skipped, 177 xfailed**. Two timezone-comparison failures in `test_where_datetimelike_categorical` (`Asia/Tokyo`, `US/Eastern`) also reproduce on unmodified `main` at `310b5be6b3`.
- Ruff lint, formatting, and whitespace checks passed.
- Full local pre-commit setup was interrupted while installing hook environments; the full hook suite has not been verified locally.

Tests used pandas 3.0.3 and the checkout's Python source with existing compiled libraries. Broader tests required a temporary test-process alias from `apply_retention_mask` to the equivalent installed `apply_boolean_mask` API (renamed in #23700); no native rebuild was performed. The eight new fallback-disabled regressions pass without that alias.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. No documentation changes are needed for this compatibility fix.
