### PR TITLE
ci: seed pre-commit cache from main builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,20 @@ jobs:
         # since other jobs depend on it.
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
+  checks:
+    needs: telemetry-setup
+    permissions:
+      actions: read
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@codex/checks-main-cache
+    with:
+      # Seed the default-branch pre-commit cache without running checks that only apply to PRs.
+      base-branch: main
+      enable_check_size: false
+      enable_check_generated_files: false
+      enable_check_pr_job_dependencies: false
+      enable_check_version_files_changed: false
+      enable_check_version_against_tag: false
   cpp-build:
     needs: [build-details, telemetry-setup]
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,11 +51,12 @@ jobs:
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   checks:
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: telemetry-setup
     permissions:
       actions: read
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@codex/checks-main-cache
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       # Seed the default-branch pre-commit cache without running checks that only apply to PRs.
       base-branch: main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,10 +234,13 @@ jobs:
     permissions:
       contents: read
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@codex/checks-main-cache
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize cudf-spark-jni cuml-compat-tests"
+      # Main builds seed this cache. PR merge refs can restore it but should not create
+      # duplicate archives that are inaccessible to other PRs.
+      pre-commit-cache-read-only: true
   conda-cpp-build:
     needs: [build-details, checks]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,7 +234,7 @@ jobs:
     permissions:
       contents: read
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@codex/checks-main-cache
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize cudf-spark-jni cuml-compat-tests"

--- a/.github/workflows/wheels-build-stage.yaml
+++ b/.github/workflows/wheels-build-stage.yaml
@@ -125,7 +125,8 @@ jobs:
           INPUTS_SCRIPT: ${{ inputs.script }}
         shell: bash -leo pipefail {0}
       - name: Save Cython cache
-        if: inputs.stage == 'python' && steps.cython-cache-restore.outputs.cache-hit != 'true'
+        # PRs restore this cache but do not create merge-ref-scoped entries.
+        if: inputs.stage == 'python' && inputs.build_type != 'pull-request' && steps.cython-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.cache/cython


### PR DESCRIPTION
## Description

Run the shared checks workflow as a style-only job only on trusted `main` builds, where it writes the reusable pre-commit cache.

PR checks use the shared workflow’s read-only cache mode: they restore the pre-commit cache but do not create merge-ref-scoped copies that are inaccessible to other PRs.

Likewise, staged Python wheel builds still restore the Cython cache in PRs, but save it only from non-PR builds. This prevents short-lived PR cache entries while retaining cache reuse from trusted builds.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- Pre-commit hooks passed for the changed workflow files, including YAML lint and zizmor.
- Two Build workflow runs on this branch: first populated the pre-commit cache; the second restored it without creating another entry.