### PR TITLE
Route list-offset utilities through memory resources

### DIFF
--- a/cpp/src/lists/utilities.cu
+++ b/cpp/src/lists/utilities.cu
@@ -15,10 +15,13 @@ namespace cudf::lists::detail {
 std::unique_ptr<column> generate_labels(lists_column_view const& input,
                                         size_type n_elements,
                                         cuda::stream_ref stream,
-                                        rmm::device_async_resource_ref mr)
+                                        cudf::memory_resources mr)
 {
-  auto labels = make_numeric_column(
-    data_type(type_to_id<size_type>()), n_elements, cudf::mask_state::UNALLOCATED, stream, mr);
+  auto labels             = make_numeric_column(data_type(type_to_id<size_type>()),
+                                    n_elements,
+                                    cudf::mask_state::UNALLOCATED,
+                                    stream,
+                                    mr.get_output_mr());
   auto const labels_begin = labels->mutable_view().template begin<size_type>();
   cudf::detail::label_segments(
     input.offsets_begin(), input.offsets_end(), labels_begin, labels_begin + n_elements, stream);
@@ -28,11 +31,11 @@ std::unique_ptr<column> generate_labels(lists_column_view const& input,
 std::unique_ptr<column> reconstruct_offsets(column_view const& labels,
                                             size_type n_lists,
                                             cuda::stream_ref stream,
-                                            rmm::device_async_resource_ref mr)
+                                            cudf::memory_resources mr)
 
 {
   auto out_offsets = make_numeric_column(
-    data_type{type_id::INT32}, n_lists + 1, mask_state::UNALLOCATED, stream, mr);
+    data_type{type_id::INT32}, n_lists + 1, mask_state::UNALLOCATED, stream, mr.get_output_mr());
 
   auto const labels_begin  = labels.template begin<size_type>();
   auto const offsets_begin = out_offsets->mutable_view().template begin<int32_t>();
@@ -46,13 +49,16 @@ std::unique_ptr<column> reconstruct_offsets(column_view const& labels,
 
 std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                                cuda::stream_ref stream,
-                                               rmm::device_async_resource_ref mr)
+                                               cudf::memory_resources mr)
 {
   if (input.is_empty()) { return empty_like(input.offsets()); }
 
-  auto out_offsets = make_numeric_column(
-    data_type(type_id::INT32), input.size() + 1, cudf::mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+  auto out_offsets = make_numeric_column(data_type(type_id::INT32),
+                                         input.size() + 1,
+                                         cudf::mask_state::UNALLOCATED,
+                                         stream,
+                                         mr.get_output_mr());
+  thrust::transform(rmm::exec_policy_nosync(stream, mr.get_temporary_mr()),
                     input.offsets_begin(),
                     input.offsets_end(),
                     out_offsets->mutable_view().begin<int32_t>(),

--- a/cpp/src/lists/utilities.hpp
+++ b/cpp/src/lists/utilities.hpp
@@ -19,13 +19,13 @@ namespace cudf::lists::detail {
  * @param input The input lists column
  * @param n_elements The number of elements in the child column of the input lists column
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned object
+ * @param mr Memory resources used for returned and temporary allocations
  * @return A column containing list labels corresponding to each element in the child column
  */
 std::unique_ptr<column> generate_labels(lists_column_view const& input,
                                         size_type n_elements,
                                         cuda::stream_ref stream,
-                                        rmm::device_async_resource_ref mr);
+                                        cudf::memory_resources mr);
 
 /**
  * @brief Reconstruct an offsets column from the input list labels column.
@@ -33,24 +33,24 @@ std::unique_ptr<column> generate_labels(lists_column_view const& input,
  * @param labels The list labels corresponding to each list element
  * @param n_lists The number of lists to build the offsets column
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned object
+ * @param mr Memory resources used for returned and temporary allocations
  * @return The output offsets column
  */
 std::unique_ptr<column> reconstruct_offsets(column_view const& labels,
                                             size_type n_lists,
                                             cuda::stream_ref stream,
-                                            rmm::device_async_resource_ref mr);
+                                            cudf::memory_resources mr);
 
 /**
  * @brief Generate 0-based list offsets from the offsets of the input lists column.
  *
  * @param input The input lists column
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned object
+ * @param mr Memory resources used for returned and temporary allocations
  * @return The output offsets column with values start from 0
  */
 std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                                cuda::stream_ref stream,
-                                               rmm::device_async_resource_ref mr);
+                                               cudf::memory_resources mr);
 
 }  // namespace cudf::lists::detail


### PR DESCRIPTION
## Description

A part of https://github.com/NVIDIA/cudf/issues/20780.

- Port `cudf::lists::detail::get_normalized_offsets` to take `cudf::memory_resources`.
- Route the returned offsets through the output resource and offset-normalization scratch through the temporary resource.
- Update internal list utility callers to forward the resource pair explicitly.

## Test plan
- [x] Pre-commit checks on all changed files
- [x] `LISTS_TEST` (1229/1229 passed)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.