### PR TITLE
TEST: Reuse describe test frames

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_describe.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_describe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -104,9 +104,9 @@ def test_dataframe_describe_include_all():
     )
 
 
-@pytest.mark.parametrize(
-    "pdf",
-    [
+@pytest.fixture(
+    scope="module",
+    params=[
         pd.DataFrame(
             {
                 "a": [1, 2, 3],
@@ -147,75 +147,14 @@ def test_dataframe_describe_include_all():
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "include",
-    [None, "all", ["str"], ["int"], ["str", "int", "category"]],
-)
-def test_describe_misc_include(pdf, include):
-    df = cudf.DataFrame(pdf)
-
-    expected = pdf.describe(include=include)
-    actual = df.describe(include=include)
-
-    for col in expected.columns:
-        if expected[col].dtype == np.dtype("object"):
-            expected[col] = expected[col].fillna(-1).astype("str")
-            actual[col] = actual[col].fillna(-1).astype("str")
-
-    assert_eq(expected, actual)
+def describe_frame(request):
+    pdf = request.param
+    return pdf, cudf.DataFrame(pdf)
 
 
-@pytest.mark.parametrize(
-    "pdf",
-    [
-        pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "b": [10, 22, 33],
-                "c": [0.3234, 0.23432, 0.0],
-                "d": ["hello", "world", "hello"],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "b": ["hello", "world", "hello"],
-                "c": [0.3234, 0.23432, 0.0],
-            }
-        ),
-        pd.DataFrame(
-            {
-                "int_data": [1, 2, 3],
-                "str_data": ["hello", "world", "hello"],
-                "float_data": [0.3234, 0.23432, 0.0],
-                "timedelta_data": pd.Series(
-                    [1, 2, 1], dtype="timedelta64[ns]"
-                ),
-                "datetime_data": pd.Series([1, 2, 1], dtype="datetime64[ns]"),
-            }
-        ),
-        pd.DataFrame(
-            {
-                "int_data": [1, 2, 3],
-                "str_data": ["hello", "world", "hello"],
-                "float_data": [0.3234, 0.23432, 0.0],
-                "timedelta_data": pd.Series(
-                    [1, 2, 1], dtype="timedelta64[ns]"
-                ),
-                "datetime_data": pd.Series([1, 2, 1], dtype="datetime64[ns]"),
-                "category_data": pd.Series(["a", "a", "b"], dtype="category"),
-            }
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "exclude", [None, ["str"], ["int"], ["str", "int", "category"]]
-)
-def test_describe_misc_exclude(pdf, exclude):
-    df = cudf.DataFrame(pdf)
-
-    expected = pdf.describe(exclude=exclude)
-    actual = df.describe(exclude=exclude)
+def _assert_describe_equal(pdf, df, **kwargs):
+    expected = pdf.describe(**kwargs)
+    actual = df.describe(**kwargs)
 
     for col in expected.columns:
         if expected[col].dtype == np.dtype("object"):
@@ -223,6 +162,18 @@ def test_describe_misc_exclude(pdf, exclude):
             actual[col] = actual[col].fillna(-1).astype("str")
 
     assert_eq(expected, actual)
+
+
+def test_describe_misc_include(describe_frame):
+    pdf, df = describe_frame
+    for include in (None, "all", ["str"], ["int"], ["str", "int", "category"]):
+        _assert_describe_equal(pdf, df, include=include)
+
+
+def test_describe_misc_exclude(describe_frame):
+    pdf, df = describe_frame
+    for exclude in (None, ["str"], ["int"], ["str", "int", "category"]):
+        _assert_describe_equal(pdf, df, exclude=exclude)
 
 
 def test_empty_dataframe_describe():


### PR DESCRIPTION
## Description

Constructs the read-only pandas/cuDF describe inputs once at module scope and retains every include/exclude and dtype assertion.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.