### PR TITLE
Route valid_if through memory resources

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -1066,21 +1066,29 @@ std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
 }
 
 std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
-  cudf::size_type size, std::optional<double> null_probability, unsigned seed)
+  cudf::size_type size,
+  std::optional<double> null_probability,
+  unsigned seed,
+  cuda::stream_ref stream,
+  cudf::memory_resources resources)
 {
   if (not null_probability.has_value()) { return {rmm::device_buffer{}, 0}; }
   CUDF_EXPECTS(*null_probability >= 0.0 and *null_probability <= 1.0,
                "Null probability must be within the range [0.0, 1.0]");
   if (*null_probability == 0.0f) {
-    return {cudf::create_null_mask(size, cudf::mask_state::ALL_VALID), 0};
+    return {
+      cudf::create_null_mask(size, cudf::mask_state::ALL_VALID, stream, resources.get_output_mr()),
+      0};
   } else if (*null_probability == 1.0) {
-    return {cudf::create_null_mask(size, cudf::mask_state::ALL_NULL), size};
+    return {
+      cudf::create_null_mask(size, cudf::mask_state::ALL_NULL, stream, resources.get_output_mr()),
+      size};
   } else {
     return cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                   cuda::counting_iterator<cudf::size_type>{size},
                                   bool_generator{seed, 1.0 - *null_probability},
-                                  cudf::get_default_stream(),
-                                  cudf::get_current_device_resource_ref());
+                                  stream,
+                                  resources);
   }
 }
 

--- a/cpp/benchmarks/common/generate_input.hpp
+++ b/cpp/benchmarks/common/generate_input.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -664,7 +666,13 @@ std::vector<cudf::type_id> mix_dtypes(std::pair<cudf::type_id, cudf::type_id> co
  * @param null_probability probability of a null value
  *  no value implies no null mask, =0 implies all valids, >=1 implies all nulls
  * @param seed Optional, seed for the pseudo-random engine
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param resources Memory resources used for the returned bitmask and temporary allocations
  * @return null mask device buffer with random null mask data and null count
  */
 std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
-  cudf::size_type size, std::optional<double> null_probability = std::nullopt, unsigned seed = 1);
+  cudf::size_type size,
+  std::optional<double> null_probability = std::nullopt,
+  unsigned seed                          = 1,
+  cuda::stream_ref stream                = cudf::get_default_stream(),
+  cudf::memory_resources resources       = cudf::get_current_device_resource_ref());

--- a/cpp/include/cudf/strings/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/strings/detail/copy_if_else.cuh
@@ -62,7 +62,7 @@ std::unique_ptr<cudf::column> copy_if_else(StringIterLeft lhs_begin,
       return filter_fn(idx) ? lhs_begin[idx].has_value() : rhs_begin[idx].has_value();
     },
     stream,
-    mr);
+    cudf::memory_resources{mr, mr});
   if (null_count == 0) { null_mask = rmm::device_buffer{}; }
 
   // build vector of strings

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -62,7 +62,8 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
 
   // create null mask
   auto validator = [] __device__(string_index_pair const item) { return item.first != nullptr; };
-  auto new_nulls = cudf::detail::valid_if(begin, end, validator, stream, mr);
+  auto new_nulls =
+    cudf::detail::valid_if(begin, end, validator, stream, cudf::memory_resources{mr, mr});
   auto const null_count = new_nulls.second;
   auto null_mask =
     (null_count > 0) ? std::move(new_nulls.first) : rmm::device_buffer{0, stream, mr};

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -54,7 +54,7 @@ std::pair<rmm::device_buffer, size_type> create_null_mask(column_device_view con
                           cuda::counting_iterator<size_type>{size},
                           func_validity,
                           stream,
-                          mr);
+                          cudf::memory_resources{mr, mr});
 }
 
 struct shift_functor {

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -137,7 +137,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
       return (indices_itr[idx] < max_size);  // new nulls have max values
     },
     stream,
-    mr);
+    cudf::memory_resources{mr, mr});
   rmm::device_buffer new_null_mask =
     (new_nulls.second > 0) ? std::move(new_nulls.first) : rmm::device_buffer{0, stream, mr};
 

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -120,7 +120,7 @@ struct remap_indices_dispatch_fn {
       iota + input.size(),
       [d_indices] __device__(size_type idx) { return d_indices[idx] >= 0; },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
 
     return {std::move(indices_column), std::move(null_mask), null_count};
   }

