### PR TITLE
Route copy_if, reduce, and label_segments through memory resources

### DIFF
--- a/cpp/include/cudf/detail/algorithms/copy_if.cuh
+++ b/cpp/include/cudf/detail/algorithms/copy_if.cuh
@@ -37,6 +37,7 @@ namespace cudf::detail {
  * @param result Device-accessible iterator to start of output values
  * @param predicate Unary predicate that returns true for elements to copy
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return Iterator pointing to the end of the output range
  */
 template <typename InputIterator,
@@ -48,12 +49,13 @@ OutputIterator copy_if(InputIterator begin,
                        StencilIterator stencil,
                        OutputIterator result,
                        Predicate predicate,
-                       cuda::stream_ref stream)
+                       cuda::stream_ref stream,
+                       cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
+  auto const temp_mr   = mr.get_temporary_mr();
 
-  auto num_selected =
-    cudf::detail::device_scalar<cuda::std::size_t>(stream, cudf::get_current_device_resource_ref());
+  auto num_selected = cudf::detail::device_scalar<cuda::std::size_t>(stream, temp_mr);
 
   auto temp_storage_bytes = std::size_t{0};
   CUDF_CUDA_TRY(cub::DeviceSelect::FlaggedIf(nullptr,
@@ -66,8 +68,7 @@ OutputIterator copy_if(InputIterator begin,
                                              predicate,
                                              stream.get()));
 
-  auto d_temp_storage =
-    rmm::device_buffer(temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  auto d_temp_storage = rmm::device_buffer(temp_storage_bytes, stream, temp_mr);
 
   CUDF_CUDA_TRY(cub::DeviceSelect::FlaggedIf(d_temp_storage.data(),
                                              temp_storage_bytes,
@@ -98,6 +99,7 @@ OutputIterator copy_if(InputIterator begin,
  * @param output Device-accessible iterator to start of output values
  * @param predicate Unary predicate that returns true for elements to copy
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return Iterator pointing to the end of the output range
  */
 template <typename Predicate, typename InputIterator, typename OutputIterator>
@@ -105,13 +107,14 @@ OutputIterator copy_if(InputIterator begin,
                        InputIterator end,
                        OutputIterator output,
                        Predicate predicate,
-                       cuda::stream_ref stream)
+                       cuda::stream_ref stream,
+                       cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
+  auto const temp_mr   = mr.get_temporary_mr();
 
   // Device scalar to store the number of selected elements
-  auto num_selected =
-    cudf::detail::device_scalar<cuda::std::size_t>(stream, cudf::get_current_device_resource_ref());
+  auto num_selected = cudf::detail::device_scalar<cuda::std::size_t>(stream, temp_mr);
 
   // First call to get temporary storage size
   size_t temp_storage_bytes = 0;
@@ -125,8 +128,7 @@ OutputIterator copy_if(InputIterator begin,
                                       stream.get()));
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  rmm::device_buffer d_temp_storage(temp_storage_bytes, stream, temp_mr);
 
   // Run copy_if
   CUDF_CUDA_TRY(cub::DeviceSelect::If(d_temp_storage.data(),
@@ -154,7 +156,8 @@ void copy_if_async(InputIterator begin,
                    InputIterator end,
                    OutputIterator output,
                    Predicate predicate,
-                   cuda::stream_ref stream)
+                   cuda::stream_ref stream,
+                   cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
 
@@ -163,7 +166,7 @@ void copy_if_async(InputIterator begin,
   CUDF_CUDA_TRY(cub::DeviceSelect::If(
     nullptr, tmp_bytes, begin, output, no_out, num_items, predicate, stream.get()));
 
-  auto tmp_stg = rmm::device_buffer(tmp_bytes, stream, cudf::get_current_device_resource_ref());
+  auto tmp_stg = rmm::device_buffer(tmp_bytes, stream, mr.get_temporary_mr());
   CUDF_CUDA_TRY(cub::DeviceSelect::If(
     tmp_stg.data(), tmp_bytes, begin, output, no_out, num_items, predicate, stream.get()));
 }
@@ -184,7 +187,8 @@ void copy_if_async(InputIterator begin,
                    StencilIterator stencil,
                    OutputIterator result,
                    Predicate predicate,
-                   cuda::stream_ref stream)
+                   cuda::stream_ref stream,
+                   cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
 
@@ -193,7 +197,7 @@ void copy_if_async(InputIterator begin,
   CUDF_CUDA_TRY(cub::DeviceSelect::FlaggedIf(
     nullptr, tmp_bytes, begin, stencil, result, no_out, num_items, predicate, stream.get()));
 
-  auto tmp = rmm::device_buffer(tmp_bytes, stream, cudf::get_current_device_resource_ref());
+  auto tmp = rmm::device_buffer(tmp_bytes, stream, mr.get_temporary_mr());
   CUDF_CUDA_TRY(cub::DeviceSelect::FlaggedIf(
     tmp.data(), tmp_bytes, begin, stencil, result, no_out, num_items, predicate, stream.get()));
 }

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -33,25 +33,29 @@ namespace cudf::detail {
  * @param init Initial value for the reduction
  * @param binary_op Binary reduction operator
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return The reduction result
  */
 template <typename Op,
           typename InputIterator,
           typename OutputType = cuda::std::iter_value_t<InputIterator>>
-OutputType reduce(
-  InputIterator begin, InputIterator end, OutputType init, Op binary_op, cuda::stream_ref stream)
+OutputType reduce(InputIterator begin,
+                  InputIterator end,
+                  OutputType init,
+                  Op binary_op,
+                  cuda::stream_ref stream,
+                  cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
+  auto const temp_mr   = mr.get_temporary_mr();
 
   // Device scalar to store the result
-  auto result =
-    cudf::detail::device_scalar<OutputType>(stream, cudf::get_current_device_resource_ref());
+  auto result = cudf::detail::device_scalar<OutputType>(stream, temp_mr);
 
   // Build environment with stream and memory resource for cub::DeviceReduce::Reduce
   auto env = cuda::std::execution::env{
-    cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream.get()}},
-    cuda::std::execution::prop{cuda::mr::get_memory_resource_t{},
-                               cudf::get_current_device_resource_ref()}};
+    cuda::std::execution::prop{cuda::get_stream_t{}, stream},
+    cuda::std::execution::prop{cuda::mr::get_memory_resource_t{}, temp_mr}};
   CUDF_CUDA_TRY(cub::DeviceReduce::Reduce(begin, result.data(), num_items, binary_op, init, env));
 
   // Copy result back to host via pinned memory
@@ -80,6 +84,7 @@ OutputType reduce(
  * @param values_output Device-accessible iterator to start of output reduced values
  * @param op Binary reduction operator
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return A pair of iterators pointing to the end of the output key and value ranges
  */
 template <typename Op,
@@ -94,13 +99,14 @@ cuda::std::pair<KeysOutputIterator, ValuesOutputIterator> reduce_by_key(
   KeysOutputIterator keys_output,
   ValuesOutputIterator values_output,
   Op op,
-  cuda::stream_ref stream)
+  cuda::stream_ref stream,
+  cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(keys_begin, keys_end);
+  auto const temp_mr   = mr.get_temporary_mr();
 
   // Device scalar to store the number of runs (unique keys)
-  auto d_num_runs =
-    cudf::detail::device_scalar<cuda::std::size_t>(stream, cudf::get_current_device_resource_ref());
+  auto d_num_runs = cudf::detail::device_scalar<cuda::std::size_t>(stream, temp_mr);
 
   // First call to get temporary storage size
   size_t temp_storage_bytes = 0;
@@ -116,8 +122,7 @@ cuda::std::pair<KeysOutputIterator, ValuesOutputIterator> reduce_by_key(
                                                stream.get()));
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  rmm::device_buffer d_temp_storage(temp_storage_bytes, stream, temp_mr);
 
   // Run reduce-by-key
   CUDF_CUDA_TRY(cub::DeviceReduce::ReduceByKey(d_temp_storage.data(),
@@ -156,7 +161,8 @@ void reduce_by_key_async(KeysInputIterator keys_begin,
                          KeysOutputIterator keys_output,
                          ValuesOutputIterator values_output,
                          Op op,
-                         cuda::stream_ref stream)
+                         cuda::stream_ref stream,
+                         cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(keys_begin, keys_end);
 
@@ -172,8 +178,7 @@ void reduce_by_key_async(KeysInputIterator keys_begin,
                                                num_items,
                                                stream.get()));
 
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  rmm::device_buffer d_temp_storage(temp_storage_bytes, stream, mr.get_temporary_mr());
 
   CUDF_CUDA_TRY(cub::DeviceReduce::ReduceByKey(d_temp_storage.data(),
                                                temp_storage_bytes,
@@ -206,6 +211,7 @@ void reduce_by_key_async(KeysInputIterator keys_begin,
  * @param init Initial value for the reduction
  * @param reduce_op Binary reduction operator
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return The reduction result
  */
 template <typename TransformationOp,
@@ -217,13 +223,14 @@ OutputType transform_reduce(InputIterator begin,
                             TransformationOp transform_op,
                             OutputType init,
                             ReductionOp reduce_op,
-                            cuda::stream_ref stream)
+                            cuda::stream_ref stream,
+                            cudf::memory_resources mr)
 {
   auto const num_items = cuda::std::distance(begin, end);
+  auto const temp_mr   = mr.get_temporary_mr();
 
   // Device scalar to store the result
-  auto result =
-    cudf::detail::device_scalar<OutputType>(stream, cudf::get_current_device_resource_ref());
+  auto result = cudf::detail::device_scalar<OutputType>(stream, temp_mr);
 
   size_t temp_storage_bytes = 0;
   CUDF_CUDA_TRY(cub::DeviceReduce::TransformReduce(nullptr,
@@ -236,8 +243,7 @@ OutputType transform_reduce(InputIterator begin,
                                                    init,
                                                    stream.get()));
 
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  rmm::device_buffer d_temp_storage(temp_storage_bytes, stream, temp_mr);
   CUDF_CUDA_TRY(cub::DeviceReduce::TransformReduce(d_temp_storage.data(),
                                                    temp_storage_bytes,
                                                    begin,
@@ -265,12 +271,17 @@ OutputType transform_reduce(InputIterator begin,
  * @param end Device-accessible iterator to end of input values
  * @param op Predicate operator to apply to each element
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return true if the predicate is true for all elements, false otherwise
  */
 template <typename TransformOp, typename InputIterator>
-bool all_of(InputIterator begin, InputIterator end, TransformOp op, cuda::stream_ref stream)
+bool all_of(InputIterator begin,
+            InputIterator end,
+            TransformOp op,
+            cuda::stream_ref stream,
+            cudf::memory_resources mr)
 {
-  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream, mr);
 }
 
 /**
@@ -286,12 +297,17 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, cuda::stream
  * @param end Device-accessible iterator to end of input values
  * @param op Predicate operator to apply to each element
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return true if the predicate is true for any element, false otherwise
  */
 template <typename TransformOp, typename InputIterator>
-bool any_of(InputIterator begin, InputIterator end, TransformOp op, cuda::stream_ref stream)
+bool any_of(InputIterator begin,
+            InputIterator end,
+            TransformOp op,
+            cuda::stream_ref stream,
+            cudf::memory_resources mr)
 {
-  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream, mr);
 }
 
 /**
@@ -307,12 +323,17 @@ bool any_of(InputIterator begin, InputIterator end, TransformOp op, cuda::stream
  * @param end Device-accessible iterator to end of input values
  * @param op Predicate operator to apply to each element
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return true if the predicate is false for all elements, false otherwise
  */
 template <typename TransformOp, typename InputIterator>
-bool none_of(InputIterator begin, InputIterator end, TransformOp op, cuda::stream_ref stream)
+bool none_of(InputIterator begin,
+             InputIterator end,
+             TransformOp op,
+             cuda::stream_ref stream,
+             cudf::memory_resources mr)
 {
-  return not any_of(begin, end, op, stream);
+  return not any_of(begin, end, op, stream, mr);
 }
 
 /**
@@ -329,13 +350,15 @@ bool none_of(InputIterator begin, InputIterator end, TransformOp op, cuda::strea
  * @param end Device-accessible iterator to end of input values
  * @param predicate Unary predicate that returns true for elements to count
  * @param stream CUDA stream to use
+ * @param mr Device memory resources to use
  * @return The count of elements satisfying the predicate
  */
 template <typename Predicate, typename InputIterator>
 cuda::std::size_t count_if(InputIterator begin,
                            InputIterator end,
                            Predicate predicate,
-                           cuda::stream_ref stream)
+                           cuda::stream_ref stream,
+                           cudf::memory_resources mr)
 {
   // Transform each element to 0 or 1 based on predicate, then sum
   auto transform_op = [predicate] __device__(auto const& val) -> cuda::std::size_t {
@@ -343,7 +366,7 @@ cuda::std::size_t count_if(InputIterator begin,
   };
 
   return transform_reduce(
-    begin, end, transform_op, cuda::std::size_t{0}, cuda::std::plus<>{}, stream);
+    begin, end, transform_op, cuda::std::size_t{0}, cuda::std::plus<>{}, stream, mr);
 }
 
 }  // namespace cudf::detail

--- a/cpp/include/cudf/detail/labeling/label_segments.cuh
+++ b/cpp/include/cudf/detail/labeling/label_segments.cuh
@@ -173,13 +173,16 @@ void labels_to_offsets(InputIterator labels_begin,
   auto list_sizes = rmm::device_uvector<OutputType>(num_segments, stream);
 
   // Count the numbers of labels in the each segment.
-  auto const end = cudf::detail::reduce_by_key(labels_begin,  // keys
-                                               labels_end,
-                                               cuda::make_constant_iterator<OutputType>(1),
-                                               list_indices.begin(),  // output unique label values
-                                               list_sizes.begin(),    // count for each label
-                                               cuda::std::plus<OutputType>(),
-                                               stream);
+  auto const end =
+    cudf::detail::reduce_by_key(labels_begin,  // keys
+                                labels_end,
+                                cuda::make_constant_iterator<OutputType>(1),
+                                list_indices.begin(),  // output unique label values
+                                list_sizes.begin(),    // count for each label
+                                cuda::std::plus<OutputType>(),
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()});
 
   auto const num_non_empty_segments = cuda::std::distance(list_indices.begin(), end.first);
 

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -157,11 +157,14 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::column_view const& lh
                                                      rmm::device_async_resource_ref mr)
 {
   auto gather_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
-  auto const gather_map_end = cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
-                                                    cuda::counting_iterator<size_type>{size},
-                                                    gather_map.begin(),
-                                                    is_left,
-                                                    stream);
+  auto const gather_map_end =
+    cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
+                          cuda::counting_iterator<size_type>{size},
+                          gather_map.begin(),
+                          is_left,
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   gather_map.resize(cuda::std::distance(gather_map.begin(), gather_map_end), stream);
 
@@ -191,11 +194,14 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::scalar const& lhs,
                                                      rmm::device_async_resource_ref mr)
 {
   auto scatter_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
-  auto const scatter_map_end = cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
-                                                     cuda::counting_iterator<size_type>{size},
-                                                     scatter_map.begin(),
-                                                     is_left,
-                                                     stream);
+  auto const scatter_map_end =
+    cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
+                          cuda::counting_iterator<size_type>{size},
+                          scatter_map.begin(),
+                          is_left,
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   auto const scatter_map_size  = std::distance(scatter_map.begin(), scatter_map_end);
   auto scatter_source          = std::vector<std::reference_wrapper<scalar const>>{std::ref(lhs)};

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -45,7 +45,9 @@ bool has_nonempty_null_rows(cudf::column_view const& input, cuda::stream_ref str
 
   auto const row_begin = cuda::counting_iterator<cudf::size_type>{0};
   auto const row_end   = row_begin + input.size();
-  return cudf::detail::count_if(row_begin, row_end, is_dirty_row, stream) > 0;
+  auto const temp_mr   = cudf::get_current_device_resource_ref();
+  return cudf::detail::count_if(
+           row_begin, row_end, is_dirty_row, stream, cudf::memory_resources{temp_mr, temp_mr}) > 0;
 }
 
 }  // namespace

--- a/cpp/src/groupby/sort/group_bitwise.cu
+++ b/cpp/src/groupby/sort/group_bitwise.cu
@@ -38,6 +38,7 @@ struct bitwise_group_reduction_functor {
       make_fixed_width_column(values.type(), num_groups, mask_state::UNALLOCATED, stream, mr);
     if (values.is_empty()) { return result; }
 
+    auto const temp_mr      = cudf::get_current_device_resource_ref();
     auto const do_reduction = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
       cudf::detail::reduce_by_key_async(group_labels.data(),
                                         group_labels.data() + group_labels.size(),
@@ -45,7 +46,8 @@ struct bitwise_group_reduction_functor {
                                         cuda::make_discard_iterator(),
                                         out_iter,
                                         binop,
-                                        stream);
+                                        stream,
+                                        cudf::memory_resources{temp_mr, temp_mr});
     };
 
     auto const d_values_ptr       = column_device_view::create(values, stream);

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -149,13 +149,15 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
   auto corr_iter =
     cudf::detail::make_counting_transform_iterator(cudf::size_type{0}, covariance_transform_op);
 
+  auto const temp_mr = cudf::get_current_device_resource_ref();
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
                                     corr_iter,
                                     cuda::make_discard_iterator(),
                                     d_result,
                                     cuda::std::plus<result_type>(),
-                                    stream);
+                                    stream,
+                                    cudf::memory_resources{temp_mr, temp_mr});
 
   auto is_null = [ddof, min_periods] __device__(size_type group_size) {
     return not(group_size == 0 or group_size - ddof <= 0 or group_size < min_periods);

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -46,21 +46,27 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
                                cuda::proclaim_return_type<size_type>(
                                  [] __device__(auto b) { return static_cast<size_type>(b); }));
 
-    cudf::detail::reduce_by_key_async(group_labels.begin(),
-                                      group_labels.end(),
-                                      bitmask_iterator,
-                                      cuda::make_discard_iterator(),
-                                      result->mutable_view().begin<size_type>(),
-                                      cuda::std::plus<size_type>(),
-                                      stream);
+    cudf::detail::reduce_by_key_async(
+      group_labels.begin(),
+      group_labels.end(),
+      bitmask_iterator,
+      cuda::make_discard_iterator(),
+      result->mutable_view().begin<size_type>(),
+      cuda::std::plus<size_type>(),
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
   } else {
-    cudf::detail::reduce_by_key_async(group_labels.begin(),
-                                      group_labels.end(),
-                                      cuda::make_constant_iterator(1),
-                                      cuda::make_discard_iterator(),
-                                      result->mutable_view().begin<size_type>(),
-                                      cuda::std::plus<size_type>(),
-                                      stream);
+    cudf::detail::reduce_by_key_async(
+      group_labels.begin(),
+      group_labels.end(),
+      cuda::make_constant_iterator(1),
+      cuda::make_discard_iterator(),
+      result->mutable_view().begin<size_type>(),
+      cuda::std::plus<size_type>(),
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
   }
 
   return result;

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -67,13 +67,16 @@ void compute_m2_fn(column_device_view const& values,
                     m2_vals.begin(),
                     m2_fn);
 
-  cudf::detail::reduce_by_key_async(group_labels.begin(),
-                                    group_labels.end(),
-                                    m2_vals.begin(),
-                                    cuda::make_discard_iterator(),
-                                    d_result,
-                                    cuda::std::plus<ResultType>(),
-                                    stream);
+  cudf::detail::reduce_by_key_async(
+    group_labels.begin(),
+    group_labels.end(),
+    m2_vals.begin(),
+    cuda::make_discard_iterator(),
+    d_result,
+    cuda::std::plus<ResultType>(),
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 }
 
 struct m2_functor {

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -86,13 +86,16 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
     rmm::device_uvector<size_type> group_count = [&] {
       if (n < 0) {
         rmm::device_uvector<size_type> group_count(num_groups, stream);
-        cudf::detail::reduce_by_key_async(group_labels.begin(),
-                                          group_labels.end(),
-                                          bitmask_iterator,
-                                          cuda::make_discard_iterator(),
-                                          group_count.begin(),
-                                          cuda::std::plus<size_type>(),
-                                          stream);
+        cudf::detail::reduce_by_key_async(
+          group_labels.begin(),
+          group_labels.end(),
+          bitmask_iterator,
+          cuda::make_discard_iterator(),
+          group_count.begin(),
+          cuda::std::plus<size_type>(),
+          stream,
+          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                 cudf::get_current_device_resource_ref()});
         return group_count;
       } else {
         return rmm::device_uvector<size_type>(0, stream);

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -118,7 +118,8 @@ std::unique_ptr<column> group_nunique(column_view const& values,
                                     cuda::make_discard_iterator(),
                                     result->mutable_view().begin<size_type>(),
                                     cuda::std::plus<size_type>(),
-                                    stream);
+                                    stream,
+                                    cudf::memory_resources{temp_mr, temp_mr});
 
   return result;
 }

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -79,13 +79,16 @@ void reduce_by_key_fn(column_device_view const& values,
                     vars.begin(),
                     var_fn);
 
-  cudf::detail::reduce_by_key_async(group_labels.begin(),
-                                    group_labels.end(),
-                                    vars.begin(),
-                                    cuda::make_discard_iterator(),
-                                    d_result,
-                                    cuda::std::plus<ResultType>(),
-                                    stream);
+  cudf::detail::reduce_by_key_async(
+    group_labels.begin(),
+    group_labels.end(),
+    vars.begin(),
+    cuda::make_discard_iterator(),
+    d_result,
+    cuda::std::plus<ResultType>(),
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 }
 
 struct var_functor {

--- a/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
+++ b/cpp/src/groupby/sort/sort_helper_group_offsets.cuh
@@ -51,8 +51,13 @@ size_type compute_group_offsets(table_view const& keys,
   auto const ufn    = cudf::detail::unique_copy_fn<decltype(itr), decltype(row_eq)>{
     itr, duplicate_keep_option::KEEP_FIRST, row_eq, size - 1};
   thrust::transform(rmm::exec_policy_nosync(stream, temp_mr), itr, itr + size, result.begin(), ufn);
-  auto const result_end = cudf::detail::copy_if(
-    itr, itr + size, result.begin(), group_offsets.begin(), cuda::std::identity{}, stream);
+  auto const result_end = cudf::detail::copy_if(itr,
+                                                itr + size,
+                                                result.begin(),
+                                                group_offsets.begin(),
+                                                cuda::std::identity{},
+                                                stream,
+                                                cudf::memory_resources{temp_mr, temp_mr});
   return cuda::std::distance(group_offsets.begin(), result_end);
 }
 

--- a/cpp/src/io/json/column_tree_construction.cu
+++ b/cpp/src/io/json/column_tree_construction.cu
@@ -193,13 +193,16 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
                            parent_col_ids.end());
     rmm::device_uvector<NodeIndexT> non_leaf_nodes(num_non_leaf_columns, stream);
     rmm::device_uvector<NodeIndexT> non_leaf_nodes_children(num_non_leaf_columns, stream);
-    cudf::detail::reduce_by_key_async(parent_col_ids.begin() + 1,
-                                      parent_col_ids.end(),
-                                      cuda::make_constant_iterator(1),
-                                      non_leaf_nodes.begin(),
-                                      non_leaf_nodes_children.begin(),
-                                      cuda::std::plus<NodeIndexT>(),
-                                      stream);
+    cudf::detail::reduce_by_key_async(
+      parent_col_ids.begin() + 1,
+      parent_col_ids.end(),
+      cuda::make_constant_iterator(1),
+      non_leaf_nodes.begin(),
+      non_leaf_nodes_children.begin(),
+      cuda::std::plus<NodeIndexT>(),
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
 
     thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     non_leaf_nodes_children.begin(),

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -1090,7 +1090,9 @@ void scatter_offsets(tree_meta_t const& tree,
              column_categories[col_ids[parent_node_id]] == NC_LIST and
              (!d_ignore_vals[col_ids[parent_node_id]]);
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
   // For children of list and in ignore_vals, find it's parent node id, and set corresponding
   // parent's null mask to null. Setting mixed type list rows to null.
   auto const num_list_children = cuda::std::distance(

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -287,7 +287,13 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
   }
 
   auto const num_tokens = tokens.size();
-  auto const num_nodes  = cudf::detail::count_if(tokens.begin(), tokens.end(), is_node, stream);
+  auto const num_nodes =
+    cudf::detail::count_if(tokens.begin(),
+                           tokens.end(),
+                           is_node,
+                           stream,
+                           cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                  cudf::get_current_device_resource_ref()});
 
   // Node levels: transform_exclusive_scan, copy_if.
   rmm::device_uvector<TreeDepthT> node_levels(num_nodes, stream, mr);
@@ -309,12 +315,15 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
                            token_level_output_it,
                            size_type{0});
 
-    auto const node_levels_end = cudf::detail::copy_if(token_levels.begin(),
-                                                       token_levels.end(),
-                                                       tokens.begin(),
-                                                       node_levels.begin(),
-                                                       is_node,
-                                                       stream);
+    auto const node_levels_end =
+      cudf::detail::copy_if(token_levels.begin(),
+                            token_levels.end(),
+                            tokens.begin(),
+                            node_levels.begin(),
+                            is_node,
+                            stream,
+                            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                   cudf::get_current_device_resource_ref()});
     CUDF_EXPECTS(
       !depth_out_of_range.value(stream),
       "JSON token nesting depth is outside the supported range for TreeDepthT [" +
@@ -337,7 +346,9 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
                                 tokens.begin(),
                                 node_token_ids.begin(),
                                 is_node,
-                                stream);
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()});
 
     // previous push node_id
     // if previous node is a push, then i-1
@@ -387,7 +398,13 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
   auto const node_categories_it =
     cuda::make_transform_output_iterator(node_categories.begin(), token_to_node{});
   auto const node_categories_end =
-    cudf::detail::copy_if(tokens.begin(), tokens.end(), node_categories_it, is_node, stream);
+    cudf::detail::copy_if(tokens.begin(),
+                          tokens.end(),
+                          node_categories_it,
+                          is_node,
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
   CUDF_EXPECTS(cuda::std::distance(node_categories_it, node_categories_end) ==
                  static_cast<std::ptrdiff_t>(num_nodes),
                "node category count mismatch");
@@ -410,7 +427,9 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
     [is_node, tokens_gpu = tokens.begin()] __device__(size_type i) -> bool {
       return is_node(tokens_gpu[i]);
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
   CUDF_EXPECTS(cuda::std::distance(node_range_out_it, node_range_out_end) ==
                  static_cast<std::ptrdiff_t>(num_nodes),
                "node range count mismatch");
@@ -432,7 +451,13 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
         default: return false;
       };
     };
-    auto const num_nested = cudf::detail::count_if(tokens.begin(), tokens.end(), is_nested, stream);
+    auto const num_nested =
+      cudf::detail::count_if(tokens.begin(),
+                             tokens.end(),
+                             is_nested,
+                             stream,
+                             cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                    cudf::get_current_device_resource_ref()});
     rmm::device_uvector<TreeDepthT> token_levels(num_nested, stream);
     rmm::device_uvector<NodeIndexT> token_id(num_nested, stream);
     rmm::device_uvector<NodeIndexT> parent_node_ids(num_nested, stream);
@@ -451,8 +476,14 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
     auto zipped_in_it =
       cuda::make_zip_iterator(push_pop_it, cuda::counting_iterator<NodeIndexT>{0});
     auto zipped_out_it = cuda::make_zip_iterator(token_levels.begin(), token_id.begin());
-    cudf::detail::copy_if_async(
-      zipped_in_it, zipped_in_it + num_tokens, tokens.begin(), zipped_out_it, is_nested, stream);
+    cudf::detail::copy_if_async(zipped_in_it,
+                                zipped_in_it + num_tokens,
+                                tokens.begin(),
+                                zipped_out_it,
+                                is_nested,
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()});
 
     thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            token_levels.begin(),
@@ -768,7 +799,9 @@ get_array_children_indices(TreeDepthT row_array_children_level,
     [row_array_children_level] __device__(auto level) -> bool {
       return level == row_array_children_level;
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
   auto level2_parent_nodes =
     cuda::make_permutation_iterator(parent_node_ids.begin(), level2_nodes.cbegin());
   thrust::exclusive_scan_by_key(

--- a/cpp/src/io/orc/reader_impl_decode.cu
+++ b/cpp/src/io/orc/reader_impl_decode.cu
@@ -312,7 +312,9 @@ void update_null_mask(cudf::detail::hostdevice_2dvector<column_desc>& chunks,
           [parent_valid_map_base] __device__(auto idx) -> bool {
             return bit_is_set(parent_valid_map_base, idx);
           },
-          stream);
+          stream,
+          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                 cudf::get_current_device_resource_ref()});
 
         auto merged_null_mask = cudf::detail::create_null_mask(
           parent_mask_len, mask_state::ALL_NULL, cuda::stream_ref(stream), mr);

--- a/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
@@ -165,8 +165,13 @@ void hybrid_scan_reader_impl::setup_next_pass(
       }
       auto chunk_iter = cuda::transform_iterator(pass.chunks.d_begin(),
                                                  parquet::detail::get_chunk_compressed_size{});
-      return cudf::detail::reduce(
-        chunk_iter, chunk_iter + pass.chunks.size(), size_t{0}, cuda::std::plus<size_t>{}, _stream);
+      return cudf::detail::reduce(chunk_iter,
+                                  chunk_iter + pass.chunks.size(),
+                                  size_t{0},
+                                  cuda::std::plus<size_t>{},
+                                  _stream,
+                                  cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                         cudf::get_current_device_resource_ref()});
     }();
     pass.base_mem_size = decomp_dict_data_size + compressed_data_size;
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
@@ -405,7 +405,9 @@ bool hybrid_scan_reader_impl::are_all_rows_pruned(cudf::column_view const& row_m
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{row_mask.size()},
     is_row_pruned_fn{row_mask.nullable(), row_mask.begin<bool>(), row_mask.null_mask()},
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 }
 
 void hybrid_scan_reader_impl::update_row_mask(cudf::column_view const& in_row_mask,

--- a/cpp/src/io/parquet/experimental/page_index_filter.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter.cu
@@ -206,11 +206,14 @@ struct page_stats_caster : public stats_caster_base {
                    row_str_sizes.begin());
 
     // Total bytes in the output chars buffer
-    auto const total_bytes = cudf::detail::reduce(row_str_sizes.begin(),
-                                                  row_str_sizes.end(),
-                                                  std::size_t{0},
-                                                  cuda::std::plus<std::size_t>{},
-                                                  stream);
+    auto const total_bytes =
+      cudf::detail::reduce(row_str_sizes.begin(),
+                           row_str_sizes.end(),
+                           std::size_t{0},
+                           cuda::std::plus<std::size_t>{},
+                           stream,
+                           cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                  cudf::get_current_device_resource_ref()});
 
     CUDF_EXPECTS(
       total_bytes <= cuda::std::numeric_limits<cudf::size_type>::max(),
@@ -1014,7 +1017,9 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
       cudf::detail::all_of(row_mask.template begin<bool>() + row_mask_offset,
                            row_mask.template begin<bool>() + row_mask_offset + total_rows,
                            cuda::std::identity{},
-                           stream)) {
+                           stream,
+                           cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                  cudf::get_current_device_resource_ref()})) {
     return thrust::host_vector<bool>(0);
   }
 

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -501,12 +501,15 @@ uint32_t get_aggregated_decode_kernel_mask(cudf::detail::hostdevice_span<PageInf
                                            cuda::stream_ref stream)
 {
   // determine which kernels to invoke
-  return cudf::detail::transform_reduce(pages.device_begin(),
-                                        pages.device_end(),
-                                        mask_tform{},
-                                        uint32_t{0},
-                                        cuda::std::bit_or<uint32_t>{},
-                                        stream);
+  return cudf::detail::transform_reduce(
+    pages.device_begin(),
+    pages.device_end(),
+    mask_tform{},
+    uint32_t{0},
+    cuda::std::bit_or<uint32_t>{},
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 }
 
 /**

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -3475,8 +3475,15 @@ void EncodePages(device_span<EncPage> pages,
   auto num_pages = pages.size();
 
   // determine which kernels to invoke
-  auto kernel_mask = cudf::detail::transform_reduce(
-    pages.begin(), pages.end(), mask_tform{}, uint32_t{0}, cuda::std::bit_or<uint32_t>{}, stream);
+  auto kernel_mask =
+    cudf::detail::transform_reduce(pages.begin(),
+                                   pages.end(),
+                                   mask_tform{},
+                                   uint32_t{0},
+                                   cuda::std::bit_or<uint32_t>{},
+                                   stream,
+                                   cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                          cudf::get_current_device_resource_ref()});
 
   // get the number of streams we need from the pool
   int nkernels = std::bitset<32>(kernel_mask).count();

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1022,18 +1022,23 @@ void compute_page_string_sizes_pass2(cudf::detail::hostdevice_span<PageInfo> pag
                          pages.device_end(),
                          cuda::proclaim_return_type<bool>(
                            [] __device__(auto const& page) { return page.temp_string_size != 0; }),
-                         stream);
+                         stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()});
 
   if (need_sizes) {
     // sum up all of the temp_string_sizes
     auto const page_sizes = cuda::proclaim_return_type<int64_t>(
       [] __device__(PageInfo const& page) { return page.temp_string_size; });
-    auto const total_size = cudf::detail::transform_reduce(pages.device_begin(),
-                                                           pages.device_end(),
-                                                           page_sizes,
-                                                           int64_t{0},
-                                                           cuda::std::plus<int64_t>{},
-                                                           stream);
+    auto const total_size = cudf::detail::transform_reduce(
+      pages.device_begin(),
+      pages.device_end(),
+      page_sizes,
+      int64_t{0},
+      cuda::std::plus<int64_t>{},
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
 
     // now do an exclusive scan over the temp_string_sizes to get offsets for each
     // page's chunk of the temp buffer

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -170,8 +170,13 @@ void reader_impl::setup_next_pass(read_mode mode)
     auto chunk_iter = cuda::transform_iterator(pass.chunks.d_begin(), get_chunk_compressed_size{});
     pass.base_mem_size =
       decomp_dict_data_size +
-      cudf::detail::reduce(
-        chunk_iter, chunk_iter + pass.chunks.size(), size_t{0}, cuda::std::plus<size_t>{}, _stream);
+      cudf::detail::reduce(chunk_iter,
+                           chunk_iter + pass.chunks.size(),
+                           size_t{0},
+                           cuda::std::plus<size_t>{},
+                           _stream,
+                           cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                  cudf::get_current_device_resource_ref()});
 
     // if we are doing subpass reading, generate more accurate num_row estimates for list columns.
     // this helps us to generate more accurate subpass splits.

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -312,15 +312,18 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
   // generate key offsets (offsets to the start of each partition of keys). worst case is 1 page per
   // key
   rmm::device_uvector<size_type> key_offsets(pages.size() + 1, stream);
-  auto page_keys             = make_page_key_iterator(pages);
-  auto const key_offsets_end = cudf::detail::reduce_by_key(page_keys,
-                                                           page_keys + pages.size(),
-                                                           cuda::make_constant_iterator(1),
-                                                           cuda::make_discard_iterator(),
-                                                           key_offsets.begin(),
-                                                           cuda::std::plus<>{},
-                                                           stream)
-                                 .second;
+  auto page_keys = make_page_key_iterator(pages);
+  auto const key_offsets_end =
+    cudf::detail::reduce_by_key(page_keys,
+                                page_keys + pages.size(),
+                                cuda::make_constant_iterator(1),
+                                cuda::make_discard_iterator(),
+                                key_offsets.begin(),
+                                cuda::std::plus<>{},
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()})
+      .second;
 
   size_t const num_unique_keys = key_offsets_end - key_offsets.begin();
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -401,9 +404,15 @@ std::tuple<rmm::device_uvector<page_span>, size_t, size_t> compute_next_subpass(
                                   has_offset_index});
 
   // total page count over all columns
-  auto page_count_iter   = cuda::make_transform_iterator(page_bounds.begin(), get_span_size{});
-  auto const total_pages = cudf::detail::reduce(
-    page_count_iter, page_count_iter + num_columns, size_t{0}, cuda::std::plus<size_t>{}, stream);
+  auto page_count_iter = cuda::make_transform_iterator(page_bounds.begin(), get_span_size{});
+  auto const total_pages =
+    cudf::detail::reduce(page_count_iter,
+                         page_count_iter + num_columns,
+                         size_t{0},
+                         cuda::std::plus<size_t>{},
+                         stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()});
 
   return {
     std::move(page_bounds), total_pages, h_aggregated_info[end_index].size_bytes - cumulative_size};
@@ -651,7 +660,9 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
                          cuda::proclaim_return_type<bool>([] __device__(auto const& res) {
                            return res.status == codec_status::SUCCESS;
                          }),
-                         stream),
+                         stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()}),
     "Error during decompression");
 
   return {std::move(pass_decomp_pages), std::move(subpass_decomp_pages)};
@@ -671,20 +682,29 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
     cuda::make_transform_iterator(pages.begin(), flat_column_num_rows{chunks.data()});
   auto const row_counts_begin = row_counts.begin();
   auto page_keys              = make_page_key_iterator(pages);
-  auto const row_counts_end   = cudf::detail::reduce_by_key(page_keys,
-                                                          page_keys + pages.size(),
-                                                          size_iter,
-                                                          cuda::make_discard_iterator(),
-                                                          row_counts_begin,
-                                                          cuda::std::plus<>{},
-                                                          stream)
-                                .second;
+  auto const row_counts_end =
+    cudf::detail::reduce_by_key(page_keys,
+                                page_keys + pages.size(),
+                                size_iter,
+                                cuda::make_discard_iterator(),
+                                row_counts_begin,
+                                cuda::std::plus<>{},
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()})
+      .second;
 
   // make sure all non-zero row counts are the same
   rmm::device_uvector<size_type> compacted_row_counts(pages.size(), stream);
   auto const compacted_row_counts_begin = compacted_row_counts.begin();
-  auto const compacted_row_counts_end   = cudf::detail::copy_if(
-    row_counts_begin, row_counts_end, compacted_row_counts_begin, row_counts_nonzero{}, stream);
+  auto const compacted_row_counts_end =
+    cudf::detail::copy_if(row_counts_begin,
+                          row_counts_end,
+                          compacted_row_counts_begin,
+                          row_counts_nonzero{},
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
   if (compacted_row_counts_end != compacted_row_counts_begin) {
     auto const found_row_count = [&]() {
       auto found_row_count = cudf::detail::make_pinned_vector(
@@ -703,7 +723,9 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
       cudf::detail::count_if(compacted_row_counts_begin,
                              compacted_row_counts_end,
                              row_counts_different{static_cast<size_type>(found_row_count)},
-                             stream);
+                             stream,
+                             cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                    cudf::get_current_device_resource_ref()});
     CUDF_EXPECTS(chk == 0,
                  "Encountered malformed parquet page data (row count mismatch in page data)");
   }
@@ -755,7 +777,9 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
           }),
         decompression_info{codec, 0, 0, 0},
         decomp_sum{},
-        stream);
+        stream,
+        cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                               cudf::get_current_device_resource_ref()});
 
       // Collect pages with matching codecs
       rmm::device_uvector<device_span<uint8_t const>> temp_spans(pages.size(), stream);
@@ -784,7 +808,9 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
                               page_spans.begin(),
                               cuda::proclaim_return_type<bool>(
                                 [] __device__(auto const& span) { return span.data() != nullptr; }),
-                              stream);
+                              stream,
+                              cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                     cudf::get_current_device_resource_ref()});
       if (end_iter == page_spans.begin()) {
         // No pages compressed with this codec, skip
         continue;

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -81,11 +81,14 @@ void reader_impl::build_string_dict_indices()
                    pass.pages.d_end(),
                    set_str_dict_index_count{str_dict_index_count, pass.chunks});
 
-  auto const total_str_dict_indexes = cudf::detail::reduce(str_dict_index_count.begin(),
-                                                           str_dict_index_count.end(),
-                                                           size_t{0},
-                                                           cuda::std::plus<size_t>{},
-                                                           _stream);
+  auto const total_str_dict_indexes =
+    cudf::detail::reduce(str_dict_index_count.begin(),
+                         str_dict_index_count.end(),
+                         size_t{0},
+                         cuda::std::plus<size_t>{},
+                         _stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()});
 
   if (total_str_dict_indexes == 0) { return; }
 
@@ -451,11 +454,14 @@ void reader_impl::compute_page_string_offset_indices(size_t skip_rows, size_t nu
                          subpass.page_string_offset_indices.begin());
 
   // Compute the total number of offsets needed
-  auto const total_num_offsets = cudf::detail::reduce(d_page_offset_counts.begin(),
-                                                      d_page_offset_counts.end(),
-                                                      size_t{0},
-                                                      cuda::std::plus<size_t>{},
-                                                      _stream);
+  auto const total_num_offsets =
+    cudf::detail::reduce(d_page_offset_counts.begin(),
+                         d_page_offset_counts.end(),
+                         size_t{0},
+                         cuda::std::plus<size_t>{},
+                         _stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()});
 
   // Allocate the string offset buffer
   subpass.string_offset_buffer = rmm::device_uvector<uint32_t>(total_num_offsets, _stream, _mr);
@@ -1084,7 +1090,9 @@ void reader_impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num_
                                   cuda::make_discard_iterator(),
                                   sizes.d_begin() + (key_start / subpass.pages.size()),
                                   cuda::std::plus<>{},
-                                  _stream);
+                                  _stream,
+                                  cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                         cudf::get_current_device_resource_ref()});
 
       // For nested hierarchies, compute per-page start offset
       thrust::exclusive_scan_by_key(
@@ -1217,7 +1225,9 @@ cudf::detail::host_vector<size_t> reader_impl::calculate_page_string_offsets()
                               reduce_keys.begin(),
                               d_col_sizes.begin(),
                               cuda::std::plus<>{},
-                              _stream);
+                              _stream,
+                              cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                     cudf::get_current_device_resource_ref()});
 
   return cudf::detail::make_pinned_vector(d_col_sizes, _stream);
 }

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
@@ -343,11 +343,18 @@ std::string encoding_to_string(Encoding encoding)
 [[nodiscard]] std::string list_unsupported_encodings(device_span<PageInfo const> pages,
                                                      cuda::stream_ref stream)
 {
-  auto const to_mask     = cuda::proclaim_return_type<uint32_t>([] __device__(auto const& page) {
+  auto const to_mask = cuda::proclaim_return_type<uint32_t>([] __device__(auto const& page) {
     return is_supported_encoding(page.encoding) ? uint32_t{0} : encoding_to_mask(page.encoding);
   });
-  auto const unsupported = cudf::detail::transform_reduce(
-    pages.begin(), pages.end(), to_mask, uint32_t{0}, cuda::std::bit_or<uint32_t>(), stream);
+  auto const unsupported =
+    cudf::detail::transform_reduce(pages.begin(),
+                                   pages.end(),
+                                   to_mask,
+                                   uint32_t{0},
+                                   cuda::std::bit_or<uint32_t>(),
+                                   stream,
+                                   cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                          cudf::get_current_device_resource_ref()});
   return encoding_bitmask_to_str(unsupported);
 }
 
@@ -577,8 +584,14 @@ void decode_page_headers_impl(pass_intermediate_data& pass,
                                      c.level_bits[level_type::DEFINITION]);
     }));
   // max level data bit size.
-  auto const max_level_bits = cudf::detail::reduce(
-    level_bit_size, level_bit_size + pass.chunks.size(), int{0}, cuda::maximum<int>{}, stream);
+  auto const max_level_bits =
+    cudf::detail::reduce(level_bit_size,
+                         level_bit_size + pass.chunks.size(),
+                         int{0},
+                         cuda::maximum<int>{},
+                         stream,
+                         cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                cudf::get_current_device_resource_ref()});
   pass.level_type_size = std::max<int32_t>(1, cudf::util::div_rounding_up_safe(max_level_bits, 8));
 
   // sort the pages in chunk/schema order.
@@ -594,14 +607,17 @@ void decode_page_headers_impl(pass_intermediate_data& pass,
   rmm::device_uvector<size_type> page_counts(pass.pages.size() + 1, stream);
   auto page_keys =
     make_page_key_iterator(device_span<PageInfo const>(pass.pages.device_ptr(), pass.pages.size()));
-  auto const page_counts_end = cudf::detail::reduce_by_key(page_keys,
-                                                           page_keys + pass.pages.size(),
-                                                           cuda::make_constant_iterator(1),
-                                                           cuda::make_discard_iterator(),
-                                                           page_counts.begin(),
-                                                           cuda::std::plus<>{},
-                                                           stream)
-                                 .second;
+  auto const page_counts_end =
+    cudf::detail::reduce_by_key(page_keys,
+                                page_keys + pass.pages.size(),
+                                cuda::make_constant_iterator(1),
+                                cuda::make_discard_iterator(),
+                                page_counts.begin(),
+                                cuda::std::plus<>{},
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()})
+      .second;
   auto const num_page_counts = page_counts_end - page_counts.begin();
   pass.page_offsets          = rmm::device_uvector<size_type>(num_page_counts + 1, stream);
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),

--- a/cpp/src/join/direct_join.cu
+++ b/cpp/src/join/direct_join.cu
@@ -110,11 +110,14 @@ direct_inner_join(column_view const& left_keys,
   auto const out_iter    = cuda::tabulate_output_iterator{
     emit_match_pair{left_indices->data(), right_indices->data(), lookup.data(), d_left_keys}};
 
-  auto const out_end = cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
-                                             cuda::counting_iterator<size_type>{left_keys.size()},
-                                             out_iter,
-                                             is_match{lookup.data(), d_left_keys},
-                                             stream);
+  auto const out_end =
+    cudf::detail::copy_if(cuda::counting_iterator<size_type>{0},
+                          cuda::counting_iterator<size_type>{left_keys.size()},
+                          out_iter,
+                          is_match{lookup.data(), d_left_keys},
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   auto const num_matches = cuda::std::distance(out_iter, out_end);
   left_indices->resize(num_matches, stream);

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -301,7 +301,9 @@ distinct_hash_join::inner_join(cudf::table_view const& left,
                           output_begin,
                           cuda::proclaim_return_type<bool>(
                             [] __device__(size_type idx) { return idx != cudf::JoinNoMatch; }),
-                          stream);
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
   auto const actual_size = std::distance(output_begin, output_end);
 
   right_indices->resize(actual_size, stream);

--- a/cpp/src/join/filter_join_indices/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices.cu
@@ -179,7 +179,9 @@ filter_join_indices(cudf::table_view const& left,
             cuda::counting_iterator<size_type>{0},
             cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
             valid_predicate,
-            stream);
+            stream,
+            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                   cudf::get_current_device_resource_ref()});
 
     if (num_valid == 0) { return make_empty_result(); }
 
@@ -196,7 +198,9 @@ filter_join_indices(cudf::table_view const& left,
       cuda::counting_iterator<size_type>{0},
       output_iter,
       [valid_predicate] __device__(size_type idx) -> bool { return valid_predicate(idx); },
-      stream);
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
 
@@ -279,7 +283,9 @@ filter_join_indices(cudf::table_view const& left,
                                   cuda::counting_iterator<std::size_t>{0},
                                   output_iter,
                                   valid_predicate,
-                                  stream);
+                                  stream,
+                                  cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                         cudf::get_current_device_resource_ref()});
     }
     if (num_invalid > 0) {
       {
@@ -296,7 +302,9 @@ filter_join_indices(cudf::table_view const& left,
           cuda::counting_iterator{static_cast<std::size_t>(left.num_rows())},
           filtered_left_indices->begin() + num_valid,
           is_unmatched_idx,
-          stream);
+          stream,
+          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                 cudf::get_current_device_resource_ref()});
       }
       cub::DeviceTransform::Fill(
         filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.get());
@@ -321,7 +329,9 @@ filter_join_indices(cudf::table_view const& left,
             cuda::counting_iterator<cudf::size_type>{0},
             cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
             is_failed_matched_pair,
-            stream);
+            stream,
+            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                   cudf::get_current_device_resource_ref()});
     auto const result_size = left_indices.size() + failed_matched_count;
 
     if (result_size == 0) { return make_empty_result(); }
@@ -362,7 +372,9 @@ filter_join_indices(cudf::table_view const& left,
                                   cuda::counting_iterator<cudf::size_type>{0},
                                   secondary_iter,
                                   is_failed_matched_pair,
-                                  stream);
+                                  stream,
+                                  cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                         cudf::get_current_device_resource_ref()});
     }
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
@@ -207,7 +207,9 @@ apply_join_semantics(cudf::table_view const& left,
       cudf::detail::count_if(cuda::counting_iterator<size_type>{0},
                              cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
                              valid_predicate,
-                             stream);
+                             stream,
+                             cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                    cudf::get_current_device_resource_ref()});
 
     if (num_valid == 0) { return make_empty_result(); }
 
@@ -224,7 +226,9 @@ apply_join_semantics(cudf::table_view const& left,
       cuda::counting_iterator<size_type>{0},
       output_iter,
       [valid_predicate] __device__(size_type idx) -> bool { return valid_predicate(idx); },
-      stream);
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
 
@@ -264,7 +268,9 @@ apply_join_semantics(cudf::table_view const& left,
       cuda::counting_iterator<size_type>{0},
       cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
       [predicate_results_ptr] __device__(size_type i) -> bool { return predicate_results_ptr[i]; },
-      stream);
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
     auto const output_size = num_valid + num_invalid;
     if (output_size == 0) { return make_empty_result(); }
 
@@ -283,7 +289,9 @@ apply_join_semantics(cudf::table_view const& left,
                             cuda::counting_iterator<std::size_t>{0},
                             output_iter,
                             valid_predicate,
-                            stream);
+                            stream,
+                            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                   cudf::get_current_device_resource_ref()});
     }
     if (num_invalid > 0) {
       auto filter_passing_indices_ref = filter_passing_indices.ref(cuco::contains);
@@ -295,7 +303,9 @@ apply_join_semantics(cudf::table_view const& left,
                             cuda::counting_iterator{static_cast<std::size_t>(left.num_rows())},
                             filtered_left_indices->begin() + num_valid,
                             is_unmatched_idx,
-                            stream);
+                            stream,
+                            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                   cudf::get_current_device_resource_ref()});
 
       cub::DeviceTransform::Fill(
         filtered_right_indices->begin() + num_valid, num_invalid, JoinNoMatch, stream.get());
@@ -313,7 +323,9 @@ apply_join_semantics(cudf::table_view const& left,
       cudf::detail::count_if(cuda::counting_iterator<cudf::size_type>{0},
                              cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
                              is_failed_matched_pair,
-                             stream);
+                             stream,
+                             cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                    cudf::get_current_device_resource_ref()});
     auto const output_size = left_indices.size() + failed_matched_count;
 
     if (output_size == 0) { return make_empty_result(); }
@@ -348,7 +360,9 @@ apply_join_semantics(cudf::table_view const& left,
                             cuda::counting_iterator<cudf::size_type>{0},
                             secondary_iter,
                             is_failed_matched_pair,
-                            stream);
+                            stream,
+                            cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                   cudf::get_current_device_resource_ref()});
     }
 
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};

--- a/cpp/src/join/hash_join/size_impl.cuh
+++ b/cpp/src/join/hash_join/size_impl.cuh
@@ -63,8 +63,12 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
   };
   dispatch_join_comparator(
     _right, left, _preprocessed_right, preprocessed_left, _has_nulls, _nulls_equal, count_matches);
-  auto const output_size = cudf::detail::reduce(
-    match_counts.begin(), match_counts.end(), cuda::std::int64_t{0}, cuda::std::plus<>{}, stream);
+  auto const output_size = cudf::detail::reduce(match_counts.begin(),
+                                                match_counts.end(),
+                                                cuda::std::int64_t{0},
+                                                cuda::std::plus<>{},
+                                                stream,
+                                                cudf::memory_resources{temp_mr, temp_mr});
   CUDF_EXPECTS(output_size >= 0, "Join output size overflowed", std::overflow_error);
   return static_cast<std::size_t>(output_size);
 }
@@ -113,8 +117,12 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
   dispatch_join_comparator(
     _right, left, _preprocessed_right, preprocessed_left, _has_nulls, _nulls_equal, count_matches);
 
-  auto const left_output_size = cudf::detail::reduce(
-    match_counts.begin(), match_counts.end(), cuda::std::int64_t{0}, cuda::std::plus<>{}, stream);
+  auto const left_output_size   = cudf::detail::reduce(match_counts.begin(),
+                                                     match_counts.end(),
+                                                     cuda::std::int64_t{0},
+                                                     cuda::std::plus<>{},
+                                                     stream,
+                                                     cudf::memory_resources{temp_mr, temp_mr});
   auto const matched_right_rows = matched_build_rows.value(stream);
   CUDF_EXPECTS(left_output_size >= 0, "Join output size overflowed", std::overflow_error);
   auto const output_size = static_cast<cuda::std::uint64_t>(left_output_size) +

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -173,7 +173,9 @@ VectorPair finalize_full_join(VectorPair&& indices,
                           cuda::counting_iterator<size_type>{right_table_num_rows},
                           out_iter,
                           unmatched_flag{match_flags},
-                          stream);
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   auto const comp_size = cuda::std::distance(out_iter, new_end);
   left_out->resize(match_total + comp_size, stream);

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -206,7 +206,8 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
     [join_type] __device__(bool keep_row) -> bool {
       return keep_row == (join_type == join_kind::LEFT_SEMI_JOIN);
     },
-    stream);
+    stream,
+    cudf::memory_resources{temp_mr, temp_mr});
 
   gather_map->resize(cuda::std::distance(gather_map->begin(), gather_map_end), stream);
   return gather_map;

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -732,7 +732,8 @@ rmm::device_uvector<size_type> sort_merge_join::preprocessed_table::map_table_to
     cuda::counting_iterator<size_type>{0},
     table_mapping.begin(),
     is_row_valid{static_cast<bitmask_type const*>(_validity_mask.value().data())},
-    stream);
+    stream,
+    cudf::memory_resources{temp_mr, temp_mr});
   return table_mapping;
 }
 
@@ -870,15 +871,16 @@ sort_merge_join::left_join(table_view const& left,
 
       auto const validity_mask =
         static_cast<bitmask_type const*>(preprocessed_left._validity_mask.value().data());
-      rmm::device_uvector<size_type> null_left_indices{static_cast<std::size_t>(num_filtered_nulls),
-                                                       stream,
-                                                       cudf::get_current_device_resource_ref()};
+      auto const temp_mr = cudf::get_current_device_resource_ref();
+      rmm::device_uvector<size_type> null_left_indices{
+        static_cast<std::size_t>(num_filtered_nulls), stream, temp_mr};
       cudf::detail::copy_if_async(cuda::counting_iterator<size_type>{0},
                                   cuda::counting_iterator<size_type>{left.num_rows()},
                                   cuda::counting_iterator<size_type>{0},
                                   null_left_indices.begin(),
                                   is_row_null{validity_mask},
-                                  stream);
+                                  stream,
+                                  cudf::memory_resources{temp_mr, temp_mr});
 
       rmm::device_uvector<size_type> left_result_indices(total_output_size, stream, mr);
       rmm::device_uvector<size_type> right_result_indices(total_output_size, stream, mr);

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -70,6 +70,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
   // outgoing offsets.
   auto offsets = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, input.num_rows() + 1, mask_state::UNALLOCATED, stream, mr);
+  auto const temp_mr = cudf::get_current_device_resource_ref();
 
   auto keys =
     cuda::transform_iterator(cuda::counting_iterator<std::size_t>{0},
@@ -107,7 +108,8 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
                                     cuda::make_discard_iterator(),
                                     offsets->mutable_view().begin<int32_t>(),
                                     cuda::std::plus<size_type>(),
-                                    stream);
+                                    stream,
+                                    cudf::memory_resources{temp_mr, temp_mr});
 
   // convert to offsets
   auto total_size =
@@ -155,7 +157,8 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
 rmm::device_uvector<size_type> generate_null_counts(table_device_view const& input,
                                                     cuda::stream_ref stream)
 {
-  rmm::device_uvector<size_type> null_counts(input.num_rows(), stream);
+  auto const temp_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<size_type> null_counts(input.num_rows(), stream, temp_mr);
 
   auto keys =
     cuda::transform_iterator(cuda::counting_iterator<std::size_t>{0},
@@ -178,7 +181,8 @@ rmm::device_uvector<size_type> generate_null_counts(table_device_view const& inp
                                     cuda::make_discard_iterator(),
                                     null_counts.data(),
                                     cuda::std::plus<size_type>(),
-                                    stream);
+                                    stream,
+                                    cudf::memory_resources{temp_mr, temp_mr});
 
   return null_counts;
 }

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -79,9 +79,10 @@ dremel_data get_encoding(column_view h_col,
   };
 
   auto get_empties = [&](column_view col, size_type start, size_type end) {
-    auto lcv = lists_column_view(get_list_level(col));
-    rmm::device_uvector<size_type> empties_idx(lcv.size(), stream);
-    rmm::device_uvector<size_type> empties(lcv.size(), stream);
+    auto lcv           = lists_column_view(get_list_level(col));
+    auto const temp_mr = cudf::get_current_device_resource_ref();
+    rmm::device_uvector<size_type> empties_idx(lcv.size(), stream, temp_mr);
+    rmm::device_uvector<size_type> empties(lcv.size(), stream, temp_mr);
     auto d_off = lcv.offsets().data<int32_t>();
 
     auto empties_idx_end = cudf::detail::copy_if(
@@ -89,13 +90,13 @@ dremel_data get_encoding(column_view h_col,
       cuda::counting_iterator<size_type>{end},
       empties_idx.begin(),
       [d_off] __device__(auto i) -> bool { return d_off[i] == d_off[i + 1]; },
-      stream);
-    auto empties_end =
-      thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     empties_idx.begin(),
-                     empties_idx_end,
-                     lcv.offsets().begin<int32_t>(),
-                     empties.begin());
+      stream,
+      cudf::memory_resources{temp_mr, temp_mr});
+    auto empties_end = thrust::gather(rmm::exec_policy_nosync(stream, temp_mr),
+                                      empties_idx.begin(),
+                                      empties_idx_end,
+                                      lcv.offsets().begin<int32_t>(),
+                                      empties.begin());
 
     auto empties_size = empties_end - empties.begin();
     return std::make_tuple(std::move(empties), std::move(empties_idx), empties_size);

--- a/cpp/src/lists/set_operations.cu
+++ b/cpp/src/lists/set_operations.cu
@@ -78,12 +78,13 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
     lhs_table, rhs_table, nulls_equal, nans_equal, stream, cudf::get_current_device_resource_ref());
 
   auto const num_rows = lhs.size();
+  auto const temp_mr  = cudf::get_current_device_resource_ref();
 
   // This stores the unique label values, used as scatter map.
-  auto list_indices = rmm::device_uvector<size_type>(num_rows, stream);
+  auto list_indices = rmm::device_uvector<size_type>(num_rows, stream, temp_mr);
 
   // Stores the result of checking overlap for non-empty lists.
-  auto overlap_results = rmm::device_uvector<bool>(num_rows, stream);
+  auto overlap_results = rmm::device_uvector<bool>(num_rows, stream, temp_mr);
 
   auto const labels_begin = rhs_labels->view().begin<size_type>();
   auto const end          = cudf::detail::reduce_by_key(labels_begin,  // keys
@@ -92,7 +93,8 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
                                                list_indices.begin(),  // out keys
                                                overlap_results.begin(),  // out values
                                                cuda::std::logical_or{},  // reduction op for values
-                                               stream);
+                                               stream,
+                                               cudf::memory_resources{temp_mr, temp_mr});
 
   auto const num_non_empty_segments = cuda::std::distance(overlap_results.begin(), end.second);
 
@@ -105,11 +107,8 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
   // `overlap_results` only stores the results of non-empty lists.
   // We need to initialize `false` for the entire output array then scatter these results over.
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-    result_begin,
-    result_begin + num_rows,
-    false);
-  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    rmm::exec_policy_nosync(stream, temp_mr), result_begin, result_begin + num_rows, false);
+  thrust::scatter(rmm::exec_policy_nosync(stream, temp_mr),
                   overlap_results.begin(),
                   overlap_results.begin() + num_non_empty_segments,
                   list_indices.begin(),

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -109,7 +109,9 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
       rotated_iter_begin + num_partitions,
       d_row_indices.begin(),
       [nrows] __device__(auto index) -> bool { return (index < nrows); },
-      stream);
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
 
     //...and then use the result, d_row_indices, as gather map:
     auto uniq_tbl = cudf::detail::gather(input,

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -353,7 +353,10 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                 detail::size_begin(input),
                                 detail::size_begin(input) + input.size(),
                                 [] __device__(auto const x) { return x == 0; },
-                                stream) == static_cast<std::size_t>(input.size());
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()}) ==
+                              static_cast<std::size_t>(input.size());
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_size_iter,

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -187,7 +187,12 @@ compute_row_frequencies(table_view const& input,
 
   // Reduction results above are either group sizes of equal rows, or `0`.
   // The final output is non-zero group sizes only.
-  cudf::detail::copy_if_async(input_it, input_it + num_rows, output_it, is_not_zero{}, stream);
+  cudf::detail::copy_if_async(input_it,
+                              input_it + num_rows,
+                              output_it,
+                              is_not_zero{},
+                              stream,
+                              cudf::memory_resources{temp_mr, temp_mr});
 
   return {std::move(distinct_indices), std::move(distinct_counts)};
 }

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -167,7 +167,9 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
                           cuda::counting_iterator<size_type>{input.size()},
                           scatter_map.begin(),
                           is_null_index_predicate(input.size(), gather_map.begin<size_type>()),
-                          stream);
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   scatter_map.resize(cuda::std::distance(scatter_map.begin(), scatter_map_end), stream);
   // Bail early, if all LEAD/LAG computations succeeded. No defaults need be substituted.

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -97,7 +97,9 @@ size_type count_child_nulls(column_view const& input,
   return cudf::detail::count_if(gather_map->view().begin<size_type>(),
                                 gather_map->view().end<size_type>(),
                                 input_row_is_null,
-                                stream);
+                                stream,
+                                cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                       cudf::get_current_device_resource_ref()});
 }
 
 /**
@@ -127,7 +129,9 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                               gather_map.template end<size_type>(),
                               new_gather_map->mutable_view().template begin<size_type>(),
                               input_row_not_null,
-                              stream);
+                              stream,
+                              cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                     cudf::get_current_device_resource_ref()});
 
   // Recalculate offsets after null entries are purged.
   auto new_sizes = make_fixed_width_column(data_type{type_to_id<size_type>()},

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -77,7 +77,9 @@ struct contains_scalar_dispatch {
                auto needle = get_scalar_value<Element>(d_needle);
                return val_pair.has_value() && (needle == *val_pair);
              },
-             stream) > 0;
+             stream,
+             cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                    cudf::get_current_device_resource_ref()}) > 0;
   }
 
   template <typename Element>

--- a/cpp/src/stream_compaction/distinct_helpers.cu
+++ b/cpp/src/stream_compaction/distinct_helpers.cu
@@ -48,7 +48,9 @@ size_type copy_reduction_results(size_type const* results,
         output,
         cuda::proclaim_return_type<bool>(
           [results] __device__(auto const idx) { return results[idx] == size_type{1}; }),
-        stream);
+        stream,
+        cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                               cudf::get_current_device_resource_ref()});
     }
 
     // KEEP_FIRST and KEEP_LAST store desired row indices or the mode's initial marker.
@@ -58,7 +60,9 @@ size_type copy_reduction_results(size_type const* results,
       output,
       cuda::proclaim_return_type<bool>([init_value = reduction_init_value(keep)] __device__(
                                          auto const idx) { return idx != init_value; }),
-      stream);
+      stream,
+      cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                             cudf::get_current_device_resource_ref()});
   }();
 
   return cuda::std::distance(output, output_end);

--- a/cpp/src/stream_compaction/stream_compaction_common.cuh
+++ b/cpp/src/stream_compaction/stream_compaction_common.cuh
@@ -67,7 +67,8 @@ OutputIterator unique_copy(InputIterator first,
                            OutputIterator output,
                            BinaryPredicate comp,
                            duplicate_keep_option const keep,
-                           cuda::stream_ref stream)
+                           cuda::stream_ref stream,
+                           cudf::memory_resources mr)
 {
   size_type const last_index = cuda::std::distance(first, last) - 1;
   return cudf::detail::copy_if(
@@ -76,7 +77,8 @@ OutputIterator unique_copy(InputIterator first,
     cuda::counting_iterator<size_type>{0},
     output,
     unique_copy_fn<InputIterator, BinaryPredicate>{first, keep, comp, last_index},
-    stream);
+    stream,
+    mr);
 }
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -78,7 +78,8 @@ std::unique_ptr<table> unique(table_view const& input,
                                               d_results.begin(),
                                               mutable_view->begin<size_type>(),
                                               cuda::std::identity{},
-                                              stream);
+                                              stream,
+                                              cudf::memory_resources{temp_mr, temp_mr});
       return static_cast<size_type>(
         cuda::std::distance(mutable_view->begin<size_type>(), result_end));
     } else {
@@ -91,7 +92,8 @@ std::unique_ptr<table> unique(table_view const& input,
                                     mutable_view->begin<size_type>(),
                                     row_equal,
                                     keep,
-                                    stream);
+                                    stream,
+                                    cudf::memory_resources{temp_mr, temp_mr});
       return static_cast<size_type>(
         cuda::std::distance(mutable_view->begin<size_type>(), result_end));
     }

--- a/cpp/src/strings/replace/multi.cu
+++ b/cpp/src/strings/replace/multi.cu
@@ -347,7 +347,13 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
   auto const out_itr = cuda::make_zip_iterator(
     cuda::std::make_tuple(targets_positions.begin(), targets_indices.begin()));
   auto const copy_end =
-    cudf::detail::copy_if(copy_itr, copy_itr + chars_bytes, out_itr, copy_if_fn{}, stream);
+    cudf::detail::copy_if(copy_itr,
+                          copy_itr + chars_bytes,
+                          out_itr,
+                          copy_if_fn{},
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   // adjust target count since the copy-if may have eliminated some invalid targets
   target_count = std::min(static_cast<int64_t>(std::distance(out_itr, copy_end)), target_count);

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -300,7 +300,9 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
     copy_itr + chars_bytes + chars_offset,
     targets_positions.begin(),
     [fn] __device__(int64_t idx) -> bool { return fn.is_target_within_row(idx); },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 
   // adjust target count since the copy-if may have eliminated some invalid targets
   target_count = std::min(std::distance(targets_positions.begin(), copy_end), target_count);

--- a/cpp/src/strings/split/split.cuh
+++ b/cpp/src/strings/split/split.cuh
@@ -793,7 +793,9 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
                               cuda::counting_iterator<int64_t>{chars_bytes},
                               delimiter_positions.begin(),
                               delimiter_fn,
-                              stream);
+                              stream,
+                              cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                     cudf::get_current_device_resource_ref()});
 
   // create a vector of offsets to each string's delimiter set within delimiter_positions
   auto const delimiter_offsets =

--- a/cpp/src/table/table_equal.cu
+++ b/cpp/src/table/table_equal.cu
@@ -44,8 +44,12 @@ template <bool has_nested_columns>
       return rows_equal(detail::row::lhs_index_type{i}, detail::row::rhs_index_type{i});
     },
     stream.get()));
-  return cudf::detail::reduce(
-    eq_rows.begin(), eq_rows.end(), true, cuda::std::logical_and<bool>{}, stream);
+  return cudf::detail::reduce(eq_rows.begin(),
+                              eq_rows.end(),
+                              true,
+                              cuda::std::logical_and<bool>{},
+                              stream,
+                              cudf::memory_resources{temp_mr, temp_mr});
 }
 
 }  // namespace

--- a/cpp/src/text/bpe/byte_pair_encoding.cu
+++ b/cpp/src/text/bpe/byte_pair_encoding.cu
@@ -435,7 +435,13 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
     return d_spaces[idx] > 0;  // separator to be inserted here
   };
   auto const copy_end =
-    cudf::detail::copy_if(chars_begin + 1, chars_end, d_inserts, offsets_at_non_zero, stream);
+    cudf::detail::copy_if(chars_begin + 1,
+                          chars_end,
+                          d_inserts,
+                          offsets_at_non_zero,
+                          stream,
+                          cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                 cudf::get_current_device_resource_ref()});
 
   // this will insert the single-byte separator into positions specified in d_inserts
   auto const sep_char = cuda::constant_iterator<char>(separator.to_string(stream)[0]);

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -99,7 +99,9 @@ rmm::device_uvector<cudf::size_type> create_token_row_offsets(
     cudf::detail::count_if(cuda::counting_iterator<cudf::size_type>{0},
                            cuda::counting_iterator<cudf::size_type>{tokens_counts},
                            fn,
-                           stream);
+                           stream,
+                           cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                  cudf::get_current_device_resource_ref()});
 
   auto tokens_offsets = rmm::device_uvector<cudf::size_type>(output_count + 1, stream);
 
@@ -107,7 +109,9 @@ rmm::device_uvector<cudf::size_type> create_token_row_offsets(
                               cuda::counting_iterator<cudf::size_type>{tokens_counts},
                               tokens_offsets.begin(),
                               fn,
-                              stream);
+                              stream,
+                              cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                                                     cudf::get_current_device_resource_ref()});
 
   // set the last element to the total number of tokens
   tokens_offsets.set_element(output_count, tokens_counts, stream);

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -210,7 +210,9 @@ std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const
       // this will also set the final value to the size chars_bytes
       return idx < chars_bytes ? cudf::strings::detail::is_begin_utf8_char(d_chars[idx]) : true;
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 
   // create the output chars buffer -- just a copy of the input's chars
   rmm::device_uvector<char> output_chars(chars_bytes, stream, mr);

--- a/cpp/src/text/unicode_normalize.cu
+++ b/cpp/src/text/unicode_normalize.cu
@@ -792,7 +792,11 @@ std::unique_ptr<cudf::column> normalize_unicode(cudf::strings_column_view const&
   // If none found the column is already normalized and we can just return a copy.
   if (p.form == unicode_normalization_form::NFC || p.form == unicode_normalization_form::NFKC) {
     auto nfc_qc_fn = detail::nfc_quick_check_fn{chars_span, p.ccc_table, p.compat_decomp_flags};
-    if (!cudf::detail::any_of(byte_iter, byte_iter + chars_size, nfc_qc_fn, stream)) {
+    if (!cudf::detail::any_of(byte_iter,
+                              byte_iter + chars_size,
+                              nfc_qc_fn,
+                              stream,
+                              cudf::memory_resources{temp_mr, temp_mr})) {
       return std::make_unique<cudf::column>(input.parent(), stream, mr);
     }
   }

--- a/cpp/src/text/vocabulary_tokenize.cu
+++ b/cpp/src/text/vocabulary_tokenize.cu
@@ -430,7 +430,9 @@ std::unique_ptr<cudf::column> tokenize_with_vocabulary(cudf::strings_column_view
       if (idx == 0) return true;
       return d_marks[idx] && !d_marks[idx - 1];
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 
   auto tmp_offsets =
     std::make_unique<cudf::column>(std::move(d_tmp_offsets), rmm::device_buffer{}, 0);

--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -244,7 +244,9 @@ wordpiece_vocabulary::wordpiece_vocabulary(cudf::strings_column_view const& inpu
     cuda::counting_iterator{static_cast<cudf::size_type>(sub_map_indices.size())},
     sub_map_indices.begin(),
     copy_pieces_fn{*d_vocabulary},
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
   sub_map_indices.resize(cuda::std::distance(sub_map_indices.begin(), end), stream);
 
   // build a 2nd map with just the ## prefixed items
@@ -520,7 +522,9 @@ rmm::device_uvector<cudf::size_type> compute_all_tokens(
       if (idx == 0) { return d_input_chars[idx] == ' '; }
       return (d_input_chars[idx] != ' ' && d_input_chars[idx - 1] == ' ');
     },
-    stream);
+    stream,
+    cudf::memory_resources{cudf::get_current_device_resource_ref(),
+                           cudf::get_current_device_resource_ref()});
 
   auto const edges_count =
     input.size() + 1 + static_cast<int64_t>(cuda::std::distance(d_edges.begin(), edges_end));


### PR DESCRIPTION
## Description

A part of https://github.com/NVIDIA/cudf/issues/20780.

- Port detail `copy_if`, reduction, counting, and label-segment helpers to take `cudf::memory_resources`.
- Route output and temporary allocations explicitly through the supplied resource pair.
- Update current callers across copying, groupby, I/O, joins, lists, reductions, stream compaction, strings, and text.

## Test plan
- [x] Pre-commit checks on all changed files
- [x] Full C++ build: `ninja -k 0 -j8`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.