### PR TITLE
Route lexicographic preprocessing through memory resources

### DIFF
--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -17,6 +17,7 @@
 #include <cudf/structs/structs_column_device_view.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -702,12 +703,15 @@ struct preprocessed_table {
    *        the input tables that indicates how null values compare to all other. If it is empty,
    *        the order `null_order::BEFORE` will be used for all columns.
    * @param stream The stream to launch kernels and h->d copies on while preprocessing
+   * @param mr Device memory resources used for returned and temporary allocations
    * @return A shared pointer to a preprocessed table
    */
-  static std::shared_ptr<preprocessed_table> create(table_view const& table,
-                                                    host_span<order const> column_order,
-                                                    host_span<null_order const> null_precedence,
-                                                    cuda::stream_ref stream);
+  static std::shared_ptr<preprocessed_table> create(
+    table_view const& table,
+    host_span<order const> column_order,
+    host_span<null_order const> null_precedence,
+    cuda::stream_ref stream,
+    cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
   /**
    * @brief Preprocess tables for use with lexicographical comparison
@@ -728,6 +732,7 @@ struct preprocessed_table {
    *        the input tables that indicates how null values compare to all other. If it is empty,
    *        the order `null_order::BEFORE` will be used for all columns.
    * @param stream The stream to launch kernels and h->d copies on while preprocessing
+   * @param mr Device memory resources used for returned and temporary allocations
    * @return A pair of shared pointers to the preprocessed tables
    */
   static std::pair<std::shared_ptr<preprocessed_table>, std::shared_ptr<preprocessed_table>> create(
@@ -735,7 +740,8 @@ struct preprocessed_table {
     table_view const& rhs,
     host_span<order const> column_order,
     host_span<null_order const> null_precedence,
-    cuda::stream_ref stream);
+    cuda::stream_ref stream,
+    cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
  private:
   friend class self_comparator;
@@ -758,6 +764,7 @@ struct preprocessed_table {
    * @param has_ranked_children Flag indicating if the input table was preprocessed to transform
    *        any nested child column into an integer column using `cudf::rank`
    * @param stream The stream to launch kernels and h->d copies on while preprocessing
+   * @param mr Device memory resources used for returned and temporary allocations
    * @return A shared pointer to a preprocessed table
    */
   static std::shared_ptr<preprocessed_table> create(
@@ -767,7 +774,8 @@ struct preprocessed_table {
     host_span<order const> column_order,
     host_span<null_order const> null_precedence,
     bool has_ranked_children,
-    cuda::stream_ref stream);
+    cuda::stream_ref stream,
+    cudf::memory_resources mr);
 
   /**
    * @brief Construct a preprocessed table for use with lexicographical comparison
@@ -920,12 +928,14 @@ class self_comparator {
    *        `null_order::BEFORE` for all columns.
    * @param stream The stream to construct this object on. Not the stream that will be used for
    *        comparisons using this object.
+   * @param mr Device memory resources used for returned and temporary allocations
    */
   self_comparator(table_view const& t,
                   host_span<order const> column_order         = {},
                   host_span<null_order const> null_precedence = {},
-                  cuda::stream_ref stream                     = cudf::get_default_stream())
-    : d_t{preprocessed_table::create(t, column_order, null_precedence, stream)}
+                  cuda::stream_ref stream                     = cudf::get_default_stream(),
+                  cudf::memory_resources mr = cudf::get_current_device_resource_ref())
+    : d_t{preprocessed_table::create(t, column_order, null_precedence, stream, mr)}
   {
   }
 
@@ -1076,12 +1086,14 @@ class two_table_comparator {
    *        `null_order::BEFORE` for all columns.
    * @param stream The stream to construct this object on. Not the stream that will be used for
    *        comparisons using this object.
+   * @param mr Device memory resources used for returned and temporary allocations
    */
   two_table_comparator(table_view const& left,
                        table_view const& right,
                        host_span<order const> column_order         = {},
                        host_span<null_order const> null_precedence = {},
-                       cuda::stream_ref stream                     = cudf::get_default_stream());
+                       cuda::stream_ref stream                     = cudf::get_default_stream(),
+                       cudf::memory_resources mr = cudf::get_current_device_resource_ref());
 
   /**
    * @brief Construct an owning object for performing a lexicographic comparison between two rows of

--- a/cpp/src/binaryop/compiled/struct_binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/struct_binary_ops.cuh
@@ -68,10 +68,10 @@ void apply_struct_binary_op(mutable_column_view& out,
     lhs.size(),
     is_any_v<BinaryOperator, ops::Greater, ops::GreaterEqual> ? order::DESCENDING
                                                               : order::ASCENDING);
-  auto const tlhs = table_view{{lhs}};
-  auto const trhs = table_view{{rhs}};
-  auto const table_comparator =
-    cudf::detail::row::lexicographic::two_table_comparator{tlhs, trhs, compare_orders, {}, stream};
+  auto const tlhs             = table_view{{lhs}};
+  auto const trhs             = table_view{{rhs}};
+  auto const table_comparator = cudf::detail::row::lexicographic::two_table_comparator{
+    tlhs, trhs, compare_orders, {}, stream, cudf::get_current_device_resource_ref()};
   auto outd = column_device_view::create(out, stream);
   auto optional_iter =
     cudf::detail::make_optional_iterator<bool>(*outd, nullate::DYNAMIC{out.has_nulls()});

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -203,8 +203,8 @@ right_run_index build_right_run_index(table_view const& table,
   auto const has_nulls = has_nested_nulls(table);
   std::vector<cudf::order> column_order(table.num_columns(), cudf::order::ASCENDING);
   std::vector<cudf::null_order> null_precedence(table.num_columns(), cudf::null_order::BEFORE);
-  auto const row_less =
-    detail::row::lexicographic::self_comparator{table, column_order, null_precedence, stream};
+  auto const row_less = detail::row::lexicographic::self_comparator{
+    table, column_order, null_precedence, stream, cudf::get_current_device_resource_ref()};
   if (cudf::has_nested_columns(table)) {
     return build_right_run_index(
       sorted_order, table.num_rows(), row_less.less<true>(nullate::DYNAMIC{has_nulls}), stream);
@@ -357,7 +357,12 @@ class merge {
     std::vector<cudf::order> column_order(smaller.num_columns(), cudf::order::ASCENDING);
     std::vector<cudf::null_order> null_precedence(smaller.num_columns(), cudf::null_order::BEFORE);
     tt_comparator = std::make_unique<detail::row::lexicographic::two_table_comparator>(
-      smaller, larger, column_order, null_precedence, stream);
+      smaller,
+      larger,
+      column_order,
+      null_precedence,
+      stream,
+      cudf::get_current_device_resource_ref());
   }
 
   std::unique_ptr<rmm::device_uvector<size_type>> matches_per_row(

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -109,7 +109,7 @@ class arg_minmax_dispatcher {
     auto const null_orders =
       std::vector<null_order>{K == aggregation::ARGMIN ? null_order::AFTER : null_order::BEFORE};
     auto const comparator = cudf::detail::row::lexicographic::self_comparator{
-      table_view{{input}}, {}, null_orders, stream};
+      table_view{{input}}, {}, null_orders, stream, cudf::get_current_device_resource_ref()};
     auto d_comp =
       comparator.less<false /* has_nested_columns */>(nullate::DYNAMIC{input.has_nulls()});
     return find_extremum_idx(cuda::counting_iterator<cudf::size_type>{0},

--- a/cpp/src/reductions/nested_types_extrema_utils.cuh
+++ b/cpp/src/reductions/nested_types_extrema_utils.cuh
@@ -111,7 +111,11 @@ class arg_minmax_binop_generator {
             auto null_orders    = flattened_input->null_orders();
             null_orders.front() = cudf::null_order::AFTER;
             return cudf::detail::row::lexicographic::self_comparator{
-              flattened_input->flattened_columns(), {}, null_orders, stream_};
+              flattened_input->flattened_columns(),
+              {},
+              null_orders,
+              stream_,
+              cudf::get_current_device_resource_ref()};
           } else {
             // For list type, we cannot set a separate null order for the top level column.
             // Thus, we have to workaround this by creating a dummy (empty) struct column view
@@ -127,11 +131,19 @@ class arg_minmax_binop_generator {
                                                   0,
                                                   {}};
             return cudf::detail::row::lexicographic::self_comparator{
-              cudf::table_view{{dummy_struct, input_}}, {}, null_orders, stream_};
+              cudf::table_view{{dummy_struct, input_}},
+              {},
+              null_orders,
+              stream_,
+              cudf::get_current_device_resource_ref()};
           }
         } else {
           return cudf::detail::row::lexicographic::self_comparator{
-            input_tview, {}, std::vector<null_order>{DEFAULT_NULL_ORDER}, stream_};
+            input_tview,
+            {},
+            std::vector<null_order>{DEFAULT_NULL_ORDER},
+            stream_,
+            cudf::get_current_device_resource_ref()};
         }
       }()}
   {

--- a/cpp/src/row_operator/row_operators.cu
+++ b/cpp/src/row_operator/row_operators.cu
@@ -297,7 +297,9 @@ auto decompose_structs(table_view table,
  * This helper function generates dremel data for any list-type columns in a
  * table. This data is necessary for lexicographic comparisons.
  */
-auto list_lex_preprocess(table_view const& table, cuda::stream_ref stream)
+auto list_lex_preprocess(table_view const& table,
+                         cuda::stream_ref stream,
+                         cudf::memory_resources mr)
 {
   std::vector<detail::dremel_data> dremel_data;
   auto const num_list_columns = std::count_if(
@@ -310,8 +312,8 @@ auto list_lex_preprocess(table_view const& table, cuda::stream_ref stream)
       dremel_device_views.push_back(dremel_data.back());
     }
   }
-  auto d_dremel_device_views = detail::make_device_uvector(
-    dremel_device_views, stream, cudf::get_current_device_resource_ref());
+  auto d_dremel_device_views =
+    detail::make_device_uvector(dremel_device_views, stream, mr.get_output_mr());
   return std::make_tuple(std::move(dremel_data), std::move(d_dremel_device_views));
 }
 
@@ -562,14 +564,14 @@ transform_lists_of_structs(column_view const& lhs,
                            column_view const& rhs,
                            null_order column_null_order,
                            cuda::stream_ref stream,
-                           rmm::device_async_resource_ref mr)
+                           cudf::memory_resources mr)
 {
   std::vector<std::unique_ptr<column>> out_cols_lhs;
   std::vector<std::unique_ptr<column>> out_cols_rhs;
 
   auto const make_output = [&](auto const& new_child_lhs, auto const& new_child_rhs) {
-    return std::tuple{replace_child(lhs, new_child_lhs, out_cols_lhs, stream, mr),
-                      replace_child(rhs, new_child_rhs, out_cols_rhs, stream, mr),
+    return std::tuple{replace_child(lhs, new_child_lhs, out_cols_lhs, stream, mr.get_output_mr()),
+                      replace_child(rhs, new_child_rhs, out_cols_rhs, stream, mr.get_output_mr()),
                       std::move(out_cols_lhs),
                       std::move(out_cols_rhs)};
   };
@@ -580,22 +582,20 @@ transform_lists_of_structs(column_view const& lhs,
 
     // Found a lists-of-structs column.
     if (child_lhs.type().id() == type_id::STRUCT) {
-      auto const concatenated_children =
-        cudf::detail::concatenate(std::vector<column_view>{child_lhs, child_rhs},
-                                  stream,
-                                  cudf::get_current_device_resource_ref());
+      auto const concatenated_children = cudf::detail::concatenate(
+        std::vector<column_view>{child_lhs, child_rhs}, stream, mr.get_temporary_mr());
 
-      auto const ranks        = compute_ranks(concatenated_children->view(),
-                                       column_null_order,
-                                       stream,
-                                       cudf::get_current_device_resource_ref());
+      auto const ranks = compute_ranks(
+        concatenated_children->view(), column_null_order, stream, mr.get_temporary_mr());
       auto const ranks_slices = cudf::detail::slice(
         ranks->view(),
         {0, child_lhs.size(), child_lhs.size(), child_lhs.size() + child_rhs.size()},
         stream);
 
-      out_cols_lhs.emplace_back(std::make_unique<column>(ranks_slices.front(), stream, mr));
-      out_cols_rhs.emplace_back(std::make_unique<column>(ranks_slices.back(), stream, mr));
+      out_cols_lhs.emplace_back(
+        std::make_unique<column>(ranks_slices.front(), stream, mr.get_output_mr()));
+      out_cols_rhs.emplace_back(
+        std::make_unique<column>(ranks_slices.back(), stream, mr.get_output_mr()));
 
       return make_output(out_cols_lhs.back()->view(), out_cols_rhs.back()->view());
 
@@ -638,21 +638,21 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(
   host_span<order const> column_order,
   host_span<null_order const> null_precedence,
   bool has_ranked_children,
-  cuda::stream_ref stream)
+  cuda::stream_ref stream,
+  cudf::memory_resources mr)
 {
   check_lex_compatibility(preprocessed_input);
 
-  auto d_table        = table_device_view::create(preprocessed_input, stream);
-  auto d_column_order = detail::make_device_uvector_async(
-    column_order, stream, cudf::get_current_device_resource_ref());
-  auto d_null_precedence = detail::make_device_uvector_async(
-    null_precedence, stream, cudf::get_current_device_resource_ref());
-  auto d_depths = detail::make_device_uvector_async(
-    verticalized_col_depths, stream, cudf::get_current_device_resource_ref());
+  auto d_table        = table_device_view::create(preprocessed_input, stream, mr.get_output_mr());
+  auto d_column_order = detail::make_device_uvector_async(column_order, stream, mr.get_output_mr());
+  auto d_null_precedence =
+    detail::make_device_uvector_async(null_precedence, stream, mr.get_output_mr());
+  auto d_depths =
+    detail::make_device_uvector_async(verticalized_col_depths, stream, mr.get_output_mr());
   cudf::detail::sync_stream(stream);
 
   if (detail::has_nested_columns(preprocessed_input)) {
-    auto [dremel_data, d_dremel_device_view] = list_lex_preprocess(preprocessed_input, stream);
+    auto [dremel_data, d_dremel_device_view] = list_lex_preprocess(preprocessed_input, stream, mr);
     return std::shared_ptr<preprocessed_table>(
       new preprocessed_table(std::move(d_table),
                              std::move(d_column_order),
@@ -677,7 +677,8 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(
   table_view const& input,
   host_span<order const> column_order,
   host_span<null_order const> null_precedence,
-  cuda::stream_ref stream)
+  cuda::stream_ref stream,
+  cudf::memory_resources mr)
 {
   auto [decomposed_input, new_column_order, new_null_precedence, verticalized_col_depths] =
     decompose_structs(input, decompose_lists_column::NO, column_order, null_precedence);
@@ -695,7 +696,7 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(
           lhs_col,
           null_precedence.empty() ? null_order::BEFORE : new_null_precedence[col_idx],
           stream,
-          cudf::get_current_device_resource_ref());
+          mr.get_output_mr());
 
         transformed_cvs.emplace_back(std::move(transformed));
         transformed_columns.insert(transformed_columns.end(),
@@ -713,7 +714,8 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(
                 new_column_order,
                 new_null_precedence,
                 has_ranked_children,
-                stream);
+                stream,
+                mr);
 }
 
 std::pair<std::shared_ptr<preprocessed_table>, std::shared_ptr<preprocessed_table>>
@@ -721,7 +723,8 @@ preprocessed_table::create(table_view const& lhs,
                            table_view const& rhs,
                            host_span<order const> column_order,
                            host_span<null_order const> null_precedence,
-                           cuda::stream_ref stream)
+                           cuda::stream_ref stream,
+                           cudf::memory_resources mr)
 {
   check_shape_compatibility(lhs, rhs);
 
@@ -757,7 +760,7 @@ preprocessed_table::create(table_view const& lhs,
           rhs_col,
           null_precedence.empty() ? null_order::BEFORE : new_null_precedence_lhs[col_idx],
           stream,
-          cudf::get_current_device_resource_ref());
+          mr);
 
       transformed_lhs_cvs.emplace_back(std::move(transformed_lhs));
       transformed_rhs_cvs.emplace_back(std::move(transformed_rhs));
@@ -783,14 +786,16 @@ preprocessed_table::create(table_view const& lhs,
                  new_column_order_lhs,
                  new_null_precedence_lhs,
                  has_ranked_children_lhs,
-                 stream),
+                 stream,
+                 mr),
           create(transformed_rhs,
                  std::move(verticalized_col_depths_rhs),
                  std::move(transformed_columns_rhs),
                  new_column_order_lhs,
                  new_null_precedence_lhs,
                  has_ranked_children_rhs,
-                 stream)};
+                 stream,
+                 mr)};
 }
 
 preprocessed_table::preprocessed_table(
@@ -834,10 +839,11 @@ two_table_comparator::two_table_comparator(table_view const& left,
                                            table_view const& right,
                                            host_span<order const> column_order,
                                            host_span<null_order const> null_precedence,
-                                           cuda::stream_ref stream)
+                                           cuda::stream_ref stream,
+                                           cudf::memory_resources mr)
 {
   std::tie(d_left_table, d_right_table) =
-    preprocessed_table::create(left, right, column_order, null_precedence, stream);
+    preprocessed_table::create(left, right, column_order, null_precedence, stream, mr);
 }
 
 }  // namespace lexicographic

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -57,7 +57,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   auto const& matched_needles  = matched.second.back();
 
   auto const comparator = cudf::detail::row::lexicographic::two_table_comparator(
-    matched_haystack, matched_needles, column_order, null_precedence, stream);
+    matched_haystack, matched_needles, column_order, null_precedence, stream, mr);
   auto const has_nulls = has_nested_nulls(matched_haystack) or has_nested_nulls(matched_needles);
 
   auto const haystack_it = cudf::detail::row::lhs_iterator(0);

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -29,8 +29,8 @@ bool is_sorted(cudf::table_view const& in,
                std::vector<null_order> const& null_precedence,
                cuda::stream_ref stream)
 {
-  auto const comparator =
-    detail::row::lexicographic::self_comparator{in, column_order, null_precedence, stream};
+  auto const comparator = detail::row::lexicographic::self_comparator{
+    in, column_order, null_precedence, stream, cudf::get_current_device_resource_ref()};
 
   if (cudf::detail::has_nested_columns(in)) {
     auto const device_comparator = comparator.less<true>(has_nested_nulls(in));

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -82,8 +82,8 @@ std::unique_ptr<column> sorted_order(table_view input,
     }
   };
 
-  auto const comp =
-    cudf::detail::row::lexicographic::self_comparator(input, column_order, null_precedence, stream);
+  auto const comp = cudf::detail::row::lexicographic::self_comparator(
+    input, column_order, null_precedence, stream, mr);
   if (cudf::detail::has_nested_columns(input)) {
     auto const comparator = comp.less<true>(nullate::DYNAMIC{has_nested_nulls(input)});
     do_sort(comparator);

--- a/cpp/tests/row_operator/row_operator_tests.cu
+++ b/cpp/tests/row_operator/row_operator_tests.cu
@@ -63,8 +63,6 @@ TYPED_TEST(TypedTableViewTest, TestLexicographicalComparatorTwoTables)
 {
   using T = TypeParam;
 
-  // TODO: lexicographic row operators still allocate from the current device resource.
-
   auto const stream = this->stream();
   auto const mr     = this->resources();
 
@@ -75,6 +73,7 @@ TYPED_TEST(TypedTableViewTest, TestLexicographicalComparatorTwoTables)
   auto const rhs          = cudf::table_view{{col2}};
 
   auto const expected = cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 0, 1}, stream, mr};
+  auto const guard    = this->harness().fail_on_current_device_resource_use();
   auto const got =
     two_table_comparison(lhs,
                          rhs,
@@ -100,8 +99,6 @@ TYPED_TEST(TypedTableViewTest, TestLexicographicalComparatorSameTable)
 {
   using T = TypeParam;
 
-  // TODO: lexicographic row operators still allocate from the current device resource.
-
   auto const stream = this->stream();
   auto const mr     = this->resources();
 
@@ -110,6 +107,7 @@ TYPED_TEST(TypedTableViewTest, TestLexicographicalComparatorSameTable)
   auto const input_table  = cudf::table_view{{col1}};
 
   auto const expected = cudf::test::fixed_width_column_wrapper<bool>{{0, 0, 0, 0}, stream, mr};
+  auto const guard    = this->harness().fail_on_current_device_resource_use();
   auto const got      = self_comparison(input_table,
                                    column_order,
                                    cudf::detail::row::lexicographic::physical_element_comparator{},
@@ -132,8 +130,6 @@ TYPED_TEST(TypedTableViewTest, TestSortSameTableFromTwoTables)
 {
   using data_col   = cudf::test::fixed_width_column_wrapper<TypeParam>;
   using int32s_col = cudf::test::fixed_width_column_wrapper<int32_t>;
-
-  // TODO: lexicographic row operators still allocate from the current device resource.
 
   auto const stream = this->stream();
   auto const mr     = this->resources();
@@ -175,19 +171,21 @@ TYPED_TEST(TypedTableViewTest, TestSortSameTableFromTwoTables)
               expected_empty_rhs);
   };
 
+  auto const guard = this->harness().fail_on_current_device_resource_use();
+
   // Generate preprocessed data for both lhs and lhs at the same time.
   // Switching order of lhs and rhs tables then sorting them using their preprocessed data should
   // produce exactly the same result.
   {
     auto const [preprocessed_lhs, preprocessed_empty_rhs] =
       cudf::detail::row::lexicographic::preprocessed_table::create(
-        lhs, empty_rhs, std::vector{cudf::order::ASCENDING}, {}, stream);
+        lhs, empty_rhs, std::vector{cudf::order::ASCENDING}, {}, stream, mr);
     test_sort_two_tables(preprocessed_lhs, preprocessed_empty_rhs);
   }
   {
     auto const [preprocessed_empty_rhs, preprocessed_lhs] =
       cudf::detail::row::lexicographic::preprocessed_table::create(
-        empty_rhs, lhs, std::vector{cudf::order::ASCENDING}, {}, stream);
+        empty_rhs, lhs, std::vector{cudf::order::ASCENDING}, {}, stream, mr);
     test_sort_two_tables(preprocessed_lhs, preprocessed_empty_rhs);
   }
 }