--- a/cpp/src/groupby/common/m2_var_std.cu
+++ b/cpp/src/groupby/common/m2_var_std.cu
@@ -140,8 +140,11 @@ std::unique_ptr<column> compute_variance_std(TransformFunc&& transform_fn,
                    out_it + size,
                    transform_fn);
 
-  auto [null_mask, null_count] =
-    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
+  auto [null_mask, null_count] = cudf::detail::valid_if(validity.begin(),
+                                                        validity.end(),
+                                                        cuda::std::identity{},
+                                                        stream,
+                                                        cudf::memory_resources{mr, mr});
   if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
 
   return output;

--- a/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
+++ b/cpp/src/groupby/hash/hash_compound_agg_finalizer.cu
@@ -126,7 +126,7 @@ void hash_compound_agg_finalizer::operator()<aggregation::MEAN>(aggregation cons
       count_result.end<size_type>(),
       [] __device__(size_type const count) -> bool { return count > 0; },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
     if (null_count > 0) { result->set_null_mask(std::move(null_mask), null_count); }
   }
   cache->add_result(col, agg, std::move(result));

--- a/cpp/src/groupby/sort/group_bitwise.cu
+++ b/cpp/src/groupby/sort/group_bitwise.cu
@@ -73,8 +73,11 @@ struct bitwise_group_reduction_functor {
                    validity.begin(),
                    cuda::std::logical_or{});
 
-      auto [null_mask, null_count] =
-        cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
+      auto [null_mask, null_count] = cudf::detail::valid_if(validity.begin(),
+                                                            validity.end(),
+                                                            cuda::std::identity{},
+                                                            stream,
+                                                            cudf::memory_resources{mr, mr});
       if (null_count > 0) { result->set_null_mask(std::move(null_mask), null_count); }
     }
     return result;

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -160,8 +160,11 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
   auto is_null = [ddof, min_periods] __device__(size_type group_size) {
     return not(group_size == 0 or group_size - ddof <= 0 or group_size < min_periods);
   };
-  auto [new_nullmask, null_count] =
-    cudf::detail::valid_if(count.begin<size_type>(), count.end<size_type>(), is_null, stream, mr);
+  auto [new_nullmask, null_count] = cudf::detail::valid_if(count.begin<size_type>(),
+                                                           count.end<size_type>(),
+                                                           is_null,
+                                                           stream,
+                                                           cudf::memory_resources{mr, mr});
   if (null_count != 0) { result->set_null_mask(std::move(new_nullmask), null_count); }
   return result;
 }

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -191,8 +191,11 @@ struct group_reduction_functor<
                    validity.begin(),
                    cuda::std::logical_or{});
 
-      auto [null_mask, null_count] =
-        cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
+      auto [null_mask, null_count] = cudf::detail::valid_if(validity.begin(),
+                                                            validity.end(),
+                                                            cuda::std::identity{},
+                                                            stream,
+                                                            cudf::memory_resources{mr, mr});
       result->set_null_mask(std::move(null_mask), null_count);
     }
     return result;
@@ -245,8 +248,11 @@ struct group_reduction_functor<
                    validity.begin(),
                    cuda::std::logical_or{});
 
-      auto [null_mask, null_count] =
-        cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
+      auto [null_mask, null_count] = cudf::detail::valid_if(validity.begin(),
+                                                            validity.end(),
+                                                            cuda::std::identity{},
+                                                            stream,
+                                                            cudf::memory_resources{mr, mr});
       result->set_null_mask(std::move(null_mask), null_count);
     }
 

--- a/cpp/src/groupby/sort/group_sum_overflow.cu
+++ b/cpp/src/groupby/sort/group_sum_overflow.cu
@@ -93,8 +93,11 @@ struct group_sum_overflow_fn {
         group_valid.begin(),
         cuda::std::equal_to<size_type>{},
         cuda::std::logical_or<bool>{});
