### PR TITLE
Reuse null comparison helper in single-column sorting

### DIFF
--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -37,11 +37,11 @@ struct simple_comparator {
   __device__ bool operator()(size_type lhs, size_type rhs)
   {
     if (has_nulls) {
-      bool lhs_null{d_column.is_null(lhs)};
-      bool rhs_null{d_column.is_null(rhs)};
+      bool const lhs_null{d_column.is_null(lhs)};
+      bool const rhs_null{d_column.is_null(rhs)};
       if (lhs_null || rhs_null) {
-        if (!ascending) { cuda::std::swap(lhs_null, rhs_null); }
-        return (null_precedence == cudf::null_order::BEFORE ? !rhs_null : !lhs_null);
+        return null_compare(lhs_null, rhs_null, null_precedence) ==
+               (ascending ? weak_ordering::LESS : weak_ordering::GREATER);
       }
     }
 


### PR DESCRIPTION
## Description

This PR reuses `null_compare` in `simple_comparator` to remove duplicate null-ordering logic in single-column sorting.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
