### PR TITLE
TEST: Address Python test optimization review feedback

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_sort_index.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_sort_index.py
@@ -107,56 +107,39 @@ def _assert_dataframe_multiindex_sort_index(
 
 
 @pytest.mark.parametrize(
-    "level, ascending, na_position",
+    "axis, level, ascending, ignore_index, inplace, na_position",
     [
-        (None, True, "last"),
-        (None, False, "last"),
-        (0, True, "first"),
-        (0, False, "last"),
-        ("b", False, "first"),
-        (1, True, "last"),
-        (1, False, "last"),
-        (["b"], False, "first"),
-        ("a", False, "last"),
-        (["a", "b"], True, "last"),
-        (["b", "a"], False, "last"),
-        ([0, 1], False, "last"),
-        ([1, 0], True, "last"),
-        ([0, 2], False, "first"),
+        (0, None, True, False, False, "last"),
+        (0, None, False, False, False, "last"),
+        (0, 0, True, False, False, "first"),
+        (0, 0, False, False, False, "last"),
+        (0, "b", False, False, False, "first"),
+        (0, 1, True, False, False, "last"),
+        (0, 1, False, False, False, "last"),
+        (0, ["b"], False, False, False, "first"),
+        (0, "a", False, False, False, "last"),
+        (0, ["a", "b"], True, False, False, "last"),
+        (0, ["b", "a"], False, False, False, "last"),
+        (0, [0, 1], False, False, False, "last"),
+        (0, [1, 0], True, False, False, "last"),
+        (0, [0, 2], False, False, False, "first"),
+        (0, [1, 0], False, True, True, "first"),
+        (0, [1, 0], False, False, True, "first"),
+        (0, [1, 0], False, True, False, "first"),
+        (0, [1, 0], False, False, False, "first"),
+        ("index", [0, 2], False, False, False, "first"),
     ],
 )
-def test_dataframe_multiindex_sort_index(level, ascending, na_position):
+def test_dataframe_multiindex_sort_index(
+    axis, level, ascending, ignore_index, inplace, na_position
+):
     _assert_dataframe_multiindex_sort_index(
-        axis=0,
+        axis=axis,
         level=level,
         ascending=ascending,
-        inplace=False,
-        ignore_index=False,
-        na_position=na_position,
-    )
-
-
-@pytest.mark.parametrize("inplace", [True, False])
-@pytest.mark.parametrize("ignore_index", [True, False])
-def test_dataframe_multiindex_sort_index_lifecycle(inplace, ignore_index):
-    _assert_dataframe_multiindex_sort_index(
-        axis=0,
-        level=[1, 0],
-        ascending=False,
         inplace=inplace,
         ignore_index=ignore_index,
-        na_position="first",
-    )
-
-
-def test_dataframe_multiindex_sort_index_axis_alias():
-    _assert_dataframe_multiindex_sort_index(
-        axis="index",
-        level=[0, 2],
-        ascending=False,
-        inplace=False,
-        ignore_index=False,
-        na_position="first",
+        na_position=na_position,
     )
 
 

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -2276,17 +2276,17 @@ _DATAFRAME_LIST_OTHERS = [
 @pytest.mark.parametrize(
     "df, other",
     [
-        pytest.param(_DATAFRAME_LIST_DFS[0], _DATAFRAME_LIST_OTHERS[0]),
-        pytest.param(_DATAFRAME_LIST_DFS[1], _DATAFRAME_LIST_OTHERS[1]),
-        pytest.param(_DATAFRAME_LIST_DFS[2], _DATAFRAME_LIST_OTHERS[2]),
-        pytest.param(_DATAFRAME_LIST_DFS[3], _DATAFRAME_LIST_OTHERS[3]),
-        pytest.param(_DATAFRAME_LIST_DFS[4], _DATAFRAME_LIST_OTHERS[4]),
-        pytest.param(_DATAFRAME_LIST_DFS[5], _DATAFRAME_LIST_OTHERS[0]),
-        pytest.param(_DATAFRAME_LIST_DFS[6], _DATAFRAME_LIST_OTHERS[1]),
-        pytest.param(_DATAFRAME_LIST_DFS[7], _DATAFRAME_LIST_OTHERS[2]),
-        pytest.param(_DATAFRAME_LIST_DFS[8], _DATAFRAME_LIST_OTHERS[3]),
-        pytest.param(_DATAFRAME_LIST_DFS[9], _DATAFRAME_LIST_OTHERS[4]),
-        pytest.param(_DATAFRAME_LIST_DFS[10], _DATAFRAME_LIST_OTHERS[2]),
+        (_DATAFRAME_LIST_DFS[0], _DATAFRAME_LIST_OTHERS[0]),
+        (_DATAFRAME_LIST_DFS[1], _DATAFRAME_LIST_OTHERS[1]),
+        (_DATAFRAME_LIST_DFS[2], _DATAFRAME_LIST_OTHERS[2]),
+        (_DATAFRAME_LIST_DFS[3], _DATAFRAME_LIST_OTHERS[3]),
+        (_DATAFRAME_LIST_DFS[4], _DATAFRAME_LIST_OTHERS[4]),
+        (_DATAFRAME_LIST_DFS[5], _DATAFRAME_LIST_OTHERS[0]),
+        (_DATAFRAME_LIST_DFS[6], _DATAFRAME_LIST_OTHERS[1]),
+        (_DATAFRAME_LIST_DFS[7], _DATAFRAME_LIST_OTHERS[2]),
+        (_DATAFRAME_LIST_DFS[8], _DATAFRAME_LIST_OTHERS[3]),
+        (_DATAFRAME_LIST_DFS[9], _DATAFRAME_LIST_OTHERS[4]),
+        (_DATAFRAME_LIST_DFS[10], _DATAFRAME_LIST_OTHERS[2]),
     ],
 )
 def test_dataframe_concat_lists(df, other, sort, ignore_index):
@@ -2447,42 +2447,18 @@ _DATAFRAME_CONCAT_LIST_OTHERS = [
 @pytest.mark.parametrize(
     "df, other",
     [
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[0], _DATAFRAME_CONCAT_LIST_OTHERS[0]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[1], _DATAFRAME_CONCAT_LIST_OTHERS[1]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[2], _DATAFRAME_CONCAT_LIST_OTHERS[2]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[3], _DATAFRAME_CONCAT_LIST_OTHERS[3]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[4], _DATAFRAME_CONCAT_LIST_OTHERS[4]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[5], _DATAFRAME_CONCAT_LIST_OTHERS[5]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[6], _DATAFRAME_CONCAT_LIST_OTHERS[6]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[7], _DATAFRAME_CONCAT_LIST_OTHERS[7]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[8], _DATAFRAME_CONCAT_LIST_OTHERS[8]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[9], _DATAFRAME_CONCAT_LIST_OTHERS[9]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[10], _DATAFRAME_CONCAT_LIST_OTHERS[10]
-        ),
-        pytest.param(
-            _DATAFRAME_CONCAT_LIST_DFS[11], _DATAFRAME_CONCAT_LIST_OTHERS[3]
-        ),
+        (_DATAFRAME_CONCAT_LIST_DFS[0], _DATAFRAME_CONCAT_LIST_OTHERS[0]),
+        (_DATAFRAME_CONCAT_LIST_DFS[1], _DATAFRAME_CONCAT_LIST_OTHERS[1]),
+        (_DATAFRAME_CONCAT_LIST_DFS[2], _DATAFRAME_CONCAT_LIST_OTHERS[2]),
+        (_DATAFRAME_CONCAT_LIST_DFS[3], _DATAFRAME_CONCAT_LIST_OTHERS[3]),
+        (_DATAFRAME_CONCAT_LIST_DFS[4], _DATAFRAME_CONCAT_LIST_OTHERS[4]),
+        (_DATAFRAME_CONCAT_LIST_DFS[5], _DATAFRAME_CONCAT_LIST_OTHERS[5]),
+        (_DATAFRAME_CONCAT_LIST_DFS[6], _DATAFRAME_CONCAT_LIST_OTHERS[6]),
+        (_DATAFRAME_CONCAT_LIST_DFS[7], _DATAFRAME_CONCAT_LIST_OTHERS[7]),
+        (_DATAFRAME_CONCAT_LIST_DFS[8], _DATAFRAME_CONCAT_LIST_OTHERS[8]),
+        (_DATAFRAME_CONCAT_LIST_DFS[9], _DATAFRAME_CONCAT_LIST_OTHERS[9]),
+        (_DATAFRAME_CONCAT_LIST_DFS[10], _DATAFRAME_CONCAT_LIST_OTHERS[10]),
+        (_DATAFRAME_CONCAT_LIST_DFS[11], _DATAFRAME_CONCAT_LIST_OTHERS[3]),
     ],
 )
 def test_dataframe_concat_dataframe_lists(df, other, sort, ignore_index):

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -2613,21 +2613,27 @@ def _assert_string_index_cat(
 
 
 @pytest.mark.parametrize(
-    "data, sep, na_rep, name",
+    "data, others, sep, na_rep, name",
     [
-        pytest.param(["1", "2", "3", "4", "5"], None, None, None),
-        pytest.param(["a", "b", "c", "d", "e"], "", None, "index name"),
-        pytest.param(["a", "b", "c", "d", "e"], " ", None, None),
-        pytest.param(["a", "b", "c", "d", "e"], ",", None, None),
-        pytest.param(["a", "b", "c", "d", "e"], "|", None, None),
-        pytest.param(["a", "b", "c", "d", "e"], "|||", None, None),
-        pytest.param(["a", None, "c", None, "e"], "|", "", None),
-        pytest.param(["a", None, "c", None, "e"], "|", "null", None),
-        pytest.param(["a", None, "c", None, "e"], "|", "a", None),
+        (["1", "2", "3", "4", "5"], None, None, None, None),
+        (
+            ["a", "b", "c", "d", "e"],
+            ["f", "g", "h", "i", "j"],
+            "",
+            None,
+            "index name",
+        ),
+        (["a", "b", "c", "d", "e"], None, " ", None, None),
+        (["a", "b", "c", "d", "e"], None, ",", None, None),
+        (["a", "b", "c", "d", "e"], None, "|", None, None),
+        (["a", "b", "c", "d", "e"], None, "|||", None, None),
+        (["a", None, "c", None, "e"], None, "|", "", None),
+        (["a", None, "c", None, "e"], None, "|", "null", None),
+        (["a", None, "c", None, "e"], None, "|", "a", None),
     ],
 )
-def test_string_index_str_cat_join(data, sep, na_rep, name):
-    _assert_string_index_cat(data, None, sep, na_rep, name)
+def test_string_index_str_cat_join(data, others, sep, na_rep, name):
+    _assert_string_index_cat(data, others, sep, na_rep, name)
 
 
 def _assert_string_cat(data, others, sep, na_rep, index=None):
@@ -2650,14 +2656,14 @@ def _assert_string_cat(data, others, sep, na_rep, index=None):
 @pytest.mark.parametrize(
     "data, sep, na_rep",
     [
-        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], None, None),
-        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "", None),
-        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "|", None),
-        pytest.param(["AbC", "de", "FGHI", "j", "kLm"], "|||", None),
-        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", None),
-        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", ""),
-        pytest.param(["nOPq", None, "RsT", None, "uVw"], "|", "null"),
-        pytest.param([None, None, None, None, None], "|", "null"),
+        (["AbC", "de", "FGHI", "j", "kLm"], None, None),
+        (["AbC", "de", "FGHI", "j", "kLm"], "", None),
+        (["AbC", "de", "FGHI", "j", "kLm"], "|", None),
+        (["AbC", "de", "FGHI", "j", "kLm"], "|||", None),
+        (["nOPq", None, "RsT", None, "uVw"], "|", None),
+        (["nOPq", None, "RsT", None, "uVw"], "|", ""),
+        (["nOPq", None, "RsT", None, "uVw"], "|", "null"),
+        ([None, None, None, None, None], "|", "null"),
     ],
 )
 def test_string_cat_join(data, sep, na_rep):

