### PR TITLE
[Java] Improve CUDA initialization diagnostics

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -687,6 +687,7 @@
                                     <arg value="-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"/>
                                     <arg value="-DCUDF_JNI_LIBCUDF_STATIC=${CUDF_JNI_LIBCUDF_STATIC}"/>
                                     <arg value="-DCUDF_JNI_ENABLE_PROFILING=${CUDF_JNI_ENABLE_PROFILING}"/>
+                                    <arg value="-DBUILD_TESTS=ON"/>
                                     <arg value="-DBUILD_SHARED_LIBS=ON"/>
                                 </exec>
                                 <exec dir="${native.build.path}"
@@ -697,6 +698,8 @@
                                     <arg value="--parallel"/>
                                     <arg value="${parallel.level}"/>
                                 </exec>
+                                <!-- GPU-independent native validation; intentionally runs when
+                                     Maven Java tests are skipped. -->
                                 <exec dir="${native.build.path}"
                                       failonerror="true"
                                       executable="${native.build.path}/CUDA_ERROR_DIAGNOSTICS_TEST"/>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -697,6 +697,9 @@
                                     <arg value="--parallel"/>
                                     <arg value="${parallel.level}"/>
                                 </exec>
+                                <exec dir="${native.build.path}"
+                                      failonerror="true"
+                                      executable="${native.build.path}/CUDA_ERROR_DIAGNOSTICS_TEST"/>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash"
                                       output="${project.build.directory}/extra-resources/cudf-java-version-info.properties">

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -185,6 +185,7 @@ add_library(
   src/VariantUtilsJni.cpp
   src/aggregation128_utils.cu
   src/check_nvcomp_output_sizes.cu
+  src/cuda_error_diagnostics.cpp
   src/maps_column_view.cu
   src/multi_host_buffer_source.cpp
 )
@@ -290,7 +291,25 @@ else()
   )
 endif()
 
