### PR TITLE
TEST: Remove legacy reduction concurrency smoke test

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/series/methods/test_reductions.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import re
-from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
 
 import cupy as cp
@@ -70,24 +69,6 @@ def test_series_reductions(
     got = call_test(sr, skipna=skipna)
 
     np.testing.assert_approx_equal(expect, got, significant=4)
-
-
-def test_series_reductions_concurrency(reduction_methods):
-    rng = np.random.default_rng(seed=0)
-    srs = [cudf.Series(rng.random(100))]
-
-    def call_test(sr):
-        fn = getattr(sr, reduction_methods)
-        if reduction_methods in ["std", "var"]:
-            return fn(ddof=1)
-        else:
-            return fn()
-
-    def f(sr):
-        return call_test(sr + 1)
-
-    with ThreadPoolExecutor(10) as e:
-        list(e.map(f, srs * 50))
 
 
 @pytest.mark.parametrize("ddof", range(3))


### PR DESCRIPTION
## Description

Removes an undocumented 2019 concurrency smoke test for Series reductions. It had no result assertions or linked regression history; ordinary reduction correctness remains covered by the existing test matrix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.