### PR TITLE
Only default pinned memory on when the system supports it

### DIFF
--- a/python/cudf_polars/cudf_polars/engine/core.py
+++ b/python/cudf_polars/cudf_polars/engine/core.py
@@ -24,6 +24,9 @@ from cudf_streaming.table_chunk import TableChunk
 from rapidsmpf.coll import AllGather
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.packed_data import PackedData
+from rapidsmpf.memory.pinned_memory_resource import (
+    is_pinned_memory_resources_supported,
+)
 from rapidsmpf.statistics import Statistics
 from rapidsmpf.streaming.core.actor import run_actor_network
 
@@ -211,8 +214,9 @@ def resolve_rapidsmpf_options(rapidsmpf_options: Options | None) -> Options:
 
     - ``num_streaming_threads=4``: moderate worker count for the rapidsmpf
       streaming runtime, shared across frontends.
-    - ``pinned_memory=true``, ``pinned_initial_pool_size=0``: pinned host
-      memory enabled by default.
+    - ``pinned_memory``, ``pinned_initial_pool_size=0``: pinned host memory
+      enabled by default, but only on systems that support it (CUDA 12.6+
+      with async memory pool support).
 
     Parameters
     ----------
@@ -228,10 +232,13 @@ def resolve_rapidsmpf_options(rapidsmpf_options: Options | None) -> Options:
     if rapidsmpf_options is None:
         rapidsmpf_options = Options(get_environment_variables())
 
+    pinned_memory_default = (
+        "true" if is_pinned_memory_resources_supported() else "false"
+    )
     rapidsmpf_options.insert_if_absent(
         {
             "num_streaming_threads": "4",
-            "pinned_memory": "true",
+            "pinned_memory": pinned_memory_default,
             "pinned_initial_pool_size": "0",
         }
     )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follows up https://github.com/NVIDIA/cudf/pull/23836. Do not turn on pinned memory for systems that do not support it.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
