### PR TITLE
Isolate pandas plotting options between sharded tests

### DIFF
--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -90,6 +90,25 @@ def patch_testing_functions():
     pytest.raises = replace_kwargs({"match": None})(pytest.raises)
 
 
+@pytest.fixture(autouse=True)
+def restore_plotting_options(request):
+    # pandas' matplotlib cleanup restores figures and Matplotlib settings,
+    # but plotting options are a separate mutable global. Preserve them so
+    # tests that change xaxis.compat do not affect later plots on a worker.
+    if "mpl_cleanup" not in request.fixturenames:
+        yield
+        return
+
+    from pandas.plotting import plot_params
+
+    original = plot_params.copy()
+    try:
+        yield
+    finally:
+        plot_params.clear()
+        plot_params.update(original)
+
+
 # Node ids (matched by substring) whose only discrepancy from pandas is a
 # small (~1e-6) GPU-vs-CPU floating-point difference in transcendental numpy
 # ufuncs. Matching tests are tagged with the ``tolerant_index_compare`` marker
@@ -5279,10 +5298,6 @@ NODEIDS_TO_SKIP: dict[str, str] = {
 #: unsharded nightly and local runs keep exercising them -- skipping them
 #: everywhere would quietly drop the coverage instead of narrowing it.
 NODEIDS_TO_SKIP_WHEN_SHARDED: dict[str, str] = {
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[D]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[W]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[s]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_inferred_freq[ME]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
     "tests/strings/test_extract.py::test_extract_dataframe_capture_groups_index[bool-dtype-string=object]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
     "tests/strings/test_extract.py::test_extract_dataframe_capture_groups_index[categorical-string=object]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
     "tests/strings/test_extract.py::test_extract_dataframe_capture_groups_index[datetime-tz-string=object]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
@@ -5322,63 +5337,10 @@ NODEIDS_TO_SKIP_WHEN_SHARDED: dict[str, str] = {
     "tests/indexes/interval/test_interval.py::TestIntervalIndex::test_maybe_convert_i8_errors[scalar-datetime64[us, US/Eastern]-datetime64[us]]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/indexes/interval/test_interval.py::TestIntervalIndex::test_maybe_convert_i8_errors[scalar-datetime64[us, US/Eastern]-timedelta64[us]]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/indexes/multi/test_formats.py::TestRepr::test_tuple_width": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_memory_leak[area]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_memory_leak[line]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_plot_period_index_makes_no_right_shift[120min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_plot_period_index_makes_no_right_shift[3M]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_plot_period_index_makes_no_right_shift[7h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_plot_period_index_makes_no_right_shift[h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_scatter_line_xticks": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame.py::TestDataFramePlots::test_xcompat_plot_period": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/frame/test_frame_subplots.py::TestDataFramePlotsSubplots::test_subplots_timeseries[line]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_axis_limits[obj1]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_business_freq": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_check_xticks_rot": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_finder_annual": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_finder_hourly": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_finder_monthly": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_finder_quarterly": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_format_timedelta_ticks_wide[s]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_format_timedelta_ticks_wide[us]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[1B30Min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[QE-DEC]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_frame[YE]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_series[h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_series[min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_series[s]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_datetime_series[YE]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_inferred_freq[h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_inferred_freq[min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_frame[ME]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_frame[W]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[1s]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[3s]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[4D]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[5min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[7h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_frame[8W]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_series[11M]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_series[1s]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_series[3Y]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_mlt_series[7h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_series[h]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_series[M]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_series[min]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_line_plot_period_series[Q]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_mixed_freq_hf_first": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_mixed_freq_lf_first": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_mixed_freq_lf_first_hourly": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_mixed_freq_shared_ax": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/plotting/test_datetimelike.py::TestTSPlot::test_pickle_fig[DataFrame-idx0]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/plotting/test_datetimelike.py::TestTSPlot::test_pickle_fig[DataFrame-idx1]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/plotting/test_datetimelike.py::TestTSPlot::test_pickle_fig[Series-idx0]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/plotting/test_datetimelike.py::TestTSPlot::test_pickle_fig[Series-idx3]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_secondary_upsample": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_secondary_y_ts": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_to_weekly_resampling_disallow_how_kwd": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_ts_plot_format_coord[D-t = 2014-01-01  y = 1.000000]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_datetimelike.py::TestTSPlot::test_ts_plot_format_coord[YE-DEC-t = 2014  y = 1.000000]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
-    "tests/plotting/test_series.py::TestSeriesPlots::test_ts_area_lim": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/strings/test_api.py::test_api_per_method[index-empty1-rpartition1-category]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/strings/test_api.py::test_api_per_method[index-empty1-rpartition1-object]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/strings/test_api.py::test_api_per_method[index-empty1-rpartition2-category]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",

--- a/python/cudf/cudf_pandas_tests/test_pandas_testing_plugin.py
+++ b/python/cudf/cudf_pandas_tests/test_pandas_testing_plugin.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.parametrize("accelerated", [False, True])
+@pytest.mark.parametrize("fail_first", [False, True])
+def test_plotting_options_do_not_leak_between_tests(
+    pytester, accelerated, fail_first
+):
+    pytest.importorskip("matplotlib")
+    pytester.makeconftest(
+        """
+        from importlib import import_module
+
+        import matplotlib
+        import matplotlib.pyplot as plt
+        import pytest
+
+        restore_plotting_options = import_module(
+            "cudf.pandas.scripts.pandas-testing-plugin"
+        ).restore_plotting_options
+
+        @pytest.fixture(autouse=True)
+        def mpl_cleanup():
+            with matplotlib.rc_context():
+                matplotlib.use("template")
+                yield
+            plt.close("all")
+        """
+    )
+    pytester.makepyfile(
+        f"""
+        import pandas as pd
+
+        def test_change_plotting_options():
+            pd.plotting.plot_params["x_compat"] = True
+            pd.plotting.plot_params["custom"] = "changed"
+            assert {not fail_first!r}
+
+        def test_datetime_plot_uses_default_options():
+            assert pd.plotting.plot_params["x_compat"] is False
+            assert "custom" not in pd.plotting.plot_params
+            series = pd.Series(
+                [1, 2, 3], index=pd.date_range("2020-01-01", periods=3)
+            )
+            ax = series.plot()
+            assert ax.freq == "D"
+        """
+    )
+    args = ["-q"]
+    if accelerated:
+        args.extend(["-p", "cudf.pandas"])
+    result = pytester.runpytest_subprocess(*args)
+    result.assert_outcomes(passed=2 - fail_first, failed=int(fail_first))


### PR DESCRIPTION
## Description

Fix the plotting-state group in `NODEIDS_TO_SKIP_WHEN_SHARDED` (#22992).

`test_xcompat_plot_params` leaves the public pandas plotting option `xaxis.compat` enabled. An adjacent test normally resets it, but hashing those tests into different shards separates the mutation and reset. Later time-series plots then take the wrong plotting path. The same minimal polluter/victim pair fails with vanilla pandas, so this is test isolation, not a GPU plotting implementation bug.

Snapshot and restore pandas plotting options around tests using the existing `mpl_cleanup` fixture, including when a test fails. Remove the 57 shard-only skips reproduced by this leak. Four independent figure-pickling skips are handled separately.

## Validation

- Forced order: polluting test followed by all 61 previously skipped plotting cases, **57 failures / 5 passes before**, **62 passes after**.
- Regression tests for cleanup after successful/failed tests, with vanilla pandas and cudf.pandas: **4 passed**.
- Full plotting suite unsharded: **1,210 passed, zero failures**.
- Full plotting suite over both shards with all 61 skips removed: **1,210 passed, zero failures**; existing xfails/explicit non-strict xpasses unchanged.
- Ruff and whitespace checks passed.

Plotting intentionally executes through pandas/Matplotlib. This changes only test-state isolation; disabling CPU fallback is not applicable to this group. Tests used pandas 3.0.3 and local source Python with existing cuDF 26.10 native libraries, plus an external compatibility hook for the exact `apply_boolean_mask` → `apply_retention_mask` GPU API rename. No installed environment or vendored pandas tests were modified. Matching main native-library validation remains for CI.
