### PR TITLE
TEST: Reuse DataFrame dot test inputs

### DIFF
--- a/python/cudf/cudf/tests/dataframe/test_binops.py
+++ b/python/cudf/cudf/tests/dataframe/test_binops.py
@@ -634,6 +634,19 @@ def test_empty_column(binary_op, data, scalar):
     assert_eq(expected, got, check_dtype=False)
 
 
+DOT_OTHER_FACTORIES = [
+    lambda: cudf.DataFrame([[9, 10], [11, 12], [13, 14], [15, 16]]),
+    lambda: cudf.DataFrame(
+        [[9.4, 10.5], [11.6, 12.7], [13.8, 14.9], [15.1, 16.2]]
+    ),
+    lambda: cudf.Series([5, 6, 7, 8]),
+    lambda: cudf.Series([5.6, 6.7, 7.8, 8.9]),
+    lambda: np.array([5, 6, 7, 8]),
+    # rapids-pre-commit-hooks: disable-next-line
+    lambda: [25.5, 26.6, 27.7, 28.8],
+]
+
+
 @pytest.mark.parametrize(
     "df",
     [
@@ -652,30 +665,20 @@ def test_empty_column(binary_op, data, scalar):
         lambda: cudf.Series([14.15, 15.16, 16.17, 17.18]),
     ],
 )
-@pytest.mark.parametrize(
-    "other",
-    [
-        lambda: cudf.DataFrame([[9, 10], [11, 12], [13, 14], [15, 16]]),
-        lambda: cudf.DataFrame(
-            [[9.4, 10.5], [11.6, 12.7], [13.8, 14.9], [15.1, 16.2]]
-        ),
-        lambda: cudf.Series([5, 6, 7, 8]),
-        lambda: cudf.Series([5.6, 6.7, 7.8, 8.9]),
-        lambda: np.array([5, 6, 7, 8]),
-        # rapids-pre-commit-hooks: disable-next-line
-        lambda: [25.5, 26.6, 27.7, 28.8],
-    ],
-)
-def test_binops_dot(df, other):
+def test_binops_dot(df):
     df = df()
-    other = other()
     pdf = df.to_pandas()
-    host_other = other.to_pandas() if hasattr(other, "to_pandas") else other
 
-    expected = pdf @ host_other
-    got = df @ other
+    for other_factory in DOT_OTHER_FACTORIES:
+        other = other_factory()
+        host_other = (
+            other.to_pandas() if hasattr(other, "to_pandas") else other
+        )
 
-    assert_eq(expected, got)
+        expected = pdf @ host_other
+        got = df @ other
+
+        assert_eq(expected, got)
 
 
 def test_binop_dot_preserve_index():


### PR DESCRIPTION
## Description

Reuses the existing left-hand DataFrame inputs while retaining every right-hand operand and pandas comparison in the DataFrame dot test matrix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.