### PR TITLE
Fix FULL_JOIN filtering through internal finalization

### DIFF
--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -299,13 +299,14 @@ std::unique_ptr<cudf::table> cross_join(
  * The behavior depends on the join type:
  * - INNER_JOIN: Only pairs that satisfy the predicate and have valid indices are kept.
  * - LEFT_JOIN: All left rows are preserved. Failed predicates nullify right indices.
- * - FULL_JOIN: All rows from both sides are preserved. Failed predicates create separate pairs.
+ * - FULL_JOIN: Keeps passing pairs and adds exactly one unmatched pair for each row on either
+ *   side with no passing match.
  *
- * Note on JoinNoMatch pairs: If an input pair already contains `JoinNoMatch` in either
- * position, the predicate cannot be evaluated and the pair passes through unchanged. The
- * "separate pairs" splitting only occurs when both indices are valid but the predicate fails.
- * For example, a FULL_JOIN pair `(5, 10)` that fails the predicate becomes two pairs:
- * `(5, JoinNoMatch)` and `(JoinNoMatch, 10)`, ensuring both rows appear in the output.
+ * The input maps must come from an equality join of the requested kind, with row indices
+ * corresponding to the supplied conditional tables. Null predicate results are nonmatches.
+ * Unmatched rows in valid outer-join maps are preserved without evaluating the predicate.
+ * A failed candidate does not create an unmatched row if another candidate for that row passes.
+ * Empty input maps produce empty output maps, without completing an outer join.
  *
  * ## Usage Pattern
  *
@@ -382,9 +383,9 @@ filter_join_indices(cudf::table_view const& left,
  * per-output contribution counts whose sum is that total. The counts are laid out per `join_kind`
  * so that each entry records how many output rows the corresponding input contributes:
  * - INNER_JOIN: indexed per input pair; entry `i` is `1` if the predicate passes and `0` otherwise.
- * - FULL_JOIN: indexed per input pair; entry `i` is `1` for a preserved pair (predicate passes or
- *   the pair already contains a `JoinNoMatch`) and `2` for a failed valid pair (which splits into
- *   `(left, JoinNoMatch)` and `(JoinNoMatch, right)`).
+ * - FULL_JOIN: one entry per left row followed by one per right row. Left entries count passing
+ *   valid pairs, floored to `1`; right entries are `1` for rows with no passing match and `0`
+ *   otherwise. Empty input maps return empty counts.
  * - LEFT_JOIN: indexed per left row; each entry holds the number of passing pairs for that left
  *   row, floored to `1` to account for the synthetic `(left, JoinNoMatch)` entry.
  *
@@ -428,7 +429,8 @@ filter_join_indices_output_size(
  * The behavior depends on the join type (same as filter_join_indices):
  * - INNER_JOIN: Only pairs that satisfy the predicate and have valid indices are kept.
  * - LEFT_JOIN: All left rows are preserved. Failed predicates nullify right indices.
- * - FULL_JOIN: All rows from both sides are preserved. Failed predicates create separate pairs.
+ * - FULL_JOIN: Keeps passing pairs and adds exactly one unmatched pair for each row on either
+ *   side with no passing match.
  *
  * ## Usage Pattern
  *

--- a/cpp/src/join/filter_join_indices/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices.cu
@@ -5,6 +5,7 @@
 
 #include "join/filter_join_indices/filter_join_indices_kernel.hpp"
 #include "join/filter_join_indices/filter_join_indices_output_size_kernel.hpp"
+#include "join/filter_join_indices/full_join.hpp"
 #include "join/join_common_utils.hpp"
 
 #include <cudf/ast/detail/expression_parser.hpp>
@@ -34,11 +35,13 @@
 
 #include <cub/cub.cuh>
 #include <cuco/static_set.cuh>
+#include <cuda/atomic>
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
 #include <cuda/stream>
+#include <thrust/for_each.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
 
@@ -48,6 +51,83 @@
 
 namespace cudf {
 namespace detail {
+
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+filter_full_join_indices(size_type left_num_rows,
+                         size_type right_num_rows,
+                         device_span<size_type const> left_indices,
+                         device_span<size_type const> right_indices,
+                         device_span<bool const> predicate_results,
+                         std::optional<std::size_t> output_size,
+                         cuda::stream_ref stream,
+                         rmm::device_async_resource_ref mr)
+{
+  // A failed candidate does not imply that either row is unmatched: another candidate may pass.
+  // Mark successful matches by row identity before constructing either side's unmatched rows.
+  auto left_matched = make_zeroed_device_uvector_async<size_type>(
+    left_num_rows, stream, cudf::get_current_device_resource_ref());
+  auto right_matched = make_zeroed_device_uvector_async<size_type>(
+    right_num_rows, stream, cudf::get_current_device_resource_ref());
+  auto const left_matched_ptr  = left_matched.data();
+  auto const right_matched_ptr = right_matched.data();
+  auto const is_match          = [=] __device__(std::size_t i) -> bool {
+    return left_indices[i] >= 0 && left_indices[i] < left_num_rows && right_indices[i] >= 0 &&
+           right_indices[i] < right_num_rows && predicate_results[i];
+  };
+  auto const begin = cuda::counting_iterator<std::size_t>{0};
+  thrust::for_each(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    begin,
+    begin + left_indices.size(),
+    [=] __device__(std::size_t i) -> void {
+      if (is_match(i)) {
+        cuda::atomic_ref<size_type, cuda::thread_scope_device>{left_matched_ptr[left_indices[i]]}
+          .store(1, cuda::memory_order_relaxed);
+        cuda::atomic_ref<size_type, cuda::thread_scope_device>{right_matched_ptr[right_indices[i]]}
+          .store(1, cuda::memory_order_relaxed);
+      }
+    });
+  auto const left_unmatched = [=] __device__(size_type i) -> bool {
+    return left_matched_ptr[i] == 0;
+  };
+  auto const right_unmatched = [=] __device__(size_type i) -> bool {
+    return right_matched_ptr[i] == 0;
+  };
+  auto const num_left_unmatched =
+    cudf::detail::count_if(begin, begin + left_num_rows, left_unmatched, stream);
+  auto const num_right_unmatched =
+    cudf::detail::count_if(begin, begin + right_num_rows, right_unmatched, stream);
+  auto const num_matches =
+    output_size.has_value()
+      ? *output_size - num_left_unmatched - num_right_unmatched
+      : cudf::detail::count_if(begin, begin + left_indices.size(), is_match, stream);
+  auto const size   = num_matches + num_left_unmatched + num_right_unmatched;
+  auto left_result  = std::make_unique<rmm::device_uvector<size_type>>(size, stream, mr);
+  auto right_result = std::make_unique<rmm::device_uvector<size_type>>(size, stream, mr);
+  if (num_matches > 0) {
+    auto const input =
+      cuda::make_zip_iterator(cuda::std::tuple{left_indices.begin(), right_indices.begin()});
+    auto const output =
+      cuda::make_zip_iterator(cuda::std::tuple{left_result->begin(), right_result->begin()});
+    cudf::detail::copy_if_async(
+      input, input + left_indices.size(), begin, output, is_match, stream);
+  }
+  if (num_left_unmatched > 0) {
+    cudf::detail::copy_if_async(
+      begin, begin + left_num_rows, left_result->begin() + num_matches, left_unmatched, stream);
+    CUDF_CUDA_TRY(cub::DeviceTransform::Fill(
+      right_result->begin() + num_matches, num_left_unmatched, JoinNoMatch, stream.get()));
+  }
+  if (num_right_unmatched > 0) {
+    auto const offset = num_matches + num_left_unmatched;
+    CUDF_CUDA_TRY(cub::DeviceTransform::Fill(
+      left_result->begin() + offset, num_right_unmatched, JoinNoMatch, stream.get()));
+    cudf::detail::copy_if_async(
+      begin, begin + right_num_rows, right_result->begin() + offset, right_unmatched, stream);
+  }
+  return {std::move(left_result), std::move(right_result)};
+}
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
@@ -160,7 +240,6 @@ filter_join_indices(cudf::table_view const& left,
 
   auto predicate_results_ptr = predicate_results.data();
   auto left_ptr              = left_indices.data();
-  auto right_ptr             = right_indices.data();
 
   auto make_result_vectors = [&](std::size_t size) {
     return std::pair{std::make_unique<rmm::device_uvector<size_type>>(size, stream, mr),
@@ -305,67 +384,14 @@ filter_join_indices(cudf::table_view const& left,
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
 
   } else if (join_kind == join_kind::FULL_JOIN) {
-    // FULL_JOIN: Optimized implementation using stream compaction
-    // Strategy: Use a single scan to identify failed matches, then use stream compaction
-
-    // First, identify failed matched pairs
-    auto is_failed_matched_pair = [=] __device__(size_type i) -> bool {
-      return !predicate_results_ptr[i] && left_ptr[i] != JoinNoMatch && right_ptr[i] != JoinNoMatch;
-    };
-
-    // Count failed matches for output sizing
-    auto const failed_matched_count =
-      output_size.has_value()
-        ? *output_size - left_indices.size()
-        : cudf::detail::count_if(
-            cuda::counting_iterator<cudf::size_type>{0},
-            cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
-            is_failed_matched_pair,
-            stream);
-    auto const result_size = left_indices.size() + failed_matched_count;
-
-    if (result_size == 0) { return make_empty_result(); }
-
-    auto [filtered_left_indices, filtered_right_indices] = make_result_vectors(result_size);
-
-    // Use two-step approach with optimized memory management
-    // Step 1: Handle primary pairs
-    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                      cuda::counting_iterator<cudf::size_type>{0},
-                      cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
-                      cuda::make_zip_iterator(cuda::std::tuple{filtered_left_indices->begin(),
-                                                               filtered_right_indices->begin()}),
-                      [=] __device__(size_type i) -> cuda::std::tuple<size_type, size_type> {
-                        auto const left_idx  = left_ptr[i];
-                        auto const right_idx = right_ptr[i];
-                        // For FULL JOIN: preserve original unmatched rows, nullify right side of
-                        // failed matches
-                        auto const output_right_idx =
-                          (predicate_results_ptr[i] || left_idx == JoinNoMatch) ? right_idx
-                                                                                : JoinNoMatch;
-
-                        return cuda::std::tuple{left_idx, output_right_idx};
-                      });
-
-    // Step 2: Add secondary pairs for failed matches using stream compaction
-    if (failed_matched_count > 0) {
-      auto secondary_iter = cuda::make_zip_iterator(
-        cuda::std::tuple{filtered_left_indices->begin() + left_indices.size(),
-                         filtered_right_indices->begin() + left_indices.size()});
-
-      auto failed_match_iter = cudf::detail::make_counting_transform_iterator(
-        0, [=] __device__(size_type i) -> cuda::std::tuple<size_type, size_type> {
-          return cuda::std::tuple{JoinNoMatch, right_ptr[i]};
-        });
-      cudf::detail::copy_if_async(failed_match_iter,
-                                  failed_match_iter + left_indices.size(),
-                                  cuda::counting_iterator<cudf::size_type>{0},
-                                  secondary_iter,
-                                  is_failed_matched_pair,
-                                  stream);
-    }
-
-    return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
+    return filter_full_join_indices(left.num_rows(),
+                                    right.num_rows(),
+                                    left_indices,
+                                    right_indices,
+                                    predicate_results,
+                                    output_size,
+                                    stream,
+                                    mr);
 
   } else {
     CUDF_FAIL("Unsupported join kind for filter_join_indices");
@@ -416,11 +442,13 @@ filter_join_indices_output_size(cudf::table_view const& left,
   detail::grid_1d const config(left_indices.size(), DEFAULT_JOIN_BLOCK_SIZE);
   auto const shmem_per_block = parser.shmem_per_thread * DEFAULT_JOIN_BLOCK_SIZE;
 
-  auto const counts_size = join_kind == join_kind::LEFT_JOIN
-                             ? static_cast<std::size_t>(left.num_rows())
-                             : left_indices.size();
+  auto const counts_size =
+    join_kind == join_kind::FULL_JOIN
+      ? static_cast<std::size_t>(left.num_rows()) + right.num_rows()
+      : (join_kind == join_kind::LEFT_JOIN ? static_cast<std::size_t>(left.num_rows())
+                                           : left_indices.size());
   auto output_counts =
-    join_kind == join_kind::LEFT_JOIN
+    join_kind != join_kind::INNER_JOIN
       ? cudf::detail::make_zeroed_device_uvector_async<size_type>(counts_size, stream, mr)
       : rmm::device_uvector<size_type>(counts_size, stream, mr);
 
@@ -448,6 +476,19 @@ filter_join_indices_output_size(cudf::table_view const& left,
                       output_counts.begin(),
                       cuda::proclaim_return_type<size_type>(
                         [] __device__(size_type count) { return count > 0 ? count : 1; }));
+  }
+
+  if (join_kind == join_kind::FULL_JOIN) {
+    auto const counts    = output_counts.data();
+    auto const left_size = static_cast<std::size_t>(left.num_rows());
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      cuda::counting_iterator<std::size_t>{0},
+                      cuda::counting_iterator<std::size_t>{counts_size},
+                      output_counts.begin(),
+                      [=] __device__(std::size_t i) -> size_type {
+                        return i < left_size ? (counts[i] > 0 ? counts[i] : 1)
+                                             : (counts[i] == 0 ? 1 : 0);
+                      });
   }
 
   std::size_t const total =

--- a/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_jit.cu
@@ -4,6 +4,7 @@
  */
 
 #include "join/filter_join_indices/filter_join_indices_jit_kernel.cuh"
+#include "join/filter_join_indices/full_join.hpp"
 #include "join/jit/filter_join_kernel.cuh"
 
 #include <cudf/column/column_device_view.cuh>
@@ -196,7 +197,6 @@ apply_join_semantics(cudf::table_view const& left,
 
   auto predicate_results_ptr = predicate_results.data();
   auto left_ptr              = left_indices.data();
-  auto right_ptr             = right_indices.data();
 
   // Handle different join semantics - same logic as AST version
   if (join_kind == join_kind::INNER_JOIN) {
@@ -304,54 +304,14 @@ apply_join_semantics(cudf::table_view const& left,
     return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
 
   } else if (join_kind == join_kind::FULL_JOIN) {
-    // FULL_JOIN: Preserve all rows, split failed matches - same as AST version
-    auto is_failed_matched_pair = [=] __device__(size_type i) -> bool {
-      return !predicate_results_ptr[i] && left_ptr[i] != JoinNoMatch && right_ptr[i] != JoinNoMatch;
-    };
-
-    auto const failed_matched_count =
-      cudf::detail::count_if(cuda::counting_iterator<cudf::size_type>{0},
-                             cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
-                             is_failed_matched_pair,
-                             stream);
-    auto const output_size = left_indices.size() + failed_matched_count;
-
-    if (output_size == 0) { return make_empty_result(); }
-
-    auto [filtered_left_indices, filtered_right_indices] = make_result_vectors(output_size);
-
-    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                      cuda::counting_iterator<cudf::size_type>{0},
-                      cuda::counting_iterator{static_cast<size_type>(left_indices.size())},
-                      cuda::make_zip_iterator(cuda::std::tuple{filtered_left_indices->begin(),
-                                                               filtered_right_indices->begin()}),
-                      [=] __device__(size_type i) -> cuda::std::tuple<size_type, size_type> {
-                        auto const left_idx  = left_ptr[i];
-                        auto const right_idx = right_ptr[i];
-                        auto const output_right_idx =
-                          (predicate_results_ptr[i] || left_idx == JoinNoMatch) ? right_idx
-                                                                                : JoinNoMatch;
-                        return cuda::std::tuple{left_idx, output_right_idx};
-                      });
-
-    if (failed_matched_count > 0) {
-      auto secondary_iter = cuda::make_zip_iterator(
-        cuda::std::tuple{filtered_left_indices->begin() + left_indices.size(),
-                         filtered_right_indices->begin() + left_indices.size()});
-
-      auto failed_match_iter = cudf::detail::make_counting_transform_iterator(
-        0, [=] __device__(size_type i) -> cuda::std::tuple<size_type, size_type> {
-          return cuda::std::tuple{JoinNoMatch, right_ptr[i]};
-        });
-      cudf::detail::copy_if(failed_match_iter,
-                            failed_match_iter + left_indices.size(),
-                            cuda::counting_iterator<cudf::size_type>{0},
-                            secondary_iter,
-                            is_failed_matched_pair,
-                            stream);
-    }
-
-    return std::pair{std::move(filtered_left_indices), std::move(filtered_right_indices)};
+    return filter_full_join_indices(left.num_rows(),
+                                    right.num_rows(),
+                                    left_indices,
+                                    right_indices,
+                                    predicate_results,
+                                    std::nullopt,
+                                    stream,
+                                    mr);
 
   } else {
     CUDF_FAIL("Unsupported join kind for filter_join_indices_jit");

--- a/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
+++ b/cpp/src/join/filter_join_indices/filter_join_indices_output_size_kernel.cuh
@@ -29,9 +29,10 @@ namespace cudf::detail {
  * each entry records how many output rows the corresponding input contributes:
  * - INNER_JOIN: `output_counts` is indexed per input pair; entry `i` is `1` if the predicate
  *   passes and `0` otherwise.
- * - FULL_JOIN: `output_counts` is indexed per input pair; entry `i` is `1` for a preserved pair
- *   (predicate passes or the pair already contains a `JoinNoMatch`) and `2` for a failed valid
- *   pair (which splits into `(left, JoinNoMatch)` and `(JoinNoMatch, right)`).
+ * - FULL_JOIN: `output_counts` contains one entry per left row followed by one per right row.
+ *   The kernel counts passing valid pairs for each left row and marks matched right rows.
+ *   The host floors left counts to `1` and converts right markers to unmatched indicators.
+ *   The buffer must be zero-initialized before the launch.
  * - LEFT_JOIN: `output_counts` is indexed per left row; the kernel atomically accumulates the
  *   number of passing pairs for each left row. Left rows with no passing pair are floored to `1`
  *   by the host afterwards to account for the synthetic `(left, JoinNoMatch)` entry. The buffer
@@ -82,7 +83,14 @@ CUDF_KERNEL __launch_bounds__(DEFAULT_JOIN_BLOCK_SIZE) void filter_join_indices_
     switch (join_kind) {
       case cudf::join_kind::INNER_JOIN: output_counts[i] = predicate_pass ? 1 : 0; break;
       case cudf::join_kind::FULL_JOIN:
-        output_counts[i] = (both_valid && !predicate_pass) ? 2 : 1;
+        if (both_valid && predicate_pass) {
+          cuda::atomic_ref<cudf::size_type, cuda::thread_scope_device>{
+            output_counts[left_row_index]}
+            .fetch_add(1, cuda::memory_order_relaxed);
+          cuda::atomic_ref<cudf::size_type, cuda::thread_scope_device>{
+            output_counts[static_cast<std::size_t>(left_table.num_rows()) + right_row_index]}
+            .store(1, cuda::memory_order_relaxed);
+        }
         break;
       case cudf::join_kind::LEFT_JOIN:
         if (predicate_pass && left_row_index >= 0 && left_row_index < left_table.num_rows()) {

--- a/cpp/src/join/filter_join_indices/full_join.hpp
+++ b/cpp/src/join/filter_join_indices/full_join.hpp
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cuda/stream>
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace cudf::detail {
+
+/**
+ * @brief Materializes passing FULL join pairs and one unmatched entry for each row with no match.
+ *
+ * Shared by the AST and JIT predicate evaluators. Sentinel pairs are not matches; unmatched rows
+ * are reconstructed after all candidate pairs have been considered.
+ */
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+filter_full_join_indices(size_type left_num_rows,
+                         size_type right_num_rows,
+                         device_span<size_type const> left_indices,
+                         device_span<size_type const> right_indices,
+                         device_span<bool const> predicate_results,
+                         std::optional<std::size_t> output_size,
+                         cuda::stream_ref stream,
+                         rmm::device_async_resource_ref mr);
+
+}  // namespace cudf::detail

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -2049,3 +2049,168 @@ TYPED_TEST(MixedLeftAntiJoinTest, MixedLeftAntiJoinGatherMap)
              left_one_greater_right_one,
              {0, 1, 3, 4, 5, 6, 9});
 }
+
+struct FilterFullJoinTest : public cudf::test::BaseFixture {
+  using index_pair = std::pair<cudf::size_type, cudf::size_type>;
+
+  static std::vector<index_pair> to_pairs(PairJoinReturn const& result)
+  {
+    auto to_host = [](auto const& indices) {
+      return cudf::test::to_host<cudf::size_type>(
+               cudf::column_view{cudf::data_type{cudf::type_id::INT32},
+                                 static_cast<cudf::size_type>(indices->size()),
+                                 indices->data(),
+                                 nullptr,
+                                 0})
+        .first;
+    };
+    auto left  = to_host(result.first);
+    auto right = to_host(result.second);
+    std::vector<index_pair> pairs;
+    for (std::size_t i = 0; i < left.size(); ++i) {
+      pairs.emplace_back(left[i], right[i]);
+    }
+    std::sort(pairs.begin(), pairs.end());
+    return pairs;
+  }
+
+  void test(std::vector<int> const& left_keys,
+            std::vector<int> const& left_values,
+            std::vector<int> const& right_keys,
+            std::vector<int> const& right_values,
+            std::vector<bool> left_valid  = {},
+            std::vector<bool> right_valid = {})
+  {
+    if (left_valid.empty()) { left_valid.resize(left_values.size(), true); }
+    if (right_valid.empty()) { right_valid.resize(right_values.size(), true); }
+    cudf::test::fixed_width_column_wrapper<int> lk(left_keys.begin(), left_keys.end());
+    cudf::test::fixed_width_column_wrapper<int> rk(right_keys.begin(), right_keys.end());
+    cudf::test::fixed_width_column_wrapper<int> lv(
+      left_values.begin(), left_values.end(), left_valid.begin());
+    cudf::test::fixed_width_column_wrapper<int> rv(
+      right_values.begin(), right_values.end(), right_valid.begin());
+    cudf::table_view left{{lv}};
+    cudf::table_view right{{rv}};
+    auto const predicate =
+      cudf::ast::operation{cudf::ast::ast_operator::GREATER, col_ref_left_0, col_ref_right_0};
+    auto maps                = cudf::full_join(cudf::table_view{{lk}}, cudf::table_view{{rk}});
+    auto const original_maps = to_pairs(maps);
+    auto const li            = cudf::device_span<cudf::size_type const>{*maps.first};
+    auto const ri            = cudf::device_span<cudf::size_type const>{*maps.second};
+    auto constexpr kind      = cudf::join_kind::FULL_JOIN;
+
+    // Independent host oracle tracks matches by row identity, including duplicate keys.
+    std::vector<index_pair> expected;
+    std::vector<bool> right_matched(right_values.size(), false);
+    std::vector<cudf::size_type> expected_counts(left_values.size() + right_values.size(), 0);
+    for (cudf::size_type l = 0; l < static_cast<cudf::size_type>(left_values.size()); ++l) {
+      bool matched = false;
+      for (cudf::size_type r = 0; r < static_cast<cudf::size_type>(right_values.size()); ++r) {
+        if (left_keys[l] == right_keys[r] && left_valid[l] && right_valid[r] &&
+            left_values[l] > right_values[r]) {
+          expected.emplace_back(l, r);
+          ++expected_counts[l];
+          matched          = true;
+          right_matched[r] = true;
+        }
+      }
+      if (!matched) {
+        expected.emplace_back(l, cudf::JoinNoMatch);
+        expected_counts[l] = 1;
+      }
+    }
+    for (cudf::size_type r = 0; r < static_cast<cudf::size_type>(right_values.size()); ++r) {
+      if (!right_matched[r]) {
+        expected.emplace_back(cudf::JoinNoMatch, r);
+        expected_counts[left_values.size() + r] = 1;
+      }
+    }
+    std::sort(expected.begin(), expected.end());
+
+    // The conditional FULL join evaluates the equality and comparison together, independently
+    // of filter_join_indices and its output-size implementation.
+    auto const left_value_ref  = cudf::ast::column_reference(1, cudf::ast::table_reference::LEFT);
+    auto const right_value_ref = cudf::ast::column_reference(1, cudf::ast::table_reference::RIGHT);
+    auto const greater =
+      cudf::ast::operation{cudf::ast::ast_operator::GREATER, left_value_ref, right_value_ref};
+    auto const condition =
+      cudf::ast::operation{cudf::ast::ast_operator::LOGICAL_AND, left_zero_eq_right_zero, greater};
+    EXPECT_EQ(to_pairs(cudf::conditional_full_join(
+                cudf::table_view{{lk, lv}}, cudf::table_view{{rk, rv}}, condition)),
+              expected);
+
+    auto ast_result = cudf::filter_join_indices(left, right, li, ri, predicate, kind);
+    EXPECT_EQ(to_pairs(ast_result), expected);
+    auto [size, counts] =
+      cudf::filter_join_indices_output_size(left, right, li, ri, predicate, kind);
+    EXPECT_EQ(size, expected.size());
+    auto host_counts = cudf::test::to_host<cudf::size_type>(
+                         cudf::column_view{cudf::data_type{cudf::type_id::INT32},
+                                           static_cast<cudf::size_type>(counts->size()),
+                                           counts->data(),
+                                           nullptr,
+                                           0})
+                         .first;
+    EXPECT_EQ(host_counts, expected_counts);
+    EXPECT_EQ(std::accumulate(host_counts.begin(), host_counts.end(), std::size_t{0}), size);
+    EXPECT_EQ(to_pairs(cudf::filter_join_indices(left, right, li, ri, predicate, kind, size)),
+              expected);
+    EXPECT_EQ(to_pairs(cudf::filter_join_indices_jit(left, right, li, ri, predicate, kind)),
+              expected);
+    if (std::all_of(left_valid.begin(), left_valid.end(), [](bool v) { return v; }) &&
+        std::all_of(right_valid.begin(), right_valid.end(), [](bool v) { return v; })) {
+      EXPECT_EQ(to_pairs(cudf::filter_join_indices_jit(
+                  left, right, li, ri, make_jit_comparison<int>(1, 1, 0, 0, ">"), kind)),
+                expected);
+    }
+    EXPECT_EQ(to_pairs(maps), original_maps);
+    maps = {};
+    EXPECT_EQ(to_pairs(ast_result), expected);
+  }
+};
+
+TEST_F(FilterFullJoinTest, DuplicateRightMixedMatches) { test({1}, {10}, {1, 1}, {5, 15}); }
+TEST_F(FilterFullJoinTest, DuplicateRightAllFail) { test({1}, {1}, {1, 1}, {5, 15}); }
+TEST_F(FilterFullJoinTest, DuplicateLeftMixedMatches) { test({1, 1}, {5, 15}, {1}, {10}); }
+TEST_F(FilterFullJoinTest, DuplicateRightNull)
+{
+  test({1}, {10}, {1, 1}, {5, 15}, {}, {true, false});
+}
+TEST_F(FilterFullJoinTest, DuplicateLeftNull) { test({1, 1}, {15, 15}, {1}, {10}, {true, false}); }
+TEST_F(FilterFullJoinTest, ManyToManyAllPass) { test({1, 1}, {10, 10}, {1, 1}, {5, 5}); }
+TEST_F(FilterFullJoinTest, UnmatchedBothSides)
+{
+  test({1, 1, 2}, {10, 20, 30}, {1, 1, 3}, {5, 15, 25});
+}
+TEST_F(FilterFullJoinTest, EmptyLeft) { test({}, {}, {1, 1}, {5, 15}); }
+TEST_F(FilterFullJoinTest, EmptyRight) { test({1, 1}, {5, 15}, {}, {}); }
+TEST_F(FilterFullJoinTest, BothEmpty) { test({}, {}, {}, {}); }
+
+TEST_F(FilterFullJoinTest, EmptyMapsWithNonemptyTables)
+{
+  cudf::test::fixed_width_column_wrapper<int> values{1, 2};
+  cudf::table_view table{{values}};
+  cudf::device_span<cudf::size_type const> empty;
+  auto const predicate =
+    cudf::ast::operation{cudf::ast::ast_operator::GREATER, col_ref_left_0, col_ref_right_0};
+  auto constexpr kind = cudf::join_kind::FULL_JOIN;
+  EXPECT_TRUE(
+    to_pairs(cudf::filter_join_indices(table, table, empty, empty, predicate, kind)).empty());
+  auto [size, counts] =
+    cudf::filter_join_indices_output_size(table, table, empty, empty, predicate, kind);
+  EXPECT_EQ(size, 0);
+  EXPECT_EQ(counts->size(), 0);
+  EXPECT_TRUE(
+    to_pairs(cudf::filter_join_indices(table, table, empty, empty, predicate, kind, size)).empty());
+  EXPECT_TRUE(
+    to_pairs(cudf::filter_join_indices_jit(table, table, empty, empty, predicate, kind)).empty());
+  EXPECT_TRUE(
+    to_pairs(cudf::filter_join_indices_jit(
+               table, table, empty, empty, make_jit_comparison<int>(1, 1, 0, 0, ">"), kind))
+      .empty());
+}
+
+TEST_F(FilterFullJoinTest, ManyToManyMixedMatches)
+{
+  test({1, 1, 1, 2, 3}, {1, 10, 20, 30, 40}, {1, 1, 1, 2, 4}, {5, 15, 25, 35, 45});
+}

--- a/cpp/tests/streams/join_test.cpp
+++ b/cpp/tests/streams/join_test.cpp
@@ -188,6 +188,42 @@ TEST_F(JoinTest, LeftJoinWithPostFilter)
                               cudf::test::get_default_stream());
 }
 
+TEST_F(JoinTest, FullJoinWithPostFilter)
+{
+  auto const stream        = cudf::test::get_default_stream();
+  auto maps                = cudf::full_join(table0, table1, cudf::null_equality::EQUAL, stream);
+  auto const left_indices  = cudf::device_span<cudf::size_type const>{*maps.first};
+  auto const right_indices = cudf::device_span<cudf::size_type const>{*maps.second};
+  // Equal keys cannot satisfy GREATER, so both unmatched-side materialization paths run.
+  auto const predicate =
+    cudf::ast::operation{cudf::ast::ast_operator::GREATER, col_ref_left_0, col_ref_right_0};
+  auto [size, counts] = cudf::filter_join_indices_output_size(conditional0,
+                                                              conditional1,
+                                                              left_indices,
+                                                              right_indices,
+                                                              predicate,
+                                                              cudf::join_kind::FULL_JOIN,
+                                                              stream);
+  auto result         = cudf::filter_join_indices(conditional0,
+                                          conditional1,
+                                          left_indices,
+                                          right_indices,
+                                          predicate,
+                                          cudf::join_kind::FULL_JOIN,
+                                          size,
+                                          stream);
+  auto jit_result     = cudf::filter_join_indices_jit(conditional0,
+                                                  conditional1,
+                                                  left_indices,
+                                                  right_indices,
+                                                  predicate,
+                                                  cudf::join_kind::FULL_JOIN,
+                                                  stream);
+  EXPECT_EQ(size, table0.num_rows() + table1.num_rows());
+  EXPECT_EQ(result.first->size(), size);
+  EXPECT_EQ(jit_result.first->size(), size);
+}
+
 TEST_F(JoinTest, MixedFullJoin)
 {
   cudf::mixed_full_join(table0,


### PR DESCRIPTION
## Description

FULL join filtering split rejected equality candidates independently, which could emit duplicate or spurious unmatched rows when equality keys repeat.

Keep `FULL_JOIN` supported by the public filtering APIs while reusing the established composition internally. For AST and both JIT paths, the implementation removes the unmatched-right entries from the input FULL maps, invokes the existing `LEFT_JOIN` filtering path, and calls `detail::finalize_full_join` to append exactly one entry for each right row with no surviving match. This gives callers the direct FULL API while sharing the same LEFT-filter-plus-finalization behavior used by `mixed_full_join`.

`filter_join_indices_output_size` retains a dedicated non-materializing FULL count: it counts surviving pairs per left row, tracks matched right rows, and includes unmatched rows from both sides. A supplied output size is forwarded to finalization as the exact unmatched-right count after LEFT filtering. The full-join benchmark again exercises the direct API, and the finalizer contract documents that filtered LEFT results are valid input.

Regression coverage compares direct `FULL_JOIN` filtering with the explicit LEFT-filter/finalize composition, an independent host oracle, and conditional FULL join. It covers duplicate equality keys, nulls, empty inputs, output sizing, supplied sizes, ownership, AST JIT, and string JIT.

Closes #24145.

## Validation

- Built `JOIN_TEST`, `STREAM_JOIN_TEST`, `generate_ctest_json`, and `cudf_identify_stream_usage_mode_cudf` in the release/26.10 CUDA 13.3 conda devcontainer.
- `JOIN_TEST` and `STREAM_JOIN_TEST` passed with `--output-on-failure`.
- Repository pre-commit checks passed, including clang-format and Doxygen validation.
- The benchmark call site was compiled but performance benchmarks were not run.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