-      return cudf::detail::valid_if(
-        group_valid.begin(), group_valid.end(), cuda::std::identity{}, stream, mr);
+      return cudf::detail::valid_if(group_valid.begin(),
+                                    group_valid.end(),
+                                    cuda::std::identity{},
+                                    stream,
+                                    cudf::memory_resources{mr, mr});
     }();
 
     std::vector<std::unique_ptr<column>> children;

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -153,7 +153,8 @@ std::unique_ptr<column> label_bins(column_view const& input,
                         left_begin, left_end, right_begin));
   });
 
-  auto mask_and_count = valid_if(output_begin, output_end, filter_null_sentinel(), stream, mr);
+  auto mask_and_count = valid_if(
+    output_begin, output_end, filter_null_sentinel(), stream, cudf::memory_resources{mr, mr});
 
   output->set_null_mask(std::move(mask_and_count.first), mask_and_count.second);
   return output;

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -89,7 +89,7 @@ std::unique_ptr<column> concatenate_lists_ignore_null(column_view const& input,
           [&] __device__(auto const list_idx) { return lists_dv.is_valid(list_idx); });
       },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
   }();
 
   return make_lists_column(num_rows,
@@ -212,8 +212,11 @@ std::unique_ptr<column> concatenate_lists_nullifying_rows(column_view const& inp
 
   auto list_entries =
     gather_list_entries(input, offsets_view, num_rows, num_output_entries, stream, mr);
-  auto [null_mask, null_count] = cudf::detail::valid_if(
-    list_validities.begin(), list_validities.end(), cuda::std::identity{}, stream, mr);
+  auto [null_mask, null_count] = cudf::detail::valid_if(list_validities.begin(),
+                                                        list_validities.end(),
+                                                        cuda::std::identity{},
+                                                        stream,
+                                                        cudf::memory_resources{mr, mr});
 
   return make_lists_column(num_rows,
                            std::move(list_offsets),

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -137,7 +137,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
           return null_count != num_columns;
         },
         stream,
-        mr);
+        cudf::memory_resources{mr, mr});
     }
 
     // row is null if -any- input rows are null
@@ -146,7 +146,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
       row_null_counts.begin() + input.num_rows(),
       [] __device__(size_type null_count) { return null_count == 0; },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
   }();
 
   return {std::move(offsets), std::move(null_mask), null_count};
@@ -248,7 +248,7 @@ std::unique_ptr<column> concatenate_rows(table_view const& input,
               return row_null_counts[row_index] != num_columns;
             }),
           stream,
-          cudf::get_current_device_resource_ref());
+          cudf::memory_resources{mr, mr});
       }
       // NULLIFY_OUTPUT_ROW.  Output row is nullfied if any input row is null
       return cudf::detail::valid_if(
@@ -261,7 +261,7 @@ std::unique_ptr<column> concatenate_rows(table_view const& input,
             return row_null_counts[row_index] == 0;
           }),
         stream,
