### PR TITLE
ci: validate caller cache matrix keys

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -323,7 +323,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@codex/validate-caller-cache-matrix-key
     if: >
       fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_build_inputs ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_test_files ||
@@ -353,8 +353,8 @@ jobs:
         GPU
         DRIVER
         DEPENDENCIES
-      # PRs restore a compatible main cache but do not create merge-ref-scoped entries.
-      cache-read-only: true
+      # Validation-only: save PR-scoped entries so this run exposes the computed cache keys.
+      cache-read-only: false
       cache-environment: |
         LIBCUDF_KERNEL_CACHE_PATH=.cache/libcudf
         LIBCUDF_KERNEL_CACHE_PRELOAD=1


### PR DESCRIPTION
## Description

Validation-only PR for rapidsai/shared-actions#144. It uses rapidsai/shared-workflows#636 and temporarily allows the PR-scoped libcudf JIT caches to save, so the job logs expose the computed matrix-specific cache keys.

This PR must not merge.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.