--- a/python/cudf/cudf/tests/series/methods/test_cov_corr.py
+++ b/python/cudf/cudf/tests/series/methods/test_cov_corr.py
@@ -11,47 +11,68 @@ import cudf
 from cudf.testing import assert_eq
 from cudf.testing._utils import expect_warning_if
 
-COV_CORR_DATA_PAIRS = [
-    pytest.param(
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        id="normal-integers",
-    ),
-    pytest.param(
-        np.random.default_rng(seed=0).integers(-50, 50, 1000),
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        id="integers-normal",
-    ),
-    pytest.param(np.zeros(100), np.zeros(100), id="constant"),
-    pytest.param(
-        np.repeat(np.nan, 100), np.repeat(np.nan, 100), id="all-null"
-    ),
-    pytest.param(
-        np.array([1.123, 2.343, np.nan, 0.0]),
-        np.array([1.123, 2.343, np.nan, 0.0]),
-        id="nullable",
-    ),
-    pytest.param(
-        pa.array([5, 10, 53, None, np.nan, None]),
-        np.array([1.0, 4.0, 9.0, np.nan, 16.0, 25.0]),
-        id="arrow",
-    ),
-    pytest.param(
-        pd.Series([1.1, 2.32, 43.4], index=[0, 4, 3]),
-        pd.Series([43.4, 1.1, 2.32], index=[3, 0, 4]),
-        id="indexed-series",
-    ),
-    pytest.param(np.array([], dtype="float64"), np.array([5]), id="empty"),
-    pytest.param(
-        np.array([-3]),
-        np.random.default_rng(seed=0).normal(-100, 100, 1000),
-        id="singleton",
-    ),
-]
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(
+            (
+                np.random.default_rng(seed=0).normal(-100, 100, 1000),
+                np.random.default_rng(seed=0).integers(-50, 50, 1000),
+            ),
+            id="normal-integers",
+        ),
+        pytest.param(
+            (
+                np.random.default_rng(seed=0).integers(-50, 50, 1000),
+                np.random.default_rng(seed=0).normal(-100, 100, 1000),
+            ),
+            id="integers-normal",
+        ),
+        pytest.param((np.zeros(100), np.zeros(100)), id="constant"),
+        pytest.param(
+            (np.repeat(np.nan, 100), np.repeat(np.nan, 100)),
+            id="all-null",
+        ),
+        pytest.param(
+            (
+                np.array([1.123, 2.343, np.nan, 0.0]),
+                np.array([1.123, 2.343, np.nan, 0.0]),
+            ),
+            id="nullable",
+        ),
+        pytest.param(
+            (
+                pa.array([5, 10, 53, None, np.nan, None]),
+                np.array([1.0, 4.0, 9.0, np.nan, 16.0, 25.0]),
+            ),
+            id="arrow",
+        ),
+        pytest.param(
+            (
+                pd.Series([1.1, 2.32, 43.4], index=[0, 4, 3]),
+                pd.Series([43.4, 1.1, 2.32], index=[3, 0, 4]),
+            ),
+            id="indexed-series",
+        ),
+        pytest.param(
+            (np.array([], dtype="float64"), np.array([5])), id="empty"
+        ),
+        pytest.param(
+            (
+                np.array([-3]),
+                np.random.default_rng(seed=0).normal(-100, 100, 1000),
+            ),
+            id="singleton",
+        ),
+    ],
+)
+def cov_corr_data_pair(request):
+    return request.param
 
 
-@pytest.mark.parametrize(("data1", "data2"), COV_CORR_DATA_PAIRS)
-def test_cov1d(data1, data2):
+def test_cov1d(cov_corr_data_pair):
+    data1, data2 = cov_corr_data_pair
     gs1 = cudf.Series(data1)
     gs2 = cudf.Series(data2)
 
@@ -69,8 +90,8 @@ def test_cov1d(data1, data2):
     np.testing.assert_approx_equal(got, expected, significant=8)
 
 
-@pytest.mark.parametrize(("data1", "data2"), COV_CORR_DATA_PAIRS)
-def test_corr1d(data1, data2, corr_method):
+def test_corr1d(cov_corr_data_pair, corr_method):
+    data1, data2 = cov_corr_data_pair
     if corr_method == "spearman":
         # Pandas uses scipy.stats.spearmanr code-path
         pytest.importorskip("scipy")


### PR DESCRIPTION
## Description

Addresses small review follow-ups from these merged Python test optimization PRs:

- [#24018](https://github.com/NVIDIA/cudf/pull/24018)
- [#24019](https://github.com/NVIDIA/cudf/pull/24019)
- [#24020](https://github.com/NVIDIA/cudf/pull/24020)
- [#24029](https://github.com/NVIDIA/cudf/pull/24029)
- [#24032](https://github.com/NVIDIA/cudf/pull/24032)
- [#24033](https://github.com/NVIDIA/cudf/pull/24033)

This is a test-only follow-up that incorporates the agreed small cleanup suggestions without changing the intended test coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.