### PR TITLE
TEST: Reuse Python test inputs

### DIFF
--- a/python/cudf/cudf/tests/dataframe/indexing/test_iloc.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_iloc.py
@@ -10,6 +10,36 @@ import cudf
 from cudf.testing import assert_eq
 
 
+@pytest.fixture(scope="module")
+def multiindex_iloc_frames():
+    rng = np.random.default_rng(seed=0)
+    pdf = pd.DataFrame(rng.random(size=(7, 5)))
+    pdf.index = pd.MultiIndex(
+        [
+            ["a", "b", "c"],
+            ["house", "store", "forest"],
+            ["clouds", "clear", "storm"],
+            ["fire", "smoke", "clear"],
+            [
+                np.datetime64("2001-01-01", "ns"),
+                np.datetime64("2002-01-01", "ns"),
+                np.datetime64("2003-01-01", "ns"),
+            ],
+        ],
+        [
+            [0, 0, 0, 0, 1, 1, 2],
+            [1, 1, 1, 1, 0, 0, 2],
+            [0, 0, 2, 2, 2, 0, 1],
+            [0, 0, 0, 1, 2, 0, 1],
+            [1, 0, 1, 2, 0, 0, 1],
+        ],
+        names=["alpha", "location", "weather", "sign", "timestamp"],
+    )
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(pdf.index, gdf.index)
+    return pdf, gdf
+
+
 @pytest.mark.parametrize(
     "iloc_rows",
     [
@@ -38,35 +68,8 @@ from cudf.testing import assert_eq
         slice(1, None),
     ],
 )
-def test_multiindex_iloc(iloc_rows, iloc_columns):
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    gdf = cudf.from_pandas(pdf)
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    assert_eq(pdfIndex, gdfIndex)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_iloc(multiindex_iloc_frames, iloc_rows, iloc_columns):
+    pdf, gdf = multiindex_iloc_frames
     presult = pdf.iloc[iloc_rows, iloc_columns]
     gresult = gdf.iloc[iloc_rows, iloc_columns]
     if isinstance(gresult, cudf.DataFrame):
@@ -117,35 +120,8 @@ def test_multiindex_iloc_scalar():
         slice(1, None),
     ],
 )
-def test_multicolumn_iloc(iloc_rows, iloc_columns):
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    gdf = cudf.from_pandas(pdf)
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    assert_eq(pdfIndex, gdfIndex)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multicolumn_iloc(multiindex_iloc_frames, iloc_rows, iloc_columns):
+    pdf, gdf = multiindex_iloc_frames
     pdf = pdf.T
     gdf = gdf.T
     presult = pdf.iloc[iloc_rows, iloc_columns]

--- a/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
@@ -189,6 +189,36 @@ def expect_pandas_performance_warning(idx):
         yield
 
 
+@pytest.fixture(scope="module")
+def multiindex_loc_frames():
+    rng = np.random.default_rng(seed=0)
+    pdf = pd.DataFrame(rng.random(size=(7, 5)))
+    pdf.index = pd.MultiIndex(
+        [
+            ["a", "b", "c"],
+            ["house", "store", "forest"],
+            ["clouds", "clear", "storm"],
+            ["fire", "smoke", "clear"],
+            [
+                np.datetime64("2001-01-01", "ns"),
+                np.datetime64("2002-01-01", "ns"),
+                np.datetime64("2003-01-01", "ns"),
+            ],
+        ],
+        [
+            [0, 0, 0, 0, 1, 1, 2],
+            [1, 1, 1, 1, 0, 0, 2],
+            [0, 0, 2, 2, 2, 0, 1],
+            [0, 0, 0, 1, 2, 0, 1],
+            [1, 0, 1, 2, 0, 0, 1],
+        ],
+        names=["alpha", "location", "weather", "sign", "timestamp"],
+    )
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(pdf.index, gdf.index)
+    return pdf, gdf
+
+
 @pytest.mark.parametrize(
     "key_tuple",
     [
@@ -215,35 +245,8 @@ def expect_pandas_performance_warning(idx):
         (("c", "forest", "clear"), slice(None)),
     ],
 )
-def test_multiindex_loc(key_tuple):
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    assert_eq(pdfIndex, gdfIndex)
-    gdf = cudf.from_pandas(pdf)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc(multiindex_loc_frames, key_tuple):
+    pdf, gdf = multiindex_loc_frames
     # The index is unsorted, which makes things slow but is fine for testing.
     with expect_pandas_performance_warning(key_tuple):
         expected = pdf.loc[key_tuple]
