### PR TITLE
CI: Make cudf-spark-jni build non-blocking

### DIFF
--- a/.github/workflows/cudf-spark-jni.yaml
+++ b/.github/workflows/cudf-spark-jni.yaml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   cudf-spark-jni-build:
+    continue-on-error: true
     runs-on: linux-amd64-cpu8
     container:
       image: rapidsai/ci-spark-rapids-jni:rockylinux8-cuda12.9.1


### PR DESCRIPTION
## Description
Mark the reusable `cudf-spark-jni-build` job with `continue-on-error: true`. This keeps cuDF Spark JNI failures visible while preventing them from failing the nightly workflow and, consequently, blocking `check-nightly-ci`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.