-target_link_libraries(cudfjni PRIVATE nvtx3::nvtx3-cpp)
+target_link_libraries(cudfjni PRIVATE nvtx3::nvtx3-cpp ${CMAKE_DL_LIBS})
+
+if(BUILD_TESTS)
+  enable_testing()
+  find_package(Threads REQUIRED)
+
+  add_executable(
+    CUDA_ERROR_DIAGNOSTICS_TEST tests/cuda_error_diagnostics_test.cpp
+                                src/cuda_error_diagnostics.cpp
+  )
+  set_target_properties(
+    CUDA_ERROR_DIAGNOSTICS_TEST PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON
+  )
+  target_include_directories(
+    CUDA_ERROR_DIAGNOSTICS_TEST PRIVATE "${CMAKE_SOURCE_DIR}/include" "${CUDAToolkit_INCLUDE_DIRS}"
+  )
+  target_link_libraries(CUDA_ERROR_DIAGNOSTICS_TEST PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+  add_test(NAME CUDA_ERROR_DIAGNOSTICS_TEST COMMAND CUDA_ERROR_DIAGNOSTICS_TEST)
+endif()
 
 # ##################################################################################################
 # * cudart options --------------------------------------------------------------------------------

--- a/java/src/main/native/include/cuda_error_diagnostics.hpp
+++ b/java/src/main/native/include/cuda_error_diagnostics.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/java/src/main/native/include/cuda_error_diagnostics.hpp
+++ b/java/src/main/native/include/cuda_error_diagnostics.hpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace cudf::jni {
+
+namespace detail {
+
+enum class cuda_driver_probe_state {
+  library_unavailable,
+  symbols_unavailable,
+  initialization_failed,
+  initialized
+};
+
+struct cuda_driver_probe_result {
+  cuda_driver_probe_result(cuda_driver_probe_state state,
+                           std::string detail,
+                           int initialization_status         = 0,
+                           std::optional<int> driver_version = std::nullopt,
+                           std::optional<int> device_count   = std::nullopt)
+    : state{state},
+      detail{std::move(detail)},
+      initialization_status{initialization_status},
+      driver_version{driver_version},
+      device_count{device_count}
+  {
+  }
+
+  cuda_driver_probe_state state;
+  std::string detail;
+  int initialization_status{};
+  std::optional<int> driver_version;
+  std::optional<int> device_count;
+};
+
+struct dynamic_loader {
+  void* (*open)(char const*, int);
+  void* (*symbol)(void*, char const*);
+  char* (*error)();
+  int (*close)(void*);
+};
+
+cuda_driver_probe_result probe_cuda_driver(dynamic_loader const& loader);
+
+std::string format_cuda_initialization_diagnostic(cuda_driver_probe_result const& probe,
+                                                  int runtime_version);
+
+}  // namespace detail
+
+/**
+ * @brief Add initialization diagnostics to a CUDA error message when appropriate.
+ *
+ * Only `cudaErrorInsufficientDriver` messages are changed. The diagnostic is computed once per
+ * process and does not use the CUDA Runtime API, which may already be in a failed state.
+ */
+std::string augment_cuda_error_message(char const* message, cudaError_t status);
+
+}  // namespace cudf::jni

--- a/java/src/main/native/include/error.hpp
+++ b/java/src/main/native/include/error.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/java/src/main/native/include/error.hpp
+++ b/java/src/main/native/include/error.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "cuda_error_diagnostics.hpp"
+
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/error.hpp>
@@ -89,7 +91,8 @@ inline jthrowable cuda_exception(JNIEnv* const env, cudaError_t status, jthrowab
     env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;ILjava/lang/Throwable;)V");
   if (ctor_id == nullptr) { return nullptr; }
 
-  jstring msg = env->NewStringUTF(cudaGetErrorString(status));
+  auto const message = augment_cuda_error_message(cudaGetErrorString(status), status);
+  jstring msg        = env->NewStringUTF(message.c_str());
   if (msg == nullptr) { return nullptr; }
 
   jint err_code = static_cast<jint>(status);
@@ -153,7 +156,9 @@ inline void jni_cuda_check(JNIEnv* const env, cudaError_t cuda_status)
       env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;Ljava/lang/String;I)V");             \
     if (ctor_id == nullptr) { return ret_val; }                                                     \
     auto const empty_str = std::string{""};                                                         \
-    auto const jmessage  = env->NewStringUTF(message == nullptr ? empty_str.c_str() : message);     \
+    auto const detailed_message =                                                                   \
+      cudf::jni::augment_cuda_error_message(message, static_cast<cudaError_t>(error_code));         \
+    auto const jmessage = env->NewStringUTF(detailed_message.c_str());                              \
     if (jmessage == nullptr) { return ret_val; }                                                    \
     auto const jstacktrace =                                                                        \
       env->NewStringUTF(stacktrace == nullptr ? empty_str.c_str() : stacktrace);                    \