@@ -277,65 +280,13 @@ def test_multiindex_compatible_ordering(second_val):
         slice(None),
     ],
 )
-def test_multiindex_loc_slice(arg):
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdf = cudf.from_pandas(pdf)
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    pdf = pdf.copy(deep=False)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc_slice(multiindex_loc_frames, arg):
+    pdf, gdf = multiindex_loc_frames
     assert_eq(pdf.loc[arg], gdf.loc[arg])
 
 
-def test_multiindex_loc_errors():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    gdf = cudf.from_pandas(pdf)
-    gdf.index = gdfIndex
+def test_multiindex_loc_errors(multiindex_loc_frames):
+    _, gdf = multiindex_loc_frames
 
     with pytest.raises(KeyError):
         gdf.loc[("a", "store", "clouds", "foo")]
@@ -347,35 +298,8 @@ def test_multiindex_loc_errors():
         gdf.loc[slice(None, ("a", "store", "clouds", "fire", "x", "y"))]
 
 
-def test_multiindex_loc_then_column():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdf = cudf.from_pandas(pdf)
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    assert_eq(pdfIndex, gdfIndex)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc_then_column(multiindex_loc_frames):
+    pdf, gdf = multiindex_loc_frames
     # The index is unsorted, which makes things slow but is fine for testing.
     with pytest.warns(pd.errors.PerformanceWarning):
         expected = pdf.loc[("a", "store", "clouds", "fire"), :][0]
@@ -383,34 +307,8 @@ def test_multiindex_loc_then_column():
     assert_eq(expected, got)
 
 
-def test_multiindex_loc_rows_0():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    gdf = cudf.from_pandas(pdf)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc_rows_0(multiindex_loc_frames):
+    pdf, gdf = multiindex_loc_frames
 
     assert_exceptions_equal(
         lfunc=pdf.loc.__getitem__,
@@ -420,65 +318,13 @@ def test_multiindex_loc_rows_0():
     )
 
 
-def test_multiindex_loc_rows_1_2_key():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    gdf = cudf.from_pandas(pdf)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc_rows_1_2_key(multiindex_loc_frames):
+    pdf, gdf = multiindex_loc_frames
     assert_eq(pdf.loc[("c", "forest"), :], gdf.loc[("c", "forest"), :])
 
 
-def test_multiindex_loc_rows_1_1_key():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    gdf = cudf.from_pandas(pdf)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_loc_rows_1_1_key(multiindex_loc_frames):
+    pdf, gdf = multiindex_loc_frames
     assert_eq(pdf.loc[("c",), :], gdf.loc[("c",), :])
 
 
@@ -505,34 +351,8 @@ def test_multiindex_loc_scalar(idx_get, cols_get):
     assert_eq(actual, expected)
 
 
-def test_multiindex_rows_with_wildcard():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    gdf = cudf.from_pandas(pdf)
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
-    gdfIndex = cudf.from_pandas(pdfIndex)
-    pdf.index = pdfIndex
-    gdf.index = gdfIndex
+def test_multiindex_rows_with_wildcard(multiindex_loc_frames):
+    pdf, gdf = multiindex_loc_frames
     # The index is unsorted, which makes things slow but is fine for testing.
     with pytest.warns(pd.errors.PerformanceWarning):
         assert_eq(
@@ -568,32 +388,9 @@ def test_multiindex_rows_with_wildcard():
         )
 
 
-def test_multicolumn_loc():
-    rng = np.random.default_rng(seed=0)
-    pdf = pd.DataFrame(rng.random(size=(7, 5)))
-    pdfIndex = pd.MultiIndex(
-        [
-            ["a", "b", "c"],
-            ["house", "store", "forest"],
-            ["clouds", "clear", "storm"],
-            ["fire", "smoke", "clear"],
-            [
-                np.datetime64("2001-01-01", "ns"),
-                np.datetime64("2002-01-01", "ns"),
-                np.datetime64("2003-01-01", "ns"),
-            ],
-        ],
-        [
-            [0, 0, 0, 0, 1, 1, 2],
-            [1, 1, 1, 1, 0, 0, 2],
-            [0, 0, 2, 2, 2, 0, 1],
-            [0, 0, 0, 1, 2, 0, 1],
-            [1, 0, 1, 2, 0, 0, 1],
-        ],
-    )
-    pdfIndex.names = ["alpha", "location", "weather", "sign", "timestamp"]
+def test_multicolumn_loc(multiindex_loc_frames):
+    pdf, _ = multiindex_loc_frames
     pdf = pdf.T