@@ -198,8 +196,6 @@ TYPED_TEST(TypedTableViewTest, TestSortSameTableFromTwoTablesWithListsOfStructs)
   using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
   using strings_col = cudf::test::strings_column_wrapper;
   using structs_col = cudf::test::structs_column_wrapper;
-
-  // TODO: lexicographic row operators still allocate from the current device resource.
 
   auto const stream = this->stream();
   auto const mr     = this->resources();
@@ -267,13 +263,13 @@ TYPED_TEST(TypedTableViewTest, TestSortSameTableFromTwoTablesWithListsOfStructs)
   {
     auto const [preprocessed_lhs, preprocessed_empty_rhs] =
       cudf::detail::row::lexicographic::preprocessed_table::create(
-        lhs, empty_rhs, std::vector{cudf::order::ASCENDING}, {}, stream);
+        lhs, empty_rhs, std::vector{cudf::order::ASCENDING}, {}, stream, mr);
     test_sort_two_tables(preprocessed_lhs, preprocessed_empty_rhs);
   }
   {
     auto const [preprocessed_empty_rhs, preprocessed_lhs] =
       cudf::detail::row::lexicographic::preprocessed_table::create(
-        empty_rhs, lhs, std::vector{cudf::order::ASCENDING}, {}, stream);
+        empty_rhs, lhs, std::vector{cudf::order::ASCENDING}, {}, stream, mr);
     test_sort_two_tables(preprocessed_lhs, preprocessed_empty_rhs);
   }
 }