--- a/java/src/main/native/src/cuda_error_diagnostics.cpp
+++ b/java/src/main/native/src/cuda_error_diagnostics.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/java/src/main/native/src/cuda_error_diagnostics.cpp
+++ b/java/src/main/native/src/cuda_error_diagnostics.cpp
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cuda_error_diagnostics.hpp"
+
+#include <cuda.h>
+
+#include <dlfcn.h>
+
+#include <cstddef>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace cudf::jni {
+namespace {
+
+std::string format_cuda_version(int version)
+{
+  if (version <= 0) { return std::to_string(version); }
+  return std::to_string(version / 1000) + "." + std::to_string((version % 1000) / 10) + " (" +
+         std::to_string(version) + ")";
+}
+
+template <typename Function>
+Function load_function(detail::dynamic_loader const& loader, void* handle, char const* name)
+{
+  auto* symbol = loader.symbol(handle, name);
+  Function function{};
+  static_assert(sizeof(function) == sizeof(symbol));
+  std::memcpy(&function, &symbol, sizeof(function));
+  return function;
+}
+
+template <typename GetErrorName, typename GetErrorString>
+std::string format_driver_error(CUresult status,
+                                GetErrorName get_error_name,
+                                GetErrorString get_error_string)
+{
+  std::ostringstream out;
+  char const* name        = nullptr;
+  char const* description = nullptr;
+  if (get_error_name != nullptr) { get_error_name(status, &name); }
+  if (get_error_string != nullptr) { get_error_string(status, &description); }
+  if (name != nullptr) {
+    out << name;
+  } else {
+    out << "CUDA Driver API error";
+  }
+  out << " (" << static_cast<int>(status) << ")";
+  if (description != nullptr) { out << ": " << description; }
+  return out.str();
+}
+
+std::string generic_guidance()
+{
+  return "CUDA initialization diagnostics were inconclusive. cudaErrorInsufficientDriver can "
+         "also mean that the NVIDIA driver is unavailable, no GPU is visible, or the driver is "
+         "incompatible with the bundled CUDA runtime.";
+}
+
+detail::dynamic_loader const system_loader{dlopen, dlsym, dlerror, dlclose};
+
+std::string const& cached_cuda_initialization_diagnostic() noexcept
+{
+  static std::string const diagnostic = [] {
+    try {
+      return detail::format_cuda_initialization_diagnostic(detail::probe_cuda_driver(system_loader),
+                                                           CUDART_VERSION);
+    } catch (...) {
+      return generic_guidance();
+    }
+  }();
+  return diagnostic;
+}
+
+}  // namespace
+
+namespace detail {
+
+cuda_driver_probe_result probe_cuda_driver(dynamic_loader const& loader)
+{
+  auto* handle = loader.open("libcuda.so.1", RTLD_LAZY | RTLD_LOCAL);
+  if (handle == nullptr) {
+    auto const* error = loader.error();
+    return {cuda_driver_probe_state::library_unavailable,
+            error == nullptr ? "unknown dynamic loader error" : error};
+  }
+
+  struct library_closer {
+    dynamic_loader const& loader;
+    void* handle;
+    ~library_closer() { loader.close(handle); }
+  } close_library{loader, handle};
+
+  auto const init = load_function<decltype(&cuInit)>(loader, handle, "cuInit");
+  auto const get_driver_version =
+    load_function<decltype(&cuDriverGetVersion)>(loader, handle, "cuDriverGetVersion");
+  auto const get_device_count =
+    load_function<decltype(&cuDeviceGetCount)>(loader, handle, "cuDeviceGetCount");
+  auto const get_error_name =
+    load_function<decltype(&cuGetErrorName)>(loader, handle, "cuGetErrorName");
+  auto const get_error_string =
+    load_function<decltype(&cuGetErrorString)>(loader, handle, "cuGetErrorString");
+
+  std::vector<std::string> missing_symbols;
+  if (init == nullptr) { missing_symbols.emplace_back("cuInit"); }
+  if (get_driver_version == nullptr) { missing_symbols.emplace_back("cuDriverGetVersion"); }
+  if (get_device_count == nullptr) { missing_symbols.emplace_back("cuDeviceGetCount"); }
+  if (!missing_symbols.empty()) {
+    std::ostringstream detail;
+    for (std::size_t i = 0; i < missing_symbols.size(); ++i) {
+      if (i != 0) { detail << ", "; }
+      detail << missing_symbols[i];
+    }
+    return {cuda_driver_probe_state::symbols_unavailable, detail.str()};
+  }
+
+  auto const init_status = init(0);
+  if (init_status != CUDA_SUCCESS) {
+    return {cuda_driver_probe_state::initialization_failed,
+            format_driver_error(init_status, get_error_name, get_error_string),
+            static_cast<int>(init_status)};
+  }
+
+  cuda_driver_probe_result result{cuda_driver_probe_state::initialized, {}};
+  int driver_version{};
+  auto const driver_version_status = get_driver_version(&driver_version);
+  if (driver_version_status == CUDA_SUCCESS) {
+    result.driver_version = driver_version;
+  } else {
+    result.detail = "cuDriverGetVersion failed with " +
+                    format_driver_error(driver_version_status, get_error_name, get_error_string);
+  }
+
+  int device_count{};
+  auto const device_count_status = get_device_count(&device_count);
+  if (device_count_status == CUDA_SUCCESS) {
+    result.device_count = device_count;
+  } else {
+    if (!result.detail.empty()) { result.detail += "; "; }
+    result.detail += "cuDeviceGetCount failed with " +
+                     format_driver_error(device_count_status, get_error_name, get_error_string);
+  }
+  return result;
+}
+
+std::string format_cuda_initialization_diagnostic(cuda_driver_probe_result const& probe,
+                                                  int runtime_version)
+{
+  std::ostringstream out;
+  out << "CUDA initialization diagnostics: bundled CUDA runtime "
+      << format_cuda_version(runtime_version) << "; ";
+
+  switch (probe.state) {
+    case cuda_driver_probe_state::library_unavailable:
+      out << "libcuda.so.1 could not be loaded (" << probe.detail
+          << "). The NVIDIA driver may be absent, or its library may not be mounted in or "
+             "discoverable from the container. Verify GPU assignment, the NVIDIA container "
+             "runtime or device plugin, and the dynamic loader configuration.";
+      break;
+    case cuda_driver_probe_state::symbols_unavailable:
+      out << "libcuda.so.1 is missing required symbol(s): " << probe.detail
+          << ". The driver installation may be incomplete or incompatible.";
+      break;
+    case cuda_driver_probe_state::initialization_failed:
+      out << "libcuda.so.1 was loaded, but cuInit failed with " << probe.detail << ". ";
+      if (probe.initialization_status == CUDA_ERROR_NO_DEVICE) {
+        out << "No CUDA device is visible. Verify the container GPU assignment, device plugin or "
+               "runtime class, and CUDA_VISIBLE_DEVICES.";
+      } else if (probe.initialization_status == CUDA_ERROR_SYSTEM_DRIVER_MISMATCH) {
+        out << "The NVIDIA kernel and user-mode driver components do not match.";
+      } else if (probe.initialization_status == CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE) {
+        out << "The CUDA forward-compatibility configuration is not supported by this device.";
+      } else {
+        out << "Verify the driver installation, GPU visibility, and driver/runtime compatibility.";
+      }
+      break;
+    case cuda_driver_probe_state::initialized:
+      out << "libcuda.so.1 loaded and the Driver API initialized";
+      if (probe.driver_version.has_value()) {
+        out << "; driver supports CUDA " << format_cuda_version(*probe.driver_version);
+      }
+      if (!probe.detail.empty()) { out << "; " << probe.detail; }
+      if (probe.device_count.has_value()) {
+        out << "; visible devices: " << *probe.device_count << ". ";
+        if (*probe.device_count == 0) {
+          out << "No CUDA device is visible. Verify the container GPU assignment, device plugin "
+                 "or runtime class, and CUDA_VISIBLE_DEVICES.";
+        } else if (probe.driver_version.has_value() && *probe.driver_version < runtime_version) {
+          out << "The CUDA runtime rejected this older driver. Upgrade the host driver or use a "
+                 "compatible cuDF CUDA artifact.";
+        } else {
+          out << "The CUDA runtime still rejected the accessible driver. Verify driver/runtime "
+                 "compatibility and container driver-library mounts.";
+        }
+      } else {
+        out << ". Verify GPU visibility and driver/runtime compatibility.";
+      }
+      break;
+  }
+  return out.str();
+}
+
+}  // namespace detail
+
+std::string augment_cuda_error_message(char const* message, cudaError_t status)
+{
+  std::string result{message == nullptr ? "" : message};
+  if (status != cudaErrorInsufficientDriver) { return result; }
+
+  result += "\n";
+  result += cached_cuda_initialization_diagnostic();
+  return result;
+}
+
+}  // namespace cudf::jni

