### PR TITLE
Reject JSON object names that are not followed by a colon in `get_json_object`

### DIFF
--- a/cpp/src/json/json_path.cu
+++ b/cpp/src/json/json_path.cu
@@ -373,12 +373,9 @@ class json_state : private parser {
     }
 
     // a name is present, so the next non-whitespace char must be a ':'
-    if (!parse_whitespace()) { return parse_result::ERROR; }
-    if (*pos == ':') {
-      pos++;
-      return parse_result::SUCCESS;
-    }
-    return parse_result::EMPTY;
+    if (!parse_whitespace() || *pos != ':') { return parse_result::ERROR; }
+    pos++;
+    return parse_result::SUCCESS;
   }
 
  private:

--- a/cpp/tests/json/json_tests.cpp
+++ b/cpp/tests/json/json_tests.cpp
@@ -1059,6 +1059,18 @@ TEST_F(JsonPathTests, ObjectWithEmptyKey)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected);
 }
 
+TEST_F(JsonPathTests, ObjectNameWithoutColon)
+{
+  auto const input = cudf::test::strings_column_wrapper{
+    R"({"a" 1})", R"({"a" 1, "b":2})", R"({"a"})", R"({"a" "b"})", R"({"a" , "b":2})"};
+
+  auto const result =
+    cudf::get_json_object(cudf::strings_column_view(input), std::string_view{"$.a"});
+  auto const expected =
+    cudf::test::strings_column_wrapper{{"", "", "", "", ""}, {false, false, false, false, false}};
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected);
+}
+
 // Test that get_json_object creates valid string columns for empty/whitespace JSONPath queries
 TEST_F(JsonPathTests, EmptyPathCreatesValidColumn)
 {


### PR DESCRIPTION
## Description

Addresses issue raised in comment https://github.com/NVIDIA/cudf/pull/24028#discussion_r3992944885

`parse_name` returned `parse_result::EMPTY` when an object name parsed successfully but was not followed by a `:`. Since `next_element_internal` only treats `ERROR` as a failure, malformed members such as `{"a" 1}` were accepted as if the colon had been there, so `$.a` on `{"a" 1}` returned `1` instead of null.
A name followed by anything other than `:` is invalid JSON, so this now returns `ERROR`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.