### PR TITLE
CI: Split Conda cuDF-Polars tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -187,6 +187,7 @@ jobs:
           - 'ci/run_cudf_streaming_pytests.sh'
         test_python_cudf_polars:
           - 'python/cudf_polars/**'
+          - 'ci/test_python_cudf_polars.sh'
         test_python_cudf_streaming:
           - 'python/cudf_streaming/**'
           - 'python/libcudf_streaming/**'
@@ -419,8 +420,32 @@ jobs:
         ci/test_python_cudf.sh
       # https://github.com/NVIDIA/cudf/issues/23498
       matrix_filter: map(select(.GPU != "gb300" and .GPU != "gh200"))
+  conda-python-cudf-polars-tests:
+    needs: [conda-python-build, conda-python-build-noarch, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    if: >
+      fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_build_inputs ||
+      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all ||
+      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars ||
+      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds ||
+      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common ||
+      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars_runner
+    with:
+      build_type: pull-request
+      # https://github.com/NVIDIA/cudf/pull/22381/changes#r3196736965
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: ci/test_python_cudf_polars.sh
+      # https://github.com/NVIDIA/cudf/issues/23498
+      matrix_filter: map(select(.GPU != "gb300" and .GPU != "gh200"))
   conda-python-other-tests:
-    # Tests for dask_cudf, cudf_polars, custreamz, cudf_kafka are separated for CI parallelism
+    # Tests for dask_cudf, cudf_kafka, custreamz, and cudf_streaming run separately from cudf_polars.
     needs: [conda-python-build, conda-python-build-noarch, changed-files]
     permissions:
       actions: read
@@ -437,11 +462,9 @@ jobs:
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_dask_cudf ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_kafka ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_custreamz ||
-      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_streaming ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common ||
-      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars_runner ||
       fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_streaming_runner
     with:
       build_type: pull-request
@@ -452,7 +475,6 @@ jobs:
         RUN_DASK_CUDF_TESTS=${{ fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_build_inputs || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_other || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_dask_cudf || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common }}
         RUN_CUDF_KAFKA_TESTS=${{ fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_other || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_kafka || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common }}
         RUN_CUSTREAMZ_TESTS=${{ fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_other || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_custreamz || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common }}
-        RUN_CUDF_POLARS_TESTS=${{ fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_build_inputs || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_other || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_polars_runner }}
         RUN_CUDF_STREAMING_TESTS=${{ fromJSON(needs.changed-files.outputs.changed_file_groups).cpp_build_inputs || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_all || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_other || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_streaming || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_builds || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda_common || fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_cudf_streaming_runner }}
         ci/test_python_other.sh
       # https://github.com/NVIDIA/cudf/issues/23498

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,6 +23,7 @@ jobs:
       - conda-python-build
       - conda-python-build-noarch
       - conda-python-cudf-tests
+      - conda-python-cudf-polars-tests
       - conda-python-other-tests
       - java-build-matrix
       - java-build

--- a/ci/test_python_cudf_polars.sh
+++ b/ci/test_python_cudf_polars.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+
+source ./ci/test_python_common.sh test_python_other
+
+rapids-logger "Check GPU usage"
+nvidia-smi
+rapids-print-env
+
+rapids-logger "pytest cudf-polars"
+# Fail fast (-x) rather than trying to continue because failed tests pollute the state.
+./ci/run_cudf_polars_pytests.sh \
+  -x \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
+  --numprocesses=4 \
+  --dist=worksteal \
+  --cov-config=./pyproject.toml \
+  --cov=cudf_polars \
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-polars-coverage.xml" \
+  --cov-report=term \
+  --durations=50 --durations-min=1

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 RUN_DASK_CUDF_TESTS="${RUN_DASK_CUDF_TESTS:-true}"
 RUN_CUDF_KAFKA_TESTS="${RUN_CUDF_KAFKA_TESTS:-true}"
 RUN_CUSTREAMZ_TESTS="${RUN_CUSTREAMZ_TESTS:-true}"
-RUN_CUDF_POLARS_TESTS="${RUN_CUDF_POLARS_TESTS:-true}"
 RUN_CUDF_STREAMING_TESTS="${RUN_CUDF_STREAMING_TESTS:-true}"
 
 # Support invoking test_python_cudf.sh outside the script directory
@@ -52,21 +51,6 @@ if [[ "${RUN_CUSTREAMZ_TESTS}" == "true" ]]; then
     --cov-config=../.coveragerc \
     --cov=custreamz \
     --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/custreamz-coverage.xml" \
-    --cov-report=term \
-    --durations=50 --durations-min=1
-fi
-
-if [[ "${RUN_CUDF_POLARS_TESTS}" == "true" ]]; then
-  rapids-logger "pytest cudf-polars"
-  # Fail fast (-x) rather than trying to continue because failed tests pollute the state
-  ./ci/run_cudf_polars_pytests.sh \
-    -x \
-    --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
-    --numprocesses=4 \
-    --dist=worksteal \
-    --cov-config=./pyproject.toml \
-    --cov=cudf_polars \
-    --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-polars-coverage.xml" \
     --cov-report=term \
     --durations=50 --durations-min=1
 fi


### PR DESCRIPTION
## Description

Run cuDF-Polars tests in their own Conda Python CI job. This lets `conda-python-other-tests` run dask-cuDF, cuDF-Kafka, cuStreamz, and cuDF-streaming independently, while retaining the same Conda build prerequisites and test matrix.

Add the new job to the PR-builder gate so its result remains required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.