--- a/java/src/main/native/tests/cuda_error_diagnostics_test.cpp
+++ b/java/src/main/native/tests/cuda_error_diagnostics_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,9 +30,24 @@ struct fake_driver {
   int close_count{};
 };
 
-fake_driver* active_driver;
+fake_driver* active_driver{};
 int fake_library_handle;
 int failures{};
+
+class active_driver_guard {
+ public:
+  explicit active_driver_guard(fake_driver& driver) : previous_driver{active_driver}
+  {
+    active_driver = &driver;
+  }
+  ~active_driver_guard() { active_driver = previous_driver; }
+
+  active_driver_guard(active_driver_guard const&)            = delete;
+  active_driver_guard& operator=(active_driver_guard const&) = delete;
+
+ private:
+  fake_driver* previous_driver;
+};
 
 void expect(bool condition, char const* message)
 {
@@ -127,7 +142,7 @@ dynamic_loader const fake_loader{fake_open, fake_symbol, fake_error, fake_close}
 void test_unavailable_driver_library()
 {
   fake_driver driver;
-  active_driver            = &driver;
+  active_driver_guard guard{driver};
   driver.library_available = false;
 
   auto const result = probe_cuda_driver(fake_loader);
@@ -140,7 +155,7 @@ void test_unavailable_driver_library()
 void test_missing_required_symbols()
 {
   fake_driver driver;
-  active_driver         = &driver;
+  active_driver_guard guard{driver};
   driver.missing_symbol = "cuDeviceGetCount";
 
   auto const result = probe_cuda_driver(fake_loader);
@@ -153,7 +168,7 @@ void test_missing_required_symbols()
 void test_driver_initialization_failure()
 {
   fake_driver driver;
-  active_driver      = &driver;
+  active_driver_guard guard{driver};
   driver.init_status = CUDA_ERROR_SYSTEM_DRIVER_MISMATCH;
 
   auto const result = probe_cuda_driver(fake_loader);
@@ -169,7 +184,7 @@ void test_driver_initialization_failure()
 void test_driver_version_and_device_count()
 {
   fake_driver driver;
-  active_driver         = &driver;
+  active_driver_guard guard{driver};
   driver.driver_version = 12080;
   driver.device_count   = 2;
 
@@ -184,7 +199,7 @@ void test_driver_version_and_device_count()
 void test_query_failures()
 {
   fake_driver driver;
-  active_driver                = &driver;
+  active_driver_guard guard{driver};
   driver.driver_version_status = CUDA_ERROR_UNKNOWN;
   driver.device_count_status   = CUDA_ERROR_NO_DEVICE;
 

--- a/java/src/main/native/tests/cuda_error_diagnostics_test.cpp
+++ b/java/src/main/native/tests/cuda_error_diagnostics_test.cpp
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cuda_error_diagnostics.hpp"
+
+#include <cuda.h>
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace cudf::jni::detail {
+namespace {
+
+struct fake_driver {
+  bool library_available{true};
+  std::string missing_symbol;
+  std::string loader_error{"library unavailable"};
+  CUresult init_status{CUDA_SUCCESS};
+  CUresult driver_version_status{CUDA_SUCCESS};
+  CUresult device_count_status{CUDA_SUCCESS};
+  int driver_version{12080};
+  int device_count{1};
+  int close_count{};
+};
+
+fake_driver* active_driver;
+int fake_library_handle;
+int failures{};
+
+void expect(bool condition, char const* message)
+{
+  if (!condition) {
+    std::cerr << "FAILED: " << message << '\n';
+    ++failures;
+  }
+}
+
+void expect_contains(std::string const& value, char const* expected)
+{
+  expect(value.find(expected) != std::string::npos, expected);
+}
+
+template <typename Function>
+void* function_address(Function function)
+{
+  void* address{};
+  static_assert(sizeof(address) == sizeof(function));
+  std::memcpy(&address, &function, sizeof(address));
+  return address;
+}
+
+CUresult CUDAAPI fake_cu_init(unsigned int) { return active_driver->init_status; }
+
+CUresult CUDAAPI fake_cu_driver_get_version(int* version)
+{
+  if (active_driver->driver_version_status == CUDA_SUCCESS) {
+    *version = active_driver->driver_version;
+  }
+  return active_driver->driver_version_status;
+}
+
+CUresult CUDAAPI fake_cu_device_get_count(int* count)
+{
+  if (active_driver->device_count_status == CUDA_SUCCESS) { *count = active_driver->device_count; }
+  return active_driver->device_count_status;
+}
+
+CUresult CUDAAPI fake_cu_get_error_name(CUresult error, char const** name)
+{
+  if (error == CUDA_ERROR_NO_DEVICE) {
+    *name = "CUDA_ERROR_NO_DEVICE";
+  } else if (error == CUDA_ERROR_SYSTEM_DRIVER_MISMATCH) {
+    *name = "CUDA_ERROR_SYSTEM_DRIVER_MISMATCH";
+  } else {
+    *name = "CUDA_ERROR_UNKNOWN";
+  }
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI fake_cu_get_error_string(CUresult, char const** description)
+{
+  *description = "fake driver error";
+  return CUDA_SUCCESS;
+}
+
+void* fake_open(char const*, int)
+{
+  return active_driver->library_available ? &fake_library_handle : nullptr;
+}
+
+void* fake_symbol(void*, char const* name)
+{
+  if (active_driver->missing_symbol == name) { return nullptr; }
+  if (std::strcmp(name, "cuInit") == 0) { return function_address(&fake_cu_init); }
+  if (std::strcmp(name, "cuDriverGetVersion") == 0) {
+    return function_address(&fake_cu_driver_get_version);
+  }
+  if (std::strcmp(name, "cuDeviceGetCount") == 0) {
+    return function_address(&fake_cu_device_get_count);
+  }
+  if (std::strcmp(name, "cuGetErrorName") == 0) {
+    return function_address(&fake_cu_get_error_name);
+  }
+  if (std::strcmp(name, "cuGetErrorString") == 0) {
+    return function_address(&fake_cu_get_error_string);
+  }
+  return nullptr;
+}
+
+char* fake_error() { return active_driver->loader_error.data(); }
+
+int fake_close(void*)
+{
+  ++active_driver->close_count;
+  return 0;
+}
+
+dynamic_loader const fake_loader{fake_open, fake_symbol, fake_error, fake_close};
+
+void test_unavailable_driver_library()
+{
+  fake_driver driver;
+  active_driver            = &driver;
+  driver.library_available = false;
+
+  auto const result = probe_cuda_driver(fake_loader);
+
+  expect(result.state == cuda_driver_probe_state::library_unavailable, "library unavailable state");
+  expect(result.detail == "library unavailable", "dynamic loader error");
+  expect(driver.close_count == 0, "unopened library is not closed");
+}
+
+void test_missing_required_symbols()
+{
+  fake_driver driver;
+  active_driver         = &driver;
+  driver.missing_symbol = "cuDeviceGetCount";
+
+  auto const result = probe_cuda_driver(fake_loader);
+
+  expect(result.state == cuda_driver_probe_state::symbols_unavailable, "symbols unavailable state");
+  expect(result.detail == "cuDeviceGetCount", "missing symbol name");
+  expect(driver.close_count == 1, "opened library is closed after missing symbol");
+}
+
+void test_driver_initialization_failure()
+{
+  fake_driver driver;
+  active_driver      = &driver;
+  driver.init_status = CUDA_ERROR_SYSTEM_DRIVER_MISMATCH;
+
+  auto const result = probe_cuda_driver(fake_loader);
+
+  expect(result.state == cuda_driver_probe_state::initialization_failed,
+         "initialization failed state");
+  expect(result.initialization_status == CUDA_ERROR_SYSTEM_DRIVER_MISMATCH,
+         "initialization status");
+  expect_contains(result.detail, "CUDA_ERROR_SYSTEM_DRIVER_MISMATCH");
+  expect(driver.close_count == 1, "opened library is closed after initialization failure");
+}
+
+void test_driver_version_and_device_count()
+{
+  fake_driver driver;
+  active_driver         = &driver;
+  driver.driver_version = 12080;
+  driver.device_count   = 2;
+
+  auto const result = probe_cuda_driver(fake_loader);
+
+  expect(result.state == cuda_driver_probe_state::initialized, "initialized state");
+  expect(result.driver_version == 12080, "driver version");
+  expect(result.device_count == 2, "device count");
+  expect(driver.close_count == 1, "opened library is closed after successful probe");
+}
+
+void test_query_failures()
+{
+  fake_driver driver;
+  active_driver                = &driver;
+  driver.driver_version_status = CUDA_ERROR_UNKNOWN;
+  driver.device_count_status   = CUDA_ERROR_NO_DEVICE;
+
+  auto const result = probe_cuda_driver(fake_loader);
+
+  expect(result.state == cuda_driver_probe_state::initialized, "initialized query failure state");
+  expect(!result.driver_version.has_value(), "driver version query failure");
+  expect(!result.device_count.has_value(), "device count query failure");
+  expect_contains(result.detail, "cuDriverGetVersion failed");
+  expect_contains(result.detail, "cuDeviceGetCount failed");
+}
+
+void test_diagnostic_formatting()
+{
+  auto message = format_cuda_initialization_diagnostic(
+    {cuda_driver_probe_state::library_unavailable, "not found"}, 13000);
+  expect_contains(message, "bundled CUDA runtime 13.0 (13000)");
+  expect_contains(message, "libcuda.so.1 could not be loaded");
+  expect_contains(message, "container runtime or device plugin");
+
+  message = format_cuda_initialization_diagnostic(
+    {cuda_driver_probe_state::initialized, {}, 0, 13000, 0}, 13000);
+  expect_contains(message, "visible devices: 0");
+  expect_contains(message, "CUDA_VISIBLE_DEVICES");
+
+  message = format_cuda_initialization_diagnostic(
+    {cuda_driver_probe_state::initialized, {}, 0, 12080, 1}, 13000);
+  expect_contains(message, "driver supports CUDA 12.8 (12080)");
+  expect_contains(message, "rejected this older driver");
+  expect_contains(message, "compatible cuDF CUDA artifact");
+
+  message = format_cuda_initialization_diagnostic({cuda_driver_probe_state::initialization_failed,
+                                                   "CUDA_ERROR_SYSTEM_DRIVER_MISMATCH (803)",
+                                                   CUDA_ERROR_SYSTEM_DRIVER_MISMATCH},
+                                                  13000);
+  expect_contains(message, "kernel and user-mode driver components do not match");
+
+  message = format_cuda_initialization_diagnostic({cuda_driver_probe_state::initialization_failed,
+                                                   "CUDA_ERROR_NO_DEVICE (100)",
+                                                   CUDA_ERROR_NO_DEVICE},
+                                                  13000);
+  expect_contains(message, "No CUDA device is visible");
+
+  message =
+    format_cuda_initialization_diagnostic({cuda_driver_probe_state::initialization_failed,
+                                           "CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE (804)",
+                                           CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE},
+                                          13000);
+  expect_contains(message, "forward-compatibility configuration is not supported");
+}
+
+void test_other_cuda_errors_unchanged()
+{
+  expect(augment_cuda_error_message("invalid value", cudaErrorInvalidValue) == "invalid value",
+         "non-initialization CUDA error message");
+}
+
+void test_insufficient_driver_diagnostic_is_cached_thread_safely()
+{
+  std::vector<std::string> messages(8);
+  std::vector<std::thread> threads;
+  threads.reserve(messages.size());
+  for (std::size_t i = 0; i < messages.size(); ++i) {
+    threads.emplace_back([i, &messages] {
+      messages[i] = augment_cuda_error_message("original", cudaErrorInsufficientDriver);
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  expect_contains(messages.front(), "original\nCUDA initialization diagnostics:");
+  for (auto const& message : messages) {
+    expect(message == messages.front(), "cached concurrent diagnostic");
+  }
+}
+
+}  // namespace
+}  // namespace cudf::jni::detail
+
+int main()
+{
+  using namespace cudf::jni::detail;
+  test_unavailable_driver_library();
+  test_missing_required_symbols();
+  test_driver_initialization_failure();
+  test_driver_version_and_device_count();
+  test_query_failures();
+  test_diagnostic_formatting();
+  test_other_cuda_errors_unchanged();
+  test_insufficient_driver_diagnostic_is_cached_thread_safely();
+  return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Description

Closes #24048.

Augments `cudaErrorInsufficientDriver` with a cached Driver API probe that distinguishes missing drivers, invisible GPUs, and driver/runtime incompatibility. Driver symbols are loaded dynamically, adding no external dependency. Other CUDA errors are unchanged.

Adds a GPU-independent native test and runs it during the Maven JNI build.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
