### PR TITLE
Fix update of `libcudf-streaming-tests`

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -158,6 +158,7 @@ DEPENDENCIES=(
   libcudf
   libcudf-example
   libcudf-streaming
+  libcudf-streaming-tests
   libcudf-tests
   libcudf_kafka
   libkvikio

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1137,7 +1137,7 @@ dependencies:
           - libcudf-example==26.12.*,>=0.0.0a0
           - libcudf_kafka==26.12.*,>=0.0.0a0
           - libcudf-tests==26.12.*,>=0.0.0a0
-          - libcudf-streaming-tests==26.10.*,>=0.0.0a0
+          - libcudf-streaming-tests==26.12.*,>=0.0.0a0
   test_python_common:
     common:
       - output_types: [conda, requirements, constraints, pyproject]


### PR DESCRIPTION
## Description
When `libcudf-streaming-tests` was added in
https://github.com/NVIDIA/cudf/pull/22871, `ci/release/update-version.sh` was not updated accordingly. Update the CI script and update the version in `dependencies.yaml`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
