### PR TITLE
Reenable datetime literal validation after the native bounds fix

### DIFF
--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -5546,13 +5546,10 @@ NODEIDS_TO_SKIP_WHEN_SHARDED: dict[str, str] = {
     "tests/strings/test_strings.py::test_slice_replace[string=str[python]--10-3-z-expected7]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     "tests/strings/test_strings.py::test_slice_replace[string=str[python]-None--2-z-expected5]": "Skipped: failing in pandas-tests sharded CI (PR #22992, run 28204832469)",
     # Failing in sharded pandas-tests CI run 32294121723 (shard 1, job
-    # 96216291366). Both are nondeterministic rather than deterministic
-    # incompatibilities: test_stack_multiple_out_of_bounds[True] and the
-    # sibling unstack tests pass in the other shard, and
-    # test_to_datetime_iso8601_fails passed in the previous run of this
-    # same shard.
+    # 96216291366). Nondeterministic rather than a deterministic
+    # incompatibility: test_stack_multiple_out_of_bounds[True] and the
+    # sibling unstack tests pass in the other shard.
     "tests/frame/test_stack_unstack.py::TestStackUnstackMultiLevel::test_stack_multiple_out_of_bounds[False]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
-    "tests/tools/test_to_datetime.py::TestToDatetimeMisc::test_to_datetime_iso8601_fails[True-2012-01-01-%Y-%m-%d %H]": "Flaky under test sharding: cudf.pandas behavior is test-order-dependent (see #22992)",
 }
 
 # Keep keys in alphabetical order


### PR DESCRIPTION
## Draft: matching-native CI verification required

Remove the datetime format-literal validation skip from `NODEIDS_TO_SKIP_WHEN_SHARDED` after the already-merged native fix #23712 (commit `1ffbf2c8e44`, closes #23660).

The exact skipped input is `2012-01-01` with format `%Y-%m-%d %H`. The parser previously read the required space after the input had ended. Main now checks the remaining input length before dereferencing a format literal; `StringsDatetimeTest.IsTimestampLiteralOverrun` covers this operation.

## Evidence and local limitation

The available installed native library is cuDF 26.10, older than the fix. It still reproduces the bug deterministically:

```python
cudf.Series(['2012-01-01', ' 0'])._column.is_timestamp('%Y-%m-%d %H')
# [True, False] -- the missing space is read from the next row
cudf.Series(['2012-01-01', ' x'])._column.is_timestamp('%Y-%m-%d %H')
# [False, False]
```

The merged length guard rejects the first row before either invalid read. The exact pandas test can pass alone with the old library but fails in the broader shard; an isolated pass is **not** evidence that fixed native code was tested.

This draft is a minimal marker cleanup, not a new native implementation. It must pass CI with native libraries built from matching main sources before being marked ready. All applicable local pre-commit hooks pass. No installed-environment or native-source modifications were made.