@@ -286,8 +282,6 @@ TYPED_TEST_SUITE(NaNTableViewTest, cudf::test::FloatingPointTypes);
 TYPED_TEST(NaNTableViewTest, TestLexicographicalComparatorTwoTableNaNCase)
 {
   using T = TypeParam;
-
-  // TODO: lexicographic row operators still allocate from the current device resource.
 
   auto const stream = this->stream();
   auto const mr     = this->resources();
@@ -302,6 +296,7 @@ TYPED_TEST(NaNTableViewTest, TestLexicographicalComparatorTwoTableNaNCase)
   auto const rhs = cudf::table_view{{col2}};
 
   auto const expected = cudf::test::fixed_width_column_wrapper<bool>{{0, 0, 0, 0}, stream, mr};
+  auto const guard    = this->harness().fail_on_current_device_resource_use();
   auto const got =
     two_table_comparison(lhs,
                          rhs,

--- a/cpp/tests/row_operator/self_comparison_utilities.cu
+++ b/cpp/tests/row_operator/self_comparison_utilities.cu
@@ -25,7 +25,7 @@ std::unique_ptr<cudf::column> self_comparison(cudf::table_view input,
                                               cudf::memory_resources mr)
 {
   auto const table_comparator =
-    cudf::detail::row::lexicographic::self_comparator{input, column_order, {}, stream};
+    cudf::detail::row::lexicographic::self_comparator{input, column_order, {}, stream, mr};
 
   auto output = cudf::make_numeric_column(cudf::data_type(cudf::type_id::BOOL8),
                                           input.num_rows(),

--- a/cpp/tests/row_operator/two_table_comparison_utilities.cu
+++ b/cpp/tests/row_operator/two_table_comparison_utilities.cu
@@ -25,9 +25,8 @@ std::unique_ptr<cudf::column> two_table_comparison(cudf::table_view lhs,
                                                    cuda::stream_ref stream,
                                                    cudf::memory_resources mr)
 {
-  // TODO: lexicographic::two_table_comparator still allocates from the current device resource.
   auto const table_comparator =
-    cudf::detail::row::lexicographic::two_table_comparator{lhs, rhs, column_order, {}, stream};
+    cudf::detail::row::lexicographic::two_table_comparator{lhs, rhs, column_order, {}, stream, mr};
   auto const lhs_it = cudf::detail::row::lhs_iterator(0);
   auto const rhs_it = cudf::detail::row::rhs_iterator(0);
 

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -36,7 +36,7 @@ void row_comparison(cudf::table_view input1,
   cuda::stream_ref stream{cudf::get_default_stream()};
 
   auto const comparator = cudf::detail::row::lexicographic::two_table_comparator{
-    input1, input2, column_order, {}, stream};
+    input1, input2, column_order, {}, stream, cudf::get_current_device_resource_ref()};
   auto const lhs_it = cudf::detail::row::lhs_iterator(0);
   auto const rhs_it = cudf::detail::row::rhs_iterator(0);
 


### PR DESCRIPTION
## Description

A part of https://github.com/NVIDIA/cudf/issues/20780.

- Port lexicographic `preprocessed_table`, `self_comparator`, and `two_table_comparator` to take `cudf::memory_resources`.
- Route comparator-owned device state and preprocessing scratch through explicit output and temporary resources.
- Update sorting, joining, reduction, search, and row-operator callers and add strict current-resource test coverage.

## Test plan
- [x] Pre-commit checks on all changed files
- [x] `ROW_OPERATOR_TEST` (53/53 passed)
- [x] `TABLE_TEST` (32/32 passed)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.