### PR TITLE
Remove rapidsai channel for xgboost 3rd party pandas tests

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -130,7 +130,6 @@ files:
 
 channels:
   - rapidsai-nightly
-  - rapidsai
   - conda-forge
 
 dependencies:
@@ -316,12 +315,9 @@ dependencies:
     common:
       - output_types: conda
         packages:
-        # TODO: Remove hypothesis pinning once https://github.com/HypothesisWorks/hypothesis/issues/4365 is resolved
-          - hypothesis>=6.131.7
           - numpy
           - scipy
           - scikit-learn
-          - pip
           - xgboost>=2.0.1
   test_catboost:
     common:


### PR DESCRIPTION
## Description
Applies the similar fix to https://github.com/NVIDIA/cuml/pull/8596 in order to resolve a conda solve issue resolving our xgboost 3rd party environment

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