-    pdf.columns = pdfIndex
     gdf = cudf.from_pandas(pdf)
     assert_eq(pdf.loc[:, "a"], gdf.loc[:, "a"])
     assert_eq(pdf.loc[:, ("a", "store")], gdf.loc[:, ("a", "store")])

--- a/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
@@ -286,24 +286,34 @@ def test_dataframe_count_axis1(data, numeric_only):
     )
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        {
-            "x": [np.nan, 2, 3, 4, 100, np.nan],
-            "y": [4, 5, 6, 88, 99, np.nan],
-            "z": [7, 8, 9, 66, np.nan, 77],
-        },
-        {"x": [1, 2, 3], "y": [4, 5, 6], "z": [7, 8, 9]},
-        {
-            "x": [np.nan, np.nan, np.nan],
-            "y": [np.nan, np.nan, np.nan],
-            "z": [np.nan, np.nan, np.nan],
-        },
-        {"x": [], "y": [], "z": []},
-        {"x": []},
-    ],
+_DATAFRAME_REDUCTION_DATA = [
+    {
+        "x": [np.nan, 2, 3, 4, 100, np.nan],
+        "y": [4, 5, 6, 88, 99, np.nan],
+        "z": [7, 8, 9, 66, np.nan, 77],
+    },
+    {"x": [1, 2, 3], "y": [4, 5, 6], "z": [7, 8, 9]},
+    {
+        "x": [np.nan, np.nan, np.nan],
+        "y": [np.nan, np.nan, np.nan],
+        "z": [np.nan, np.nan, np.nan],
+    },
+    {"x": [], "y": [], "z": []},
+    {"x": []},
+]
+
+
+@pytest.fixture(
+    scope="module",
+    params=list(enumerate(_DATAFRAME_REDUCTION_DATA)),
+    ids=[f"data{i}" for i in range(len(_DATAFRAME_REDUCTION_DATA))],
 )
+def dataframe_reduction_inputs(request):
+    data_id, data = request.param
+    pdf = pd.DataFrame(data=data)
+    return data_id, pdf, cudf.DataFrame(pdf, nan_as_null=False)
+
+
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(
     "func",
@@ -328,14 +338,15 @@ def test_dataframe_count_axis1(data, numeric_only):
         "any",
     ],
 )
-def test_dataframe_reductions(request, data, axis, func, skipna):
-    pdf = pd.DataFrame(data=data)
-    gdf = cudf.DataFrame(pdf, nan_as_null=False)
+def test_dataframe_reductions(
+    request, dataframe_reduction_inputs, axis, func, skipna
+):
+    data_id, pdf, gdf = dataframe_reduction_inputs
 
