### PR TITLE
Default remote parquet metadata work to off

### DIFF
--- a/python/cudf_polars/cudf_polars/engine/core.py
+++ b/python/cudf_polars/cudf_polars/engine/core.py
@@ -43,7 +43,7 @@ from cudf_polars.streaming.base import StatsCollector
 from cudf_polars.streaming.parallel import lower_ir_graph_with_node_map
 from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.streaming.utils import _concat
-from cudf_polars.utils.config import Unspecified, get_total_device_memory
+from cudf_polars.utils.config import get_total_device_memory
 
 if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
@@ -926,7 +926,6 @@ def evaluate_on_rank(
             ir,
             ir_context.py_executor,
             stats=stats,
-            remote_only=isinstance(prefetch_file_metadata, Unspecified),
             parse_hybrid_metadata=config_options.parquet_options.use_hybrid_scan,
         )
         attach_cached_parquet_metadata(ir, cached_parquet_info_map)

--- a/python/cudf_polars/cudf_polars/streaming/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/io.py
@@ -1385,6 +1385,17 @@ def _build_parquet_source(
     )
 
 
+def _resolve_max_footer_samples(
+    paths: tuple[str, ...], max_footer_samples: int | None
+) -> int:
+    """Resolve automatic footer sampling from the scan paths."""
+    if max_footer_samples is not None:
+        return max_footer_samples
+    if any(plc.io.SourceInfo._is_remote_uri(path) for path in paths):
+        return 0
+    return 3
+
+
 def _build_source_info(
     ir: Scan | DataFrameScan,
     config_options: ConfigOptions[StreamingExecutor],
@@ -1396,11 +1407,13 @@ def _build_source_info(
     if isinstance(ir, DataFrameScan):
         return DataFrameSourceInfo.from_polars(pl.DataFrame._from_pydf(ir.df))
     elif isinstance(ir, Scan) and ir.typ == "parquet":
-        max_footer = config_options.parquet_options.max_footer_samples
+        paths = tuple(ir.paths)
+        max_footer = _resolve_max_footer_samples(
+            paths, config_options.parquet_options.max_footer_samples
+        )
         max_rg = config_options.parquet_options.max_row_group_samples
         needed_cols = frozenset(ir.schema) if needed_cols is None else needed_cols
         schema = tuple(ir.schema.items()) if schema is None else schema
-        paths = tuple(ir.paths)
         use_hybrid_scan = config_options.parquet_options.use_hybrid_scan
         return _build_parquet_source(
             paths,

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -334,7 +334,8 @@ class ParquetOptions:
         Maximum number of file footers to sample for metadata. This
         option is currently used by the streaming executor to gather
         datasource statistics before generating a physical plan. Set to
-        0 to avoid metadata sampling. Default is 3.
+        0 to avoid metadata sampling. By default, metadata sampling is disabled
+        for remote scans and samples 3 footers for local-only scans.
     max_row_group_samples
         Maximum number of row-groups to sample for unique-value statistics.
         This option may be used by the streaming executor to optimize
@@ -345,9 +346,8 @@ class ParquetOptions:
     prefetch_file_metadata
         Whether to prefetch parquet file metadata and pass it through
         `parquet_metadatas` to avoid rereading file footers. Not supported
-        by the in-memory executor, where it defaults to disabled. For the
-        streaming executor, it defaults to being enabled for remote URIs
-        (e.g. ``s3://``) only; pass ``True`` to also prefetch local files.
+        by the in-memory executor. It defaults to disabled; pass ``True`` to
+        enable it for local or remote files.
     use_jit_filter
         Whether to use JIT compilation for post-read filtering in Parquet scans.
         When enabled, filter predicates are JIT-compiled to CUDA kernels for
@@ -381,9 +381,9 @@ class ParquetOptions:
             f"{_env_prefix}__PASS_READ_LIMIT", int, default=0
         )
     )
-    max_footer_samples: int = dataclasses.field(
+    max_footer_samples: int | None = dataclasses.field(
         default_factory=_make_default_factory(
-            f"{_env_prefix}__MAX_FOOTER_SAMPLES", int, default=3
+            f"{_env_prefix}__MAX_FOOTER_SAMPLES", int, default=None
         )
     )
     max_row_group_samples: int = dataclasses.field(
@@ -391,11 +391,11 @@ class ParquetOptions:
             f"{_env_prefix}__MAX_ROW_GROUP_SAMPLES", int, default=1
         )
     )
-    prefetch_file_metadata: bool | Unspecified = dataclasses.field(
+    prefetch_file_metadata: bool = dataclasses.field(
         default_factory=_make_default_factory(
             f"{_env_prefix}__PREFETCH_FILE_METADATA",
             _bool_converter,
-            default=UNSPECIFIED,
+            default=False,
         )
     )
     use_hybrid_scan: bool = dataclasses.field(
@@ -434,12 +434,12 @@ class ParquetOptions:
             raise TypeError("chunk_read_limit must be an int")
         if not isinstance(self.pass_read_limit, int):
             raise TypeError("pass_read_limit must be an int")
-        if not isinstance(self.max_footer_samples, int):
-            raise TypeError("max_footer_samples must be an int")
+        if not isinstance(self.max_footer_samples, (int, type(None))):
+            raise TypeError("max_footer_samples must be an int or None")
         if not isinstance(self.max_row_group_samples, int):
             raise TypeError("max_row_group_samples must be an int")
-        if not isinstance(self.prefetch_file_metadata, (bool, Unspecified)):
-            raise TypeError("prefetch_file_metadata must be a bool when specified")
+        if not isinstance(self.prefetch_file_metadata, bool):
+            raise TypeError("prefetch_file_metadata must be a bool")
         if not isinstance(self.use_hybrid_scan, bool):
             raise TypeError("use_hybrid_scan must be a bool")
         if self.use_hybrid_scan and self.prefetch_file_metadata is False:
@@ -1197,31 +1197,10 @@ class ConfigOptions(Generic[ExecutorType]):
         if user_parquet_options is None:
             user_parquet_options = {}
 
-        # Engine-dependent default: only prefetch for the streaming executor.
-        # Skipped if the user or the environment has already set a value.
-        prefetch_default = UNSPECIFIED if user_executor == "streaming" else False
-        prefetch_env_set = (
-            os.environ.get(f"{ParquetOptions._env_prefix}__PREFETCH_FILE_METADATA")
-            is not None
-        )
-
         if isinstance(user_parquet_options, dict):
             user_parquet_options = dict(user_parquet_options)
-            if (
-                "prefetch_file_metadata" not in user_parquet_options
-                and not prefetch_env_set
-            ):
-                user_parquet_options["prefetch_file_metadata"] = prefetch_default
             parquet_options = ParquetOptions(**user_parquet_options)
         else:
-            if (
-                isinstance(user_parquet_options.prefetch_file_metadata, Unspecified)
-                and not prefetch_env_set
-            ):
-                user_parquet_options = dataclasses.replace(
-                    user_parquet_options,
-                    prefetch_file_metadata=prefetch_default,
-                )
             parquet_options = user_parquet_options
         # This is set in polars, and so can't be overridden by the environment
         user_raise_on_fail = engine.config.get("raise_on_fail", False)

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -346,8 +346,8 @@ class ParquetOptions:
     prefetch_file_metadata
         Whether to prefetch parquet file metadata and pass it through
         `parquet_metadatas` to avoid rereading file footers. Not supported
-        by the in-memory executor. It defaults to disabled; pass ``True`` to
-        enable it for local or remote files.
+        by the in-memory executor. It defaults to disabled; enabling
+        ``use_hybrid_scan`` implicitly enables it.
     use_jit_filter
         Whether to use JIT compilation for post-read filtering in Parquet scans.
         When enabled, filter predicates are JIT-compiled to CUDA kernels for
@@ -391,11 +391,11 @@ class ParquetOptions:
             f"{_env_prefix}__MAX_ROW_GROUP_SAMPLES", int, default=1
         )
     )
-    prefetch_file_metadata: bool = dataclasses.field(
+    prefetch_file_metadata: bool | Unspecified = dataclasses.field(
         default_factory=_make_default_factory(
             f"{_env_prefix}__PREFETCH_FILE_METADATA",
             _bool_converter,
-            default=False,
+            default=UNSPECIFIED,
         )
     )
     use_hybrid_scan: bool = dataclasses.field(
@@ -438,10 +438,12 @@ class ParquetOptions:
             raise TypeError("max_footer_samples must be an int or None")
         if not isinstance(self.max_row_group_samples, int):
             raise TypeError("max_row_group_samples must be an int")
-        if not isinstance(self.prefetch_file_metadata, bool):
-            raise TypeError("prefetch_file_metadata must be a bool")
+        if not isinstance(self.prefetch_file_metadata, (bool, Unspecified)):
+            raise TypeError("prefetch_file_metadata must be a bool when specified")
         if not isinstance(self.use_hybrid_scan, bool):
             raise TypeError("use_hybrid_scan must be a bool")
+        if isinstance(self.prefetch_file_metadata, Unspecified):
+            object.__setattr__(self, "prefetch_file_metadata", self.use_hybrid_scan)
         if self.use_hybrid_scan and self.prefetch_file_metadata is False:
             raise ValueError(
                 "use_hybrid_scan requires prefetch_file_metadata to be enabled"

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -20,6 +20,7 @@ from cudf_polars.dsl.ir import (
 from cudf_polars.dsl.utils.io import (
     CachedParquetInfo,
     _prefetch_parquet_footers_for_paths,
+    attach_cached_parquet_metadata,
     prefetch_parquet_file_metadata_for_ir,
 )
 from cudf_polars.engine.options import StreamingOptions
@@ -130,6 +131,16 @@ def test_prefetch_parquet_file_metadata_no_parquet_scans() -> None:
         Empty({}), py_executor=None, stats=None
     )
     assert result == {}
+
+
+def test_attach_cached_parquet_metadata_skips_incomplete_scan() -> None:
+    scan = _make_parquet_scan(["first.parquet", "second.parquet"])
+    fused = FusedScan(scan.schema, scan, scan.paths, scan.parquet_options, None)
+    streaming_scan = StreamingScan([fused], scan, "fused")
+
+    attach_cached_parquet_metadata(streaming_scan, {})
+
+    assert fused.cached_parquet_info is None
 
 
 def test_prefetch_skips_paths_cached_by_stats_collection(

--- a/python/cudf_polars/tests/streaming/test_stats.py
+++ b/python/cudf_polars/tests/streaming/test_stats.py
@@ -30,6 +30,7 @@ from cudf_polars.streaming.io import (
     ParquetSourceInfo,
     _build_parquet_source,
     _clear_source_info_cache,
+    _resolve_max_footer_samples,
 )
 from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
@@ -56,6 +57,19 @@ def df_and_schema() -> tuple[pl.DataFrame, Schema]:
     df_ = cudf_polars.containers.DataFrame.from_polars(df, stream=stream)
     schema = {column.name: column.dtype for column in df_.columns}
     return df, schema
+
+
+@pytest.mark.parametrize(
+    "paths", "expected",
+    [
+        (("s3://bucket/data.parquet",), 0),
+        (("/tmp/data.parquet",), 3),
+    ],
+)
+def test_default_max_footer_samples_depends_on_path(
+    paths: tuple[str, ...], expected: int
+) -> None:
+    assert _resolve_max_footer_samples(paths, None) == expected
 
 
 # Simple engine for IR translation / stats collection only (no actual GPU execution)

--- a/python/cudf_polars/tests/streaming/test_stats.py
+++ b/python/cudf_polars/tests/streaming/test_stats.py
@@ -60,7 +60,7 @@ def df_and_schema() -> tuple[pl.DataFrame, Schema]:
 
 
 @pytest.mark.parametrize(
-    "paths", "expected",
+    "paths, expected",
     [
         (("s3://bucket/data.parquet",), 0),
         (("/tmp/data.parquet",), 3),

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -643,6 +643,18 @@ def test_use_hybrid_scan_requires_prefetch_file_metadata() -> None:
         )
 
 
+def test_use_hybrid_scan_enables_prefetch_file_metadata_by_default() -> None:
+    assert ParquetOptions(use_hybrid_scan=True).prefetch_file_metadata is True
+
+    config = ConfigOptions.from_polars_engine(
+        pl.GPUEngine(
+            executor="streaming",
+            parquet_options={"use_hybrid_scan": True},
+        )
+    )
+    assert config.parquet_options.prefetch_file_metadata is True
+
+
 def test_prefetch_file_metadata_default() -> None:
     config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
     assert config.parquet_options.prefetch_file_metadata is False

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -37,7 +37,6 @@ from cudf_polars.utils.config import (
     MemoryResourceConfig,
     ParquetOptions,
     StreamingExecutor,
-    Unspecified,
     configure_kvikio,
 )
 from cudf_polars.utils.cuda_stream import get_cuda_stream
@@ -646,7 +645,7 @@ def test_use_hybrid_scan_requires_prefetch_file_metadata() -> None:
 
 def test_prefetch_file_metadata_default() -> None:
     config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
-    assert isinstance(config.parquet_options.prefetch_file_metadata, Unspecified)
+    assert config.parquet_options.prefetch_file_metadata is False
 
     config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="in-memory"))
     assert config.parquet_options.prefetch_file_metadata is False
@@ -667,12 +666,9 @@ def test_parquet_options_object_passthrough() -> None:
     assert config.parquet_options is parquet_options
 
 
-def test_parquet_options_object_engine_default() -> None:
-    # If a user passes in a ParquetOptions object instead of a plain dict, and
-    # doesn't set prefetch_file_metadata on it, we still need to fill in the
-    # right default for the chosen executor.
+def test_parquet_options_object_default() -> None:
     parquet_options = ParquetOptions()
-    assert isinstance(parquet_options.prefetch_file_metadata, Unspecified)
+    assert parquet_options.prefetch_file_metadata is False
 
     config = ConfigOptions.from_polars_engine(
         pl.GPUEngine(executor="in-memory", parquet_options=parquet_options)
@@ -682,17 +678,17 @@ def test_parquet_options_object_engine_default() -> None:
     config = ConfigOptions.from_polars_engine(
         pl.GPUEngine(executor="streaming", parquet_options=parquet_options)
     )
-    assert isinstance(config.parquet_options.prefetch_file_metadata, Unspecified)
+    assert config.parquet_options.prefetch_file_metadata is False
 
 
-def test_parquet_options_unspecified_dict_factory() -> None:
+def test_parquet_options_default_dict_factory() -> None:
     parquet_options = ParquetOptions()
     config = ConfigOptions.from_polars_engine(
         pl.GPUEngine(executor="streaming", parquet_options=parquet_options)
     )
-    assert isinstance(config.parquet_options.prefetch_file_metadata, Unspecified)
+    assert config.parquet_options.prefetch_file_metadata is False
     result = dataclasses.asdict(config, dict_factory=ConfigOptions.dict_factory)
-    assert result["parquet_options"]["prefetch_file_metadata"] is None
+    assert result["parquet_options"]["prefetch_file_metadata"] is False
     assert result["executor"]["max_concurrent_io_tasks"] == {"local": 2, "remote": 8}
 
 


### PR DESCRIPTION
Adjust the default Parquet behavior for remote data sources to avoid metadata prefetching and footer sampling unless explicitly requested.

These defaults have performed significantly better for remote Parquet reads, while preserving the existing local-read behavior and allowing users to opt in to metadata work when needed.