### PR TITLE
TEST: Reuse ORC statistics test inputs

### DIFF
--- a/python/cudf/cudf/tests/input_output/test_orc.py
+++ b/python/cudf/cudf/tests/input_output/test_orc.py
@@ -641,28 +641,9 @@ def normalized_equals(value1, value2):
         return False
 
 
-@pytest.mark.parametrize("stats_freq", ["STRIPE", "ROWGROUP"])
-@pytest.mark.parametrize("nrows", [1, 100, 100000])
-def test_orc_write_statistics(tmp_path, datadir, nrows, stats_freq):
-    supported_stat_types = [*supported_numpy_dtypes, "str"]
-    # Writing bool columns to multiple row groups is disabled
-    # until #6763 is fixed
-    if nrows == 100000:
-        supported_stat_types.remove("bool")
-
-    # Make a dataframe
-    gdf = cudf.DataFrame(
-        {
-            "col_" + str(dtype): gen_rand_series(dtype, nrows, has_nulls=True)
-            for dtype in supported_stat_types
-        }
-    )
-    fname = tmp_path / "gdf.orc"
-
-    # Write said dataframe to ORC with cuDF
+def _assert_orc_write_statistics(gdf, fname, stats_freq):
     gdf.to_orc(fname, statistics=stats_freq, stripe_size_rows=30000)
 
-    # Read back written ORC's statistics
     orc_file = orc.ORCFile(fname)
     (
         file_stats,
@@ -712,6 +693,26 @@ def test_orc_write_statistics(tmp_path, datadir, nrows, stats_freq):
                 if stats_num_vals is not None:
                     actual_num_vals = stripe_df[col].count()
                     assert stats_num_vals == actual_num_vals
+
+
+@pytest.mark.parametrize("nrows", [1, 100, 100000])
+def test_orc_write_statistics(tmp_path, nrows):
+    supported_stat_types = [*supported_numpy_dtypes, "str"]
+    # Writing bool columns to multiple row groups is disabled
+    # until #6763 is fixed
+    if nrows == 100000:
+        supported_stat_types.remove("bool")
+
+    gdf = cudf.DataFrame(
+        {
+            "col_" + str(dtype): gen_rand_series(dtype, nrows, has_nulls=True)
+            for dtype in supported_stat_types
+        }
+    )
+    for stats_freq in ("STRIPE", "ROWGROUP"):
+        _assert_orc_write_statistics(
+            gdf, tmp_path / f"gdf-{stats_freq}.orc", stats_freq
+        )
 
 
 @pytest.mark.parametrize("stats_freq", ["STRIPE", "ROWGROUP"])


### PR DESCRIPTION
## Description

Builds each ORC statistics input once per row-count case and exercises every existing statistics configuration against that shared, read-only input. Assertions and coverage remain unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.