-    if request.node.callspec.id in {
-        "True-cumsum-1-data0",
-        "True-cumprod-1-data0",
-        "True-any-1-data2",
+    if (skipna, func, axis, data_id) in {
+        (True, "cumsum", 1, 0),
+        (True, "cumprod", 1, 0),
+        (True, "any", 1, 2),
     }:
         request.applymarker(
             pytest.mark.xfail(

--- a/python/cudf/cudf/tests/series/indexing/test_iloc.py
+++ b/python/cudf/cudf/tests/series/indexing/test_iloc.py
@@ -183,49 +183,53 @@ def test_out_of_bounds_indexing_empty():
     )
 
 
-@pytest.mark.parametrize(
-    "gdf",
-    [
-        lambda: cudf.DataFrame({"a": range(10000)}),
-        lambda: cudf.DataFrame(
-            {
-                "a": range(10000),
-                "b": range(10000),
-                "c": range(10000),
-                "d": range(10000),
-                "e": range(10000),
-                "f": range(10000),
-            }
-        ),
-        lambda: cudf.DataFrame({"a": range(20), "b": range(20)}),
-        lambda: cudf.DataFrame(
-            {
-                "a": range(20),
-                "b": range(20),
-                "c": ["abc", "def", "xyz", "def", "pqr"] * 4,
-            }
-        ),
-        lambda: cudf.DataFrame(index=[1, 2, 3]),
-        lambda: cudf.DataFrame(index=range(10000)),
-        lambda: cudf.DataFrame(columns=["a", "b", "c", "d"]),
-        lambda: cudf.DataFrame(columns=["a"], index=range(10000)),
-        lambda: cudf.DataFrame(
-            columns=["a", "col2", "...col n"], index=range(10000)
-        ),
-        lambda: cudf.DataFrame(index=cudf.Series(range(10000)).astype("str")),
-        lambda: cudf.DataFrame(
-            columns=["a", "b", "c", "d"],
-            index=cudf.Series(range(10000)).astype("str"),
-        ),
-    ],
-)
+_DATAFRAME_ILOC_INDEX_BUILDERS = [
+    lambda: cudf.DataFrame({"a": range(10000)}),
+    lambda: cudf.DataFrame(
+        {
+            "a": range(10000),
+            "b": range(10000),
+            "c": range(10000),
+            "d": range(10000),
+            "e": range(10000),
+            "f": range(10000),
+        }
+    ),
+    lambda: cudf.DataFrame({"a": range(20), "b": range(20)}),
+    lambda: cudf.DataFrame(
+        {
+            "a": range(20),
+            "b": range(20),
+            "c": ["abc", "def", "xyz", "def", "pqr"] * 4,
+        }
+    ),
+    lambda: cudf.DataFrame(index=[1, 2, 3]),
+    lambda: cudf.DataFrame(index=range(10000)),
+    lambda: cudf.DataFrame(columns=["a", "b", "c", "d"]),
+    lambda: cudf.DataFrame(columns=["a"], index=range(10000)),
+    lambda: cudf.DataFrame(
+        columns=["a", "col2", "...col n"], index=range(10000)
+    ),
+    lambda: cudf.DataFrame(index=cudf.Series(range(10000)).astype("str")),
+    lambda: cudf.DataFrame(
+        columns=["a", "b", "c", "d"],
+        index=cudf.Series(range(10000)).astype("str"),
+    ),
+]
+
+
+@pytest.fixture(scope="module", params=_DATAFRAME_ILOC_INDEX_BUILDERS)
+def dataframe_iloc_index_frame(request):
+    gdf = request.param()
+    return gdf, gdf.to_pandas()
+
+
 @pytest.mark.parametrize(
     "slice",
     [slice(6), slice(1), slice(7), slice(1, 3)],
 )
-def test_dataframe_iloc_index(gdf, slice):
-    gdf = gdf()
-    pdf = gdf.to_pandas()
+def test_dataframe_iloc_index(dataframe_iloc_index_frame, slice):
+    gdf, pdf = dataframe_iloc_index_frame
 
     actual = gdf.iloc[:, slice]
     expected = pdf.iloc[:, slice]

--- a/python/cudf/cudf/tests/series/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/series/methods/test_reductions.py
@@ -25,9 +25,45 @@ def test_series_pandas_methods(data, reduction_methods):
     )
 
 
+@pytest.fixture(
+    scope="module",
+    params=[
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+    ],
+)
+def series_reduction_inputs(request):
+    dtype = request.param
+    rng = np.random.default_rng(seed=0)
+    arr = rng.random(100)
+    if np.dtype(dtype).kind in "iu":
+        arr *= 100
+        mask = arr > 10
+    else:
+        mask = arr > 0.5
+
+    arr = arr.astype(dtype)
+    if dtype in ("float32", "float64"):
+        arr[[2, 5, 14, 19, 50, 70]] = np.nan
+    sr = cudf.Series(arr)
+    sr[~mask] = None
+    psr = sr.to_pandas()
+    psr[~mask] = np.nan
+    return dtype, sr, psr
+
+
 def test_series_reductions(
-    request, reduction_methods, numeric_types_as_str, skipna
+    request, reduction_methods, series_reduction_inputs, skipna
 ):
+    numeric_types_as_str, sr, psr = series_reduction_inputs
     request.applymarker(
         pytest.mark.xfail(
             reduction_methods == "quantile",
@@ -43,21 +79,6 @@ def test_series_reductions(
             reason=f"{reduction_methods} incorrect with {skipna=}",
         )
     )
-    rng = np.random.default_rng(seed=0)
-    arr = rng.random(100)
-    if np.dtype(numeric_types_as_str).kind in "iu":
-        arr *= 100
-        mask = arr > 10
-    else:
-        mask = arr > 0.5
-
-    arr = arr.astype(numeric_types_as_str)
-    if numeric_types_as_str in ("float32", "float64"):
-        arr[[2, 5, 14, 19, 50, 70]] = np.nan
-    sr = cudf.Series(arr)
-    sr[~mask] = None
-    psr = sr.to_pandas()
-    psr[~mask] = np.nan
 
     def call_test(sr, skipna):
         fn = getattr(sr, reduction_methods)


### PR DESCRIPTION
## Description

Reuses read-only test data across indexing and reduction tests, avoiding repeated device allocations and conversions while preserving the existing assertions and parameter coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.