-        cudf::get_current_device_resource_ref());
+        cudf::memory_resources{mr, mr});
     }();
     concat->set_null_mask(std::move(null_mask), null_count);
   }

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -226,7 +226,7 @@ std::unique_ptr<column> dispatch_index_of(lists_column_view const& lists,
       output_it + num_rows,
       [] __device__(auto const idx) { return idx != NULL_SENTINEL; },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
     out_positions->set_null_mask(std::move(null_mask), null_count);
   }
   return out_positions;

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -63,7 +63,7 @@ std::pair<rmm::device_buffer, size_type> construct_child_nullmask(
                                 cuda::counting_iterator<size_type>{num_child_rows},
                                 is_valid_predicate,
                                 stream,
-                                mr);
+                                cudf::memory_resources{mr, mr});
 }
 
 /**

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -82,7 +82,7 @@ std::unique_ptr<table> build_table(
                                                explode_col_gather_map->end(),
                                                [] __device__(auto i) { return i != InvalidIndex; },
                                                stream,
-                                               mr)
+                                               cudf::memory_resources{mr, mr})
                                            : std::pair<rmm::device_buffer, size_type>{
                                                rmm::device_buffer(0, stream), size_type{0}};
 

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -273,8 +273,11 @@ struct interleave_list_entries_impl<T, std::enable_if_t<cudf::is_fixed_width<T>(
       });
 
     if (data_has_null_mask) {
-      auto [null_mask, null_count] = cudf::detail::valid_if(
-        validities.begin(), validities.end(), cuda::std::identity{}, stream, mr);
+      auto [null_mask, null_count] = cudf::detail::valid_if(validities.begin(),
+                                                            validities.end(),
+                                                            cuda::std::identity{},
+                                                            stream,
+                                                            cudf::memory_resources{mr, mr});
       if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
     }
 
@@ -367,8 +370,11 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
       num_output_lists, std::move(list_offsets), std::move(list_entries), 0, rmm::device_buffer{});
   }
 
-  auto [null_mask, null_count] = cudf::detail::valid_if(
-    list_validities.begin(), list_validities.end(), cuda::std::identity{}, stream, mr);
+  auto [null_mask, null_count] = cudf::detail::valid_if(list_validities.begin(),
+                                                        list_validities.end(),
+                                                        cuda::std::identity{},
+                                                        stream,
+                                                        cudf::memory_resources{mr, mr});
   return make_lists_column(num_output_lists,
                            std::move(list_offsets),
                            std::move(list_entries),

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -117,7 +117,7 @@ struct quantile_functor {
           return select_quantile_validity(sorted_validity, size, q, interp);
         },
         stream,
-        mr);
+        cudf::memory_resources{mr, mr});
 
       output->set_null_mask(std::move(mask), null_count);
     }

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -220,7 +220,7 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
                    return percentiles.is_valid(i % percentiles.size());
                  },
                  stream,
-                 mr)
+                 cudf::memory_resources{mr, mr})
              : std::pair<rmm::device_buffer, size_type>{rmm::device_buffer{}, 0};
   }();
 
@@ -385,8 +385,11 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
     if (null_count == 0) {
       return std::pair<rmm::device_buffer, size_type>{rmm::device_buffer{}, null_count};
     }
-    return cudf::detail::valid_if(
-      tdigest_is_empty, tdigest_is_empty + tdv.size(), cuda::std::logical_not{}, stream, mr);
+    return cudf::detail::valid_if(tdigest_is_empty,
+                                  tdigest_is_empty + tdv.size(),
+                                  cuda::std::logical_not{},
+                                  stream,
+                                  cudf::memory_resources{mr, mr});
   }();
 
   return cudf::make_lists_column(input.size(),

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -119,7 +119,7 @@ struct interleave_columns_impl<T, std::enable_if_t<std::is_same_v<T, cudf::struc
                                     cuda::counting_iterator<size_type>{output_size},
                                     validity_fn,
                                     stream,
-                                    mr);
+                                    cudf::memory_resources{mr, mr});
     };
 
     // Only create null mask if at least one input structs column is nullable.
@@ -223,7 +223,8 @@ struct interleave_columns_impl<T, std::enable_if_t<cudf::is_fixed_width<T>()>> {
                          func_value,
                          func_validity);
 
-    auto [mask, null_count] = valid_if(index_begin, index_end, func_validity, stream, mr);
+    auto [mask, null_count] =
+      valid_if(index_begin, index_end, func_validity, stream, cudf::memory_resources{mr, mr});
 
     output->set_null_mask(std::move(mask), null_count);
 

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -198,7 +198,7 @@ std::unique_ptr<column> rolling_collect_list(column_view const& input,
       return (preceding_begin[i] + following_begin[i]) >= min_periods;
     },
     stream,
-    mr);
+    cudf::memory_resources{mr, mr});
 
   return make_lists_column(input.size(),
                            std::move(offsets),

--- a/cpp/src/strings/combine/concatenate.cu
+++ b/cpp/src/strings/combine/concatenate.cu
@@ -146,7 +146,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
         thrust::seq, d_table.begin(), d_table.end(), [idx](auto col) { return col.is_null(idx); });
     },
     stream,
-    mr);
+    cudf::memory_resources{mr, mr});
 
   return make_strings_column(
     strings_count, std::move(offsets_column), chars.release(), null_count, std::move(null_mask));
@@ -239,7 +239,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
         thrust::seq, d_table.begin(), d_table.end(), [idx](auto col) { return col.is_null(idx); });
     },
     stream,
-    mr);
+    cudf::memory_resources{mr, mr});
 
   return make_strings_column(
     strings_count, std::move(offsets_column), chars.release(), null_count, std::move(null_mask));

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -204,7 +204,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                            cuda::counting_iterator<size_type>{num_rows},
                            validities_fn{comp_fn},
                            stream,
-                           mr);
+                           cudf::memory_resources{mr, mr});
 
   return make_strings_column(
     num_rows, std::move(offsets_column), chars.release(), null_count, std::move(null_mask));
@@ -279,7 +279,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                            cuda::counting_iterator<size_type>{num_rows},
                            validities_fn{comp_fn},
                            stream,
-                           mr);
+                           cudf::memory_resources{mr, mr});
 
   return make_strings_column(
     num_rows, std::move(offsets_column), chars.release(), null_count, std::move(null_mask));

--- a/cpp/src/strings/copying/copy_range.cu
+++ b/cpp/src/strings/copying/copy_range.cu
@@ -77,7 +77,7 @@ std::unique_ptr<column> copy_range(strings_column_view const& source,
                  : d_target.is_valid(idx);
       },
       stream,
-      mr);
+      cudf::memory_resources{mr, mr});
   }();
 
   // create offsets

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -114,7 +114,11 @@ std::unique_ptr<column> extract_all_record(strings_column_view const& input,
 
   // Compute null output rows
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    d_counts, d_counts + strings_count, [] __device__(auto v) { return v > 0; }, stream, mr);
+    d_counts,
+    d_counts + strings_count,
+    [] __device__(auto v) { return v > 0; },
+    stream,
+    cudf::memory_resources{mr, mr});
 
   // Return an empty lists column if there are no valid rows
   if (strings_count == null_count) {

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -34,12 +34,16 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
     // Nulls are considered false
     auto input_begin = make_null_replacement_iterator<bool>(input_device_view, false);
 
-    auto mask = detail::valid_if(input_begin, input_begin + input.size(), pred, stream, mr);
+    auto mask = detail::valid_if(
+      input_begin, input_begin + input.size(), pred, stream, cudf::memory_resources{mr, mr});
 
     return std::pair(std::make_unique<rmm::device_buffer>(std::move(mask.first)), mask.second);
   } else {
-    auto mask = detail::valid_if(
-      input_device_view.begin<bool>(), input_device_view.end<bool>(), pred, stream, mr);
+    auto mask = detail::valid_if(input_device_view.begin<bool>(),
+                                 input_device_view.end<bool>(),
+                                 pred,
+                                 stream,
+                                 cudf::memory_resources{mr, mr});
 
     return std::pair(std::make_unique<rmm::device_buffer>(std::move(mask.first)), mask.second);
   }

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -40,7 +40,7 @@ struct dispatch_nan_to_null {
                                  cuda::counting_iterator<cudf::size_type>{input.size()},
                                  pred,
                                  stream,
-                                 mr);
+                                 cudf::memory_resources{mr, mr});
 
     return std::pair(std::make_unique<rmm::device_buffer>(std::move(mask.first)), mask.second);
   }

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -306,7 +306,7 @@ struct dispatch_unary_cast_to {
                                cuda::counting_iterator{size},
                                is_convertible_floating_point<SourceT>{*d_input_ptr},
                                stream,
-                               mr);
+                               cudf::memory_resources{mr, mr});
       if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
     } else {
       output->set_null_mask(detail::copy_bitmask(input, stream, mr), input.null_count());

--- a/cpp/tests/bitmask/valid_if_tests.cu
+++ b/cpp/tests/bitmask/valid_if_tests.cu
@@ -16,7 +16,7 @@
 
 #include <cuda/iterator>
 
-struct ValidIfTest : public cudf::test::BaseFixture {};
+struct ValidIfTest : public cudf::test::BaseFixtureWithHarness {};
 
 namespace {
 struct odds_valid {
@@ -35,8 +35,8 @@ TEST_F(ValidIfTest, EmptyRange)
   auto actual        = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{0},
                                        odds_valid{},
-                                       cudf::get_default_stream(),
-                                       cudf::get_current_device_resource_ref());
+                                       stream(),
+                                       resources());
   auto const& buffer = actual.first;
   EXPECT_EQ(0u, buffer.size());
   EXPECT_EQ(nullptr, buffer.data());
@@ -45,8 +45,8 @@ TEST_F(ValidIfTest, EmptyRange)
 
 TEST_F(ValidIfTest, ExplicitMemoryResourcesEmptyRange)
 {
-  auto harness = cudf::test::memory_resource_test_harness{this->mr()};
-  auto stream  = cudf::get_default_stream();
+  auto& harness     = this->harness();
+  auto const stream = this->stream();
 
   // No harness.synchronize inside the scope: empty range has no GPU operations pending.
   auto actual = [&] {
@@ -71,29 +71,31 @@ TEST_F(ValidIfTest, InvalidRange)
   EXPECT_THROW(cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{1},
                                       cuda::counting_iterator<cudf::size_type>{0},
                                       odds_valid{},
-                                      cudf::get_default_stream(),
-                                      cudf::get_current_device_resource_ref()),
+                                      stream(),
+                                      resources()),
                cudf::logic_error);
 }
 
 TEST_F(ValidIfTest, OddsValid)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto iter = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
+  auto expected =
+    cudf::test::detail::make_null_mask(iter, iter + 10000, stream(), harness().setup_mr());
+  auto actual = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        odds_valid{},
-                                       cudf::get_default_stream(),
-                                       cudf::get_current_device_resource_ref());
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(expected.first.data(), actual.first.data(), expected.first.size());
+                                       stream(),
+                                       resources());
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    expected.first.data(), actual.first.data(), expected.first.size(), stream(), resources());
   EXPECT_EQ(5000, actual.second);
   EXPECT_EQ(expected.second, actual.second);
 }
 
 TEST_F(ValidIfTest, ExplicitMemoryResourceControl)
 {
-  auto harness              = cudf::test::memory_resource_test_harness{this->mr()};
-  auto stream               = cudf::get_default_stream();
+  auto& harness             = this->harness();
+  auto const stream         = this->stream();
   auto comparison_resources = cudf::memory_resources{harness.setup_mr(), harness.setup_mr()};
   auto iter                 = cudf::detail::make_counting_transform_iterator(0, odds_valid{});
   auto expected =
@@ -128,28 +130,32 @@ TEST_F(ValidIfTest, ExplicitMemoryResourceControl)
 
 TEST_F(ValidIfTest, AllValid)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, all_valid{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto iter = cudf::detail::make_counting_transform_iterator(0, all_valid{});
+  auto expected =
+    cudf::test::detail::make_null_mask(iter, iter + 10000, stream(), harness().setup_mr());
+  auto actual = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        all_valid{},
-                                       cudf::get_default_stream(),
-                                       cudf::get_current_device_resource_ref());
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(expected.first.data(), actual.first.data(), expected.first.size());
+                                       stream(),
+                                       resources());
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    expected.first.data(), actual.first.data(), expected.first.size(), stream(), resources());
   EXPECT_EQ(0, actual.second);
   EXPECT_EQ(expected.second, actual.second);
 }
 
 TEST_F(ValidIfTest, AllNull)
 {
-  auto iter     = cudf::detail::make_counting_transform_iterator(0, all_null{});
-  auto expected = cudf::test::detail::make_null_mask(iter, iter + 10000);
-  auto actual   = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+  auto iter = cudf::detail::make_counting_transform_iterator(0, all_null{});
+  auto expected =
+    cudf::test::detail::make_null_mask(iter, iter + 10000, stream(), harness().setup_mr());
+  auto actual = cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
                                        cuda::counting_iterator<cudf::size_type>{10000},
                                        all_null{},
-                                       cudf::get_default_stream(),
-                                       cudf::get_current_device_resource_ref());
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(expected.first.data(), actual.first.data(), expected.first.size());
+                                       stream(),
+                                       resources());
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    expected.first.data(), actual.first.data(), expected.first.size(), stream(), resources());
   EXPECT_EQ(10000, actual.second);
   EXPECT_EQ(expected.second, actual.second);
 }


### PR DESCRIPTION
## Description

A part of https://github.com/NVIDIA/cudf/issues/20780.

- Port `cudf::detail::valid_if` to take `cudf::memory_resources` and route scan scratch separately from the returned null mask.
- Update validity-mask construction callers to pass output and temporary resources explicitly.
- Add allocation-routing coverage using `BaseFixtureWithHarness`.

## Test plan
- [x] Pre-commit checks on all changed files
- [x] Build `BITMASK_TEST`, `LISTS_TEST`, and `GROUPBY_TEST`
- [x] `BITMASK_TEST` (54/54 passed)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.