### PR TITLE
Fix percentile_approx for mixed empty TDigests

### DIFF
--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -32,6 +32,7 @@
 #include <thrust/fill.h>
 #include <thrust/scan.h>
 
+#include <algorithm>
 #include <limits>
 #include <stdexcept>
 
@@ -70,103 +71,104 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
                                             int32_t const* output_offsets,
                                             double* output)
 {
-  auto const tid = cudf::detail::grid_1d::global_thread_id();
+  auto const num_tdigests = tdigest_offsets.size() - 1;
+  auto const num_pairs    = static_cast<thread_index_type>(num_tdigests) * percentiles.size();
+  auto const stride       = cudf::detail::grid_1d::grid_stride();
+  for (auto tid = cudf::detail::grid_1d::global_thread_id(); tid < num_pairs; tid += stride) {
+    auto const tdigest_index = tid / percentiles.size();
+    auto const pindex        = tid % percentiles.size();
 
-  auto const num_tdigests  = tdigest_offsets.size() - 1;
-  auto const tdigest_index = tid / percentiles.size();
-  if (tdigest_index >= num_tdigests) { return; }
-  auto const pindex = tid % percentiles.size();
+    // size of the digest we're querying
+    auto const tdigest_size = tdigest_offsets[tdigest_index + 1] - tdigest_offsets[tdigest_index];
+    // no work to do. values will be set to null
+    if (tdigest_size == 0 || !percentiles.is_valid(pindex)) { continue; }
 
-  // size of the digest we're querying
-  auto const tdigest_size = tdigest_offsets[tdigest_index + 1] - tdigest_offsets[tdigest_index];
-  // no work to do. values will be set to null
-  if (tdigest_size == 0 || !percentiles.is_valid(pindex)) { return; }
-
-  auto const output_index = [&]() {
-    if constexpr (CompactOutput) {
-      return output_offsets[tdigest_index] + pindex;
-    } else {
-      return tid;
-    }
-  }();
-
-  output[output_index] = [&]() {
-    double const percentage         = percentiles.element<double>(pindex);
-    double const* cumulative_weight = cumulative_weight_ + tdigest_offsets[tdigest_index];
-
-    // centroids for this particular tdigest
-    CentroidIter centroids = centroids_ + tdigest_offsets[tdigest_index];
-
-    // min and max for the digest
-    double const* min_val = min_ + tdigest_index;
-    double const* max_val = max_ + tdigest_index;
-
-    double const total_weight = cumulative_weight[tdigest_size - 1];
-
-    // The following Arrow code serves as a basis for this computation
-    // https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/tdigest.cc#L280
-    double const weighted_q = percentage * total_weight;
-    if (weighted_q <= 1) {
-      return *min_val;
-    } else if (weighted_q > total_weight - 1) {
-      return *max_val;
-    }
-
-    // determine what centroid this weighted quantile falls within.
-    size_type const centroid_index = static_cast<size_type>(cuda::std::distance(
-      cumulative_weight,
-      thrust::lower_bound(
-        thrust::seq, cumulative_weight, cumulative_weight + tdigest_size, weighted_q)));
-    centroid c                     = centroids[centroid_index];
-
-    // diff == how far from the "center" of the centroid we are,
-    // in unit weights.
-    // visually:
-    //
-    // centroid of weight 7
-    //        C       <-- center of the centroid
-    //    |-------|
-    //      | |  |
-    //      X Y  Z
-    // X has a diff of -2 (2 units to the left of the center of the centroid)
-    // Y has a diff of 0 (directly in the middle of the centroid)
-    // Z has a diff of 3 (3 units to the right of the center of the centroid)
-    double const diff = weighted_q + c.weight / 2 - cumulative_weight[centroid_index];
-
-    // if we're completely within a centroid of weight 1, just return that.
-    if (c.weight == 1 && cuda::std::abs(diff) <= 0.5) { return c.mean; }
-
-    // otherwise, interpolate between two centroids.
-
-    // get the two centroids we want to interpolate between
-    auto const look_left  = diff < 0;
-    auto const [lhs, rhs] = [&]() {
-      if (look_left) {
-        // if we're at the first centroid, "left" of us is the min value
-        auto const first_centroid = centroid_index == 0;
-        auto const lhs = first_centroid ? centroid{*min_val, 0} : centroids[centroid_index - 1];
-        auto const rhs = c;
-        return cuda::std::pair<centroid, centroid>{lhs, rhs};
+    auto const output_index = [&]() {
+      if constexpr (CompactOutput) {
+        return output_offsets[tdigest_index] + pindex;
       } else {
-        // if we're at the last centroid, "right" of us is the max value
-        auto const last_centroid = (centroid_index == tdigest_size - 1);
-        auto const lhs           = c;
-        auto const rhs = last_centroid ? centroid{*max_val, 0} : centroids[centroid_index + 1];
-        return cuda::std::pair<centroid, centroid>{lhs, rhs};
+        return tid;
       }
     }();
 
-    // compute interpolation value t
+    output[output_index] = [&]() {
+      double const percentage         = percentiles.element<double>(pindex);
+      double const* cumulative_weight = cumulative_weight_ + tdigest_offsets[tdigest_index];
 
-    // total interpolation range. the total range of "space" between the lhs and rhs centroids.
-    auto const tip = lhs.weight / 2 + rhs.weight / 2;
-    // if we're looking left, diff is negative, so shift it so that we are interpolating
-    // from lhs -> rhs.
-    auto const t = (look_left) ? (diff + tip) / tip : diff / tip;
+      // centroids for this particular tdigest
+      CentroidIter centroids = centroids_ + tdigest_offsets[tdigest_index];
 
-    // interpolate
-    return lerp(lhs.mean, rhs.mean, t);
-  }();
+      // min and max for the digest
+      double const* min_val = min_ + tdigest_index;
+      double const* max_val = max_ + tdigest_index;
+
+      double const total_weight = cumulative_weight[tdigest_size - 1];
+
+      // The following Arrow code serves as a basis for this computation
+      // https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/tdigest.cc#L280
+      double const weighted_q = percentage * total_weight;
+      if (weighted_q <= 1) {
+        return *min_val;
+      } else if (weighted_q > total_weight - 1) {
+        return *max_val;
+      }
+
+      // determine what centroid this weighted quantile falls within.
+      size_type const centroid_index = static_cast<size_type>(cuda::std::distance(
+        cumulative_weight,
+        thrust::lower_bound(
+          thrust::seq, cumulative_weight, cumulative_weight + tdigest_size, weighted_q)));
+      centroid c                     = centroids[centroid_index];
+
+      // diff == how far from the "center" of the centroid we are,
+      // in unit weights.
+      // visually:
+      //
+      // centroid of weight 7
+      //        C       <-- center of the centroid
+      //    |-------|
+      //      | |  |
+      //      X Y  Z
+      // X has a diff of -2 (2 units to the left of the center of the centroid)
+      // Y has a diff of 0 (directly in the middle of the centroid)
+      // Z has a diff of 3 (3 units to the right of the center of the centroid)
+      double const diff = weighted_q + c.weight / 2 - cumulative_weight[centroid_index];
+
+      // if we're completely within a centroid of weight 1, just return that.
+      if (c.weight == 1 && cuda::std::abs(diff) <= 0.5) { return c.mean; }
+
+      // otherwise, interpolate between two centroids.
+
+      // get the two centroids we want to interpolate between
+      auto const look_left  = diff < 0;
+      auto const [lhs, rhs] = [&]() {
+        if (look_left) {
+          // if we're at the first centroid, "left" of us is the min value
+          auto const first_centroid = centroid_index == 0;
+          auto const lhs = first_centroid ? centroid{*min_val, 0} : centroids[centroid_index - 1];
+          auto const rhs = c;
+          return cuda::std::pair<centroid, centroid>{lhs, rhs};
+        } else {
+          // if we're at the last centroid, "right" of us is the max value
+          auto const last_centroid = (centroid_index == tdigest_size - 1);
+          auto const lhs           = c;
+          auto const rhs = last_centroid ? centroid{*max_val, 0} : centroids[centroid_index + 1];
+          return cuda::std::pair<centroid, centroid>{lhs, rhs};
+        }
+      }();
+
+      // compute interpolation value t
+
+      // total interpolation range. the total range of "space" between the lhs and rhs centroids.
+      auto const tip = lhs.weight / 2 + rhs.weight / 2;
+      // if we're looking left, diff is negative, so shift it so that we are interpolating
+      // from lhs -> rhs.
+      auto const t = (look_left) ? (diff + tip) / tip : diff / tip;
+
+      // interpolate
+      return lerp(lhs.mean, rhs.mean, t);
+    }();
+  }
 }
 
 /**
@@ -176,12 +178,12 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
  * corresponding tdigest of from row `i` in `input`. The length of each output list
  * is the number of percentiles specified in `percentiles`
  *
- * @param input tdigest input data. One tdigest per row.
- * @param percentiles Desired percentiles in range [0, 1].
+ * @param input             tdigest input data. One tdigest per row.
+ * @param percentiles       Desired percentiles in range [0, 1].
  * @param num_output_values Number of elements to allocate in the output column.
- * @param output_offsets Optional compact output offsets for inputs containing empty digests.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned column's device memory.
+ * @param output_offsets    Optional compact output offsets for inputs containing empty digests.
+ * @param stream            CUDA stream used for device memory operations and kernel launches.
+ * @param mr                Device memory resource used for output allocation.
  *
  * @returns Column of doubles containing requested percentile values.
  */
@@ -242,29 +244,26 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
   auto centroids = cudf::detail::make_counting_transform_iterator(
     0, make_centroid{tdv.means().begin<double>(), tdv.weights().begin<double>()});
 
-  constexpr size_type block_size = 256;
-  cudf::detail::grid_1d const grid(thread_index_type{percentiles.size()} * input.size(),
-                                   block_size);
+  constexpr size_type block_size  = 256;
+  auto const logical_num_threads  = thread_index_type{percentiles.size()} * input.size();
+  auto const launched_num_threads = std::min(
+    logical_num_threads, static_cast<thread_index_type>(std::numeric_limits<size_type>::max()));
+  cudf::detail::grid_1d const grid(launched_num_threads, block_size);
+  auto const launch_kernel = [&]<bool CompactOutput>() {
+    compute_percentiles_kernel<CompactOutput><<<grid.num_blocks, block_size, 0, stream.get()>>>(
+      {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
+      *percentiles_cdv,
+      centroids,
+      tdv.min_begin(),
+      tdv.max_begin(),
+      cumulative_weights->view().begin<double>(),
+      output_offsets,
+      result->mutable_view().begin<double>());
+  };
   if (output_offsets == nullptr) {
-    compute_percentiles_kernel<false><<<grid.num_blocks, block_size, 0, stream.get()>>>(
-      {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
-      *percentiles_cdv,
-      centroids,
-      tdv.min_begin(),
-      tdv.max_begin(),
-      cumulative_weights->view().begin<double>(),
-      output_offsets,
-      result->mutable_view().begin<double>());
+    launch_kernel.template operator()<false>();
   } else {
-    compute_percentiles_kernel<true><<<grid.num_blocks, block_size, 0, stream.get()>>>(
-      {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
-      *percentiles_cdv,
-      centroids,
-      tdv.min_begin(),
-      tdv.max_begin(),
-      cumulative_weights->view().begin<double>(),
-      output_offsets,
-      result->mutable_view().begin<double>());
+    launch_kernel.template operator()<true>();
   }
   CUDF_CUDA_TRY(cudaGetLastError());
 

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -7,9 +7,9 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/algorithms/reduce.cuh>
-#include <cudf/detail/copy.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/sizes_to_offsets_iterator.cuh>
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
@@ -30,7 +30,6 @@
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
-#include <thrust/reduce.h>
 #include <thrust/scan.h>
 
 using namespace cudf::tdigest;
@@ -58,13 +57,14 @@ struct make_centroid {
 };
 
 // kernel for computing percentiles on input tdigest (mean, weight) centroid data.
-template <typename CentroidIter>
+template <bool compact_output, typename CentroidIter>
 CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_offsets,
                                             column_device_view percentiles,
                                             CentroidIter centroids_,
                                             double const* min_,
                                             double const* max_,
                                             double const* cumulative_weight_,
+                                            int32_t const* output_offsets,
                                             double* output)
 {
   auto const tid = cudf::detail::grid_1d::global_thread_id();
@@ -79,7 +79,15 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
   // no work to do. values will be set to null
   if (tdigest_size == 0 || !percentiles.is_valid(pindex)) { return; }
 
-  output[tid] = [&]() {
+  auto const output_index = [&]() {
+    if constexpr (compact_output) {
+      return output_offsets[tdigest_index] + pindex;
+    } else {
+      return tid;
+    }
+  }();
+
+  output[output_index] = [&]() {
     double const percentage         = percentiles.element<double>(pindex);
     double const* cumulative_weight = cumulative_weight_ + tdigest_offsets[tdigest_index];
 
@@ -167,14 +175,18 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
  *
  * @param input           tdigest input data. One tdigest per row.
  * @param percentiles     Desired percentiles in range [0, 1].
- * @param stream          CUDA stream used for device memory operations and kernel launches
+ * @param num_output_values Number of elements to allocate in the output column.
+ * @param output_offsets  Optional compact output offsets for inputs containing empty digests.
+ * @param stream          CUDA stream used for device memory operations and kernel launches.
  * @param mr              Device memory resource used to allocate the returned column's device
- * memory
+ *                        memory.
  *
  * @returns Column of doubles containing requested percentile values.
  */
 std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& input,
                                                    column_view const& percentiles,
+                                                   size_type num_output_values,
+                                                   int32_t const* output_offsets,
                                                    cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
@@ -208,9 +220,6 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
 
   auto percentiles_cdv = column_device_view::create(percentiles, stream);
 
-  // leaf is a column of size input.size() * percentiles.size()
-  auto const num_output_values = input.size() * percentiles.size();
-
   // null percentiles become null results.
   auto [null_mask, null_count] = [&]() {
     return percentiles.null_count() != 0
@@ -232,15 +241,29 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
     0, make_centroid{tdv.means().begin<double>(), tdv.weights().begin<double>()});
 
   constexpr size_type block_size = 256;
-  cudf::detail::grid_1d const grid(percentiles.size() * input.size(), block_size);
-  compute_percentiles_kernel<<<grid.num_blocks, block_size, 0, stream.get()>>>(
-    {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
-    *percentiles_cdv,
-    centroids,
-    tdv.min_begin(),
-    tdv.max_begin(),
-    cumulative_weights->view().begin<double>(),
-    result->mutable_view().begin<double>());
+  cudf::detail::grid_1d const grid(thread_index_type{percentiles.size()} * input.size(),
+                                   block_size);
+  if (output_offsets == nullptr) {
+    compute_percentiles_kernel<false><<<grid.num_blocks, block_size, 0, stream.get()>>>(
+      {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
+      *percentiles_cdv,
+      centroids,
+      tdv.min_begin(),
+      tdv.max_begin(),
+      cumulative_weights->view().begin<double>(),
+      output_offsets,
+      result->mutable_view().begin<double>());
+  } else {
+    compute_percentiles_kernel<true><<<grid.num_blocks, block_size, 0, stream.get()>>>(
+      {offsets.begin<size_type>(), static_cast<size_t>(offsets.size())},
+      *percentiles_cdv,
+      centroids,
+      tdv.min_begin(),
+      tdv.max_begin(),
+      cumulative_weights->view().begin<double>(),
+      output_offsets,
+      result->mutable_view().begin<double>());
+  }
   CUDF_CUDA_TRY(cudaGetLastError());
 
   return result;
@@ -347,21 +370,26 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   CUDF_EXPECTS(percentiles.type().id() == type_id::FLOAT64,
                "percentile_approx expects float64 percentile inputs");
 
-  // output is a list column with each row containing percentiles.size() percentile values
-  auto offsets = cudf::make_fixed_width_column(
-    data_type{type_id::INT32}, input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  auto const all_empty_rows = cudf::detail::count_if(
-                                detail::size_begin(input),
-                                detail::size_begin(input) + input.size(),
-                                [] __device__(auto const x) { return x == 0; },
-                                stream) == static_cast<std::size_t>(input.size());
-  auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                         row_size_iter,
-                         row_size_iter + input.size() + 1,
-                         offsets->mutable_view().begin<int32_t>());
+  auto const null_count     = static_cast<size_type>(cudf::detail::count_if(
+    detail::size_begin(input),
+    detail::size_begin(input) + input.size(),
+    [] __device__(auto const x) { return x == 0; },
+    stream));
+  auto const all_empty_rows = null_count == input.size();
+
+  auto make_uniform_offsets = [&](size_type row_size) {
+    auto offsets = cudf::make_fixed_width_column(
+      data_type{type_id::INT32}, input.size() + 1, mask_state::UNALLOCATED, stream, mr);
+    auto const row_size_iter = cuda::make_constant_iterator(row_size);
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           row_size_iter,
+                           row_size_iter + input.size() + 1,
+                           offsets->mutable_view().begin<int32_t>());
+    return offsets;
+  };
 
   if (percentiles.size() == 0 || all_empty_rows) {
+    auto offsets = make_uniform_offsets(0);
     return cudf::make_lists_column(
       input.size(),
       std::move(offsets),
@@ -371,36 +399,41 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
         input.size(), mask_state::ALL_NULL, cuda::stream_ref(stream), mr));
   }
 
-  // if any of the input digests are empty, nullify the corresponding output rows (values will be
-  // uninitialized)
-  auto [bitmask, null_count] = [stream, mr, &tdv]() {
+  // If any input digests are empty, nullify the corresponding output rows.
+  auto bitmask = [stream, mr, &tdv, null_count]() {
+    if (null_count == 0) { return rmm::device_buffer{}; }
     auto tdigest_is_empty = cuda::transform_iterator(
       detail::size_begin(tdv),
       cuda::proclaim_return_type<size_type>(
         [] __device__(size_type tdigest_size) -> size_type { return tdigest_size == 0; }));
-    auto const null_count =
-      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     tdigest_is_empty,
-                     tdigest_is_empty + tdv.size(),
-                     0);
-    if (null_count == 0) {
-      return std::pair<rmm::device_buffer, size_type>{rmm::device_buffer{}, null_count};
-    }
-    return cudf::detail::valid_if(
+    auto validity = cudf::detail::valid_if(
       tdigest_is_empty, tdigest_is_empty + tdv.size(), cuda::std::logical_not{}, stream, mr);
+    return std::move(validity.first);
   }();
 
-  auto result =
-    cudf::make_lists_column(input.size(),
-                            std::move(offsets),
-                            detail::compute_approx_percentiles(input, percentiles, stream, mr),
-                            null_count,
-                            std::move(bitmask));
+  std::unique_ptr<column> offsets;
+  size_type num_output_values;
+  if (null_count == 0) {
+    offsets           = make_uniform_offsets(percentiles.size());
+    num_output_values = input.size() * percentiles.size();
+  } else {
+    auto const row_size_iter = cuda::transform_iterator(
+      detail::size_begin(tdv),
+      cuda::proclaim_return_type<size_type>(
+        [row_size = percentiles.size()] __device__(size_type tdigest_size) -> size_type {
+          return tdigest_size == 0 ? 0 : row_size;
+        }));
+    auto compact_offsets = cudf::detail::make_offsets_child_column(
+      row_size_iter, row_size_iter + input.size(), stream, mr);
+    offsets           = std::move(compact_offsets.first);
+    num_output_values = compact_offsets.second;
+  }
 
-  // Empty digests produce null rows whose child values are uninitialized. Since list factories do
-  // not sanitize null rows, remove those child values before returning the nested column.
-  return null_count == 0 ? std::move(result)
-                         : cudf::detail::purge_nonempty_nulls(result->view(), stream, mr);
+  auto const output_offsets = null_count == 0 ? nullptr : offsets->view().begin<int32_t>();
+  auto child                = detail::compute_approx_percentiles(
+    input, percentiles, num_output_values, output_offsets, stream, mr);
+  return cudf::make_lists_column(
+    input.size(), std::move(offsets), std::move(child), null_count, std::move(bitmask));
 }
 
 }  // namespace tdigest

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -7,14 +7,15 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/algorithms/reduce.cuh>
+#include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
-#include <cudf/detail/sizes_to_offsets_iterator.cuh>
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/quantiles.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -22,7 +23,6 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/cmath>
 #include <cuda/std/utility>
@@ -31,6 +31,9 @@
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/scan.h>
+
+#include <limits>
+#include <stdexcept>
 
 using namespace cudf::tdigest;
 
@@ -57,7 +60,7 @@ struct make_centroid {
 };
 
 // kernel for computing percentiles on input tdigest (mean, weight) centroid data.
-template <bool compact_output, typename CentroidIter>
+template <bool CompactOutput, typename CentroidIter>
 CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_offsets,
                                             column_device_view percentiles,
                                             CentroidIter centroids_,
@@ -80,7 +83,7 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
   if (tdigest_size == 0 || !percentiles.is_valid(pindex)) { return; }
 
   auto const output_index = [&]() {
-    if constexpr (compact_output) {
+    if constexpr (CompactOutput) {
       return output_offsets[tdigest_index] + pindex;
     } else {
       return tid;
@@ -370,17 +373,9 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   CUDF_EXPECTS(percentiles.type().id() == type_id::FLOAT64,
                "percentile_approx expects float64 percentile inputs");
 
-  auto const null_count     = static_cast<size_type>(cudf::detail::count_if(
-    detail::size_begin(input),
-    detail::size_begin(input) + input.size(),
-    [] __device__(auto const x) { return x == 0; },
-    stream));
-  auto const all_empty_rows = null_count == input.size();
-
-  auto make_uniform_offsets = [&](size_type row_size) {
+  auto const make_offsets = [&](auto row_size_iter) {
     auto offsets = cudf::make_fixed_width_column(
       data_type{type_id::INT32}, input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-    auto const row_size_iter = cuda::make_constant_iterator(row_size);
     thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            row_size_iter,
                            row_size_iter + input.size() + 1,
@@ -388,8 +383,8 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
     return offsets;
   };
 
-  if (percentiles.size() == 0 || all_empty_rows) {
-    auto offsets = make_uniform_offsets(0);
+  auto const make_all_null_result = [&]() {
+    auto offsets = make_offsets(cuda::make_constant_iterator(size_type{0}));
     return cudf::make_lists_column(
       input.size(),
       std::move(offsets),
@@ -397,36 +392,57 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
       input.size(),
       cudf::detail::create_null_mask(
         input.size(), mask_state::ALL_NULL, cuda::stream_ref(stream), mr));
-  }
+  };
+
+  if (percentiles.size() == 0) { return make_all_null_result(); }
+
+  auto const null_count = static_cast<size_type>(cudf::detail::count_if(
+    detail::size_begin(input),
+    detail::size_begin(input) + input.size(),
+    [] __device__(auto const tdigest_size) -> bool { return tdigest_size == 0; },
+    stream));
+
+  if (null_count == input.size()) { return make_all_null_result(); }
+
+  auto const output_size = thread_index_type{input.size() - null_count} * percentiles.size();
+  CUDF_EXPECTS(output_size <= std::numeric_limits<size_type>::max(),
+               "Size of output exceeds the column size limit",
+               std::overflow_error);
+  auto const num_output_values = static_cast<size_type>(output_size);
 
   // If any input digests are empty, nullify the corresponding output rows.
   auto bitmask = [stream, mr, &tdv, null_count]() {
     if (null_count == 0) { return rmm::device_buffer{}; }
-    auto tdigest_is_empty = cuda::transform_iterator(
-      detail::size_begin(tdv),
-      cuda::proclaim_return_type<size_type>(
-        [] __device__(size_type tdigest_size) -> size_type { return tdigest_size == 0; }));
-    auto validity = cudf::detail::valid_if(
-      tdigest_is_empty, tdigest_is_empty + tdv.size(), cuda::std::logical_not{}, stream, mr);
-    return std::move(validity.first);
+
+    auto mask = cudf::create_null_mask(tdv.size(), mask_state::UNINITIALIZED, stream, mr);
+    auto valid_count =
+      cudf::detail::device_scalar<size_type>(0, stream, cudf::get_current_device_resource_ref());
+    constexpr size_type block_size{256};
+    auto const grid = cudf::detail::grid_1d{static_cast<thread_index_type>(tdv.size()), block_size};
+    cudf::detail::valid_if_kernel<block_size>
+      <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.get()>>>(
+        static_cast<bitmask_type*>(mask.data()),
+        detail::size_begin(tdv),
+        tdv.size(),
+        [] __device__(size_type tdigest_size) -> bool { return tdigest_size != 0; },
+        valid_count.data());
+    CUDF_CUDA_TRY(cudaGetLastError());
+    return mask;
   }();
 
   std::unique_ptr<column> offsets;
-  size_type num_output_values;
   if (null_count == 0) {
-    offsets           = make_uniform_offsets(percentiles.size());
-    num_output_values = input.size() * percentiles.size();
+    offsets = make_offsets(cuda::make_constant_iterator(percentiles.size()));
   } else {
-    auto const row_size_iter = cuda::transform_iterator(
-      detail::size_begin(tdv),
+    auto const row_size_iter = cudf::detail::make_counting_transform_iterator(
+      size_type{0},
       cuda::proclaim_return_type<size_type>(
-        [row_size = percentiles.size()] __device__(size_type tdigest_size) -> size_type {
-          return tdigest_size == 0 ? 0 : row_size;
+        [sizes_begin = detail::size_begin(tdv),
+         num_rows    = input.size(),
+         row_size    = percentiles.size()] __device__(size_type i) -> size_type {
+          return i < num_rows && sizes_begin[i] != 0 ? row_size : 0;
         }));
-    auto compact_offsets = cudf::detail::make_offsets_child_column(
-      row_size_iter, row_size_iter + input.size(), stream, mr);
-    offsets           = std::move(compact_offsets.first);
-    num_output_values = compact_offsets.second;
+    offsets = make_offsets(row_size_iter);
   }
 
   auto const output_offsets = null_count == 0 ? nullptr : offsets->view().begin<int32_t>();

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -7,12 +7,12 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/algorithms/reduce.cuh>
-#include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/null_mask.hpp>
@@ -176,13 +176,12 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
  * corresponding tdigest of from row `i` in `input`. The length of each output list
  * is the number of percentiles specified in `percentiles`
  *
- * @param input           tdigest input data. One tdigest per row.
- * @param percentiles     Desired percentiles in range [0, 1].
+ * @param input tdigest input data. One tdigest per row.
+ * @param percentiles Desired percentiles in range [0, 1].
  * @param num_output_values Number of elements to allocate in the output column.
- * @param output_offsets  Optional compact output offsets for inputs containing empty digests.
- * @param stream          CUDA stream used for device memory operations and kernel launches.
- * @param mr              Device memory resource used to allocate the returned column's device
- *                        memory.
+ * @param output_offsets Optional compact output offsets for inputs containing empty digests.
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory.
  *
  * @returns Column of doubles containing requested percentile values.
  */
@@ -414,9 +413,9 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   auto bitmask = [stream, mr, &tdv, null_count]() {
     if (null_count == 0) { return rmm::device_buffer{}; }
 
-    auto mask = cudf::create_null_mask(tdv.size(), mask_state::UNINITIALIZED, stream, mr);
-    auto valid_count =
-      cudf::detail::device_scalar<size_type>(0, stream, cudf::get_current_device_resource_ref());
+    auto mask        = cudf::create_null_mask(tdv.size(), mask_state::UNINITIALIZED, stream, mr);
+    auto valid_count = cudf::detail::make_zeroed_device_uvector_async<size_type>(
+      1, stream, cudf::get_current_device_resource_ref());
     constexpr size_type block_size{256};
     auto const grid = cudf::detail::grid_1d{static_cast<thread_index_type>(tdv.size()), block_size};
     cudf::detail::valid_if_kernel<block_size>

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -24,6 +24,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <cuda/std/algorithm>
 #include <cuda/std/cmath>
 #include <cuda/std/utility>
 #include <cuda/stream>
@@ -78,9 +79,9 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
     auto const tdigest_index = tid / percentiles.size();
     auto const pindex        = tid % percentiles.size();
 
-    // size of the digest we're querying
+    // Size of the digest we're querying.
     auto const tdigest_size = tdigest_offsets[tdigest_index + 1] - tdigest_offsets[tdigest_index];
-    // no work to do. values will be set to null
+    // No work to do. Values will be set to null.
     if (tdigest_size == 0 || !percentiles.is_valid(pindex)) { continue; }
 
     auto const output_index = [&]() {
@@ -95,16 +96,16 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
       double const percentage         = percentiles.element<double>(pindex);
       double const* cumulative_weight = cumulative_weight_ + tdigest_offsets[tdigest_index];
 
-      // centroids for this particular tdigest
+      // Centroids for this particular tdigest.
       CentroidIter centroids = centroids_ + tdigest_offsets[tdigest_index];
 
-      // min and max for the digest
+      // Min and max for the digest.
       double const* min_val = min_ + tdigest_index;
       double const* max_val = max_ + tdigest_index;
 
       double const total_weight = cumulative_weight[tdigest_size - 1];
 
-      // The following Arrow code serves as a basis for this computation
+      // The following Arrow code serves as a basis for this computation.
       // https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/tdigest.cc#L280
       double const weighted_q = percentage * total_weight;
       if (weighted_q <= 1) {
@@ -113,11 +114,10 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
         return *max_val;
       }
 
-      // determine what centroid this weighted quantile falls within.
+      // Determine what centroid this weighted quantile falls within.
       size_type const centroid_index = static_cast<size_type>(cuda::std::distance(
         cumulative_weight,
-        thrust::lower_bound(
-          thrust::seq, cumulative_weight, cumulative_weight + tdigest_size, weighted_q)));
+        cuda::std::lower_bound(cumulative_weight, cumulative_weight + tdigest_size, weighted_q)));
       centroid c                     = centroids[centroid_index];
 
       // diff == how far from the "center" of the centroid we are,
@@ -134,12 +134,12 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
       // Z has a diff of 3 (3 units to the right of the center of the centroid)
       double const diff = weighted_q + c.weight / 2 - cumulative_weight[centroid_index];
 
-      // if we're completely within a centroid of weight 1, just return that.
+      // If we're completely within a centroid of weight 1, just return that.
       if (c.weight == 1 && cuda::std::abs(diff) <= 0.5) { return c.mean; }
 
-      // otherwise, interpolate between two centroids.
+      // Otherwise, interpolate between two centroids.
 
-      // get the two centroids we want to interpolate between
+      // Get the two centroids we want to interpolate between.
       auto const look_left  = diff < 0;
       auto const [lhs, rhs] = [&]() {
         if (look_left) {
@@ -157,15 +157,15 @@ CUDF_KERNEL void compute_percentiles_kernel(device_span<int32_t const> tdigest_o
         }
       }();
 
-      // compute interpolation value t
+      // Compute interpolation value t.
 
-      // total interpolation range. the total range of "space" between the lhs and rhs centroids.
+      // Total interpolation range. The total range of "space" between the lhs and rhs centroids.
       auto const tip = lhs.weight / 2 + rhs.weight / 2;
-      // if we're looking left, diff is negative, so shift it so that we are interpolating
+      // If we're looking left, diff is negative, so shift it so that we are interpolating
       // from lhs -> rhs.
       auto const t = (look_left) ? (diff + tip) / tip : diff / tip;
 
-      // interpolate
+      // Interpolate.
       return lerp(lhs.mean, rhs.mean, t);
     }();
   }

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -7,6 +7,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/algorithms/reduce.cuh>
+#include <cudf/detail/copy.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/tdigest/tdigest.hpp>
@@ -389,11 +390,17 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
       tdigest_is_empty, tdigest_is_empty + tdv.size(), cuda::std::logical_not{}, stream, mr);
   }();
 
-  return cudf::make_lists_column(input.size(),
-                                 std::move(offsets),
-                                 detail::compute_approx_percentiles(input, percentiles, stream, mr),
-                                 null_count,
-                                 std::move(bitmask));
+  auto result =
+    cudf::make_lists_column(input.size(),
+                            std::move(offsets),
+                            detail::compute_approx_percentiles(input, percentiles, stream, mr),
+                            null_count,
+                            std::move(bitmask));
+
+  // Empty digests produce null rows whose child values are uninitialized. Since list factories do
+  // not sanitize null rows, remove those child values before returning the nested column.
+  return null_count == 0 ? std::move(result)
+                         : cudf::detail::purge_nonempty_nulls(result->view(), stream, mr);
 }
 
 }  // namespace tdigest

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -597,12 +597,13 @@ TEST_F(PercentileApproxTest, GroupByWithNullsGold)
 
 TEST_F(PercentileApproxTest, GroupByWithMixedEmptyAndNonEmptyDigests)
 {
-  auto const delta = 1000;
+  auto const delta = 1'000;
 
   auto const values =
     cudf::test::fixed_width_column_wrapper<double>{{1, 0, 3}, {true, false, true}};
   auto const keys        = cudf::test::fixed_width_column_wrapper<int32_t>{0, 1, 2};
-  auto const percentiles = cudf::test::fixed_width_column_wrapper<double>{0.0, 0.5, 1.0};
+  auto const percentiles = cudf::test::fixed_width_column_wrapper<double>{
+    {0.0, 0.25, 0.5, 1.0}, {true, false, true, true}};
 
   cudf::groupby::groupby gb(
     cudf::table_view{{keys}}, cudf::null_policy::EXCLUDE, cudf::sorted::YES);
@@ -615,9 +616,10 @@ TEST_F(PercentileApproxTest, GroupByWithMixedEmptyAndNonEmptyDigests)
   cudf::tdigest::tdigest_column_view tdv(*tdigest_column.second[0].results[0]);
   auto const result = cudf::percentile_approx(tdv, percentiles);
 
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 3, 3, 6};
-  cudf::test::fixed_width_column_wrapper<double> child{1, 1, 1, 3, 3, 3};
-  std::vector<bool> valids{true, false, true};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 4, 4, 8};
+  cudf::test::fixed_width_column_wrapper<double> child{
+    {1, 0, 1, 1, 3, 0, 3, 3}, {true, false, true, true, true, false, true, true}};
+  auto const valids            = std::vector<bool>{true, false, true};
   auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids.begin(), valids.end());
   auto const expected          = cudf::make_lists_column(
     3, offsets.release(), child.release(), null_count, std::move(null_mask));

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -627,6 +627,58 @@ TEST_F(PercentileApproxTest, GroupByWithMixedEmptyAndNonEmptyDigests)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
 
+TEST_F(PercentileApproxTest, GroupByWithMixedEmptyDigestMaskBoundaries)
+{
+  auto const delta       = 1'000;
+  auto const percentiles = cudf::test::fixed_width_column_wrapper<double>{0.5};
+
+  for (auto const num_rows : {31, 32, 33, 65, 257}) {
+    SCOPED_TRACE(::testing::Message() << "num_rows=" << num_rows);
+
+    std::vector<int32_t> key_data(num_rows);
+    std::vector<double> value_data(num_rows);
+    std::vector<bool> validities(num_rows);
+    std::vector<cudf::size_type> offsets_data(num_rows + 1, 0);
+    std::vector<double> child_data;
+    child_data.reserve((num_rows + 1) / 2);
+
+    for (cudf::size_type row = 0; row < num_rows; ++row) {
+      key_data[row]   = row;
+      value_data[row] = row;
+      validities[row] = row % 2 == 0;
+      if (validities[row]) { child_data.push_back(value_data[row]); }
+      offsets_data[row + 1] = static_cast<cudf::size_type>(child_data.size());
+    }
+
+    auto const keys =
+      cudf::test::fixed_width_column_wrapper<int32_t>(key_data.begin(), key_data.end());
+    auto const values = cudf::test::fixed_width_column_wrapper<double>(
+      value_data.begin(), value_data.end(), validities.begin());
+
+    cudf::groupby::groupby gb(
+      cudf::table_view{{keys}}, cudf::null_policy::EXCLUDE, cudf::sorted::YES);
+    std::vector<cudf::groupby::aggregation_request> requests;
+    std::vector<std::unique_ptr<cudf::groupby_aggregation>> aggregations;
+    aggregations.push_back(cudf::make_tdigest_aggregation<cudf::groupby_aggregation>(delta));
+    requests.push_back({values, std::move(aggregations)});
+    auto const tdigest_column = gb.aggregate(requests);
+
+    cudf::tdigest::tdigest_column_view tdv(*tdigest_column.second[0].results[0]);
+    auto const result = cudf::percentile_approx(tdv, percentiles);
+
+    auto offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>(offsets_data.begin(),
+                                                                           offsets_data.end());
+    auto child =
+      cudf::test::fixed_width_column_wrapper<double>(child_data.begin(), child_data.end());
+    auto [null_mask, null_count] =
+      cudf::test::detail::make_null_mask(validities.begin(), validities.end());
+    auto const expected = cudf::make_lists_column(
+      num_rows, offsets.release(), child.release(), null_count, std::move(null_mask));
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  }
+}
+
 namespace {
 
 TEST_F(PercentileApproxTest, CompressedTdigestsAgainstHostQuantiles)

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -595,6 +595,36 @@ TEST_F(PercentileApproxTest, GroupByWithNullsGold)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, expected);
 }
 
+TEST_F(PercentileApproxTest, GroupByWithMixedEmptyAndNonEmptyDigests)
+{
+  auto const delta = 1000;
+
+  auto const values =
+    cudf::test::fixed_width_column_wrapper<double>{{1, 0, 3}, {true, false, true}};
+  auto const keys        = cudf::test::fixed_width_column_wrapper<int32_t>{0, 1, 2};
+  auto const percentiles = cudf::test::fixed_width_column_wrapper<double>{0.0, 0.5, 1.0};
+
+  cudf::groupby::groupby gb(
+    cudf::table_view{{keys}}, cudf::null_policy::EXCLUDE, cudf::sorted::YES);
+  std::vector<cudf::groupby::aggregation_request> requests;
+  std::vector<std::unique_ptr<cudf::groupby_aggregation>> aggregations;
+  aggregations.push_back(cudf::make_tdigest_aggregation<cudf::groupby_aggregation>(delta));
+  requests.push_back({values, std::move(aggregations)});
+  auto const tdigest_column = gb.aggregate(requests);
+
+  cudf::tdigest::tdigest_column_view tdv(*tdigest_column.second[0].results[0]);
+  auto const result = cudf::percentile_approx(tdv, percentiles);
+
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 3, 3, 6};
+  cudf::test::fixed_width_column_wrapper<double> child{1, 1, 1, 3, 3, 3};
+  std::vector<bool> valids{true, false, true};
+  auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids.begin(), valids.end());
+  auto const expected          = cudf::make_lists_column(
+    3, offsets.release(), child.release(), null_count, std::move(null_mask));
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+}
+
 namespace {
 
 TEST_F(PercentileApproxTest, CompressedTdigestsAgainstHostQuantiles)


### PR DESCRIPTION
## Description

Closes #24056.

`percentile_approx` currently marks rows from empty TDigests null while retaining
`percentiles.size()` child elements for those rows. Mixed empty and non-empty input
therefore produces non-empty null list rows, which downstream consumers reject.

This change:

- gives empty TDigests zero-length list ranges and writes non-empty rows directly into
  a compact child column;
- builds the parent validity mask without an additional host synchronization;
- preserves the dense fast path when no TDigests are empty; and
- bounds the percentile kernel launch and uses a grid-stride loop for sparse inputs
  whose dense row/percentile pair count exceeds a valid CUDA grid.

Regression coverage includes nullable percentile values and mixed-input validity-mask
boundaries at 31, 32, 33, 65, and 257 rows.

Validation on `2cf22a1fb5b864bd53128034d34217943bea0047`:

```text
[==========] Running 2 tests from 1 test suite.
[  PASSED  ] 2 tests.

[==========] 388 tests from 67 test suites ran. (2119 ms total)
[  PASSED  ] 388 tests.
```

The native build used CUDA 12.9.1 and `CMAKE_CUDA_ARCHITECTURES=80-real;89